### PR TITLE
refactor: deduplicate preset examples in READMEs

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -64,7 +64,9 @@ report.AssertNoViolations(t, violations)
 
 기본값이 아닌 모델이나 severity/exclude 옵션이 필요할 때만 `opts...`를 넘기면 됩니다.
 
-### DDD (기본값)
+### 개별 rule 제어 (DDD 예시)
+
+각 체크를 세밀하게 제어하려면 직접 조합합니다:
 
 ```go
 func TestArchitecture(t *testing.T) {
@@ -94,52 +96,15 @@ func TestArchitecture(t *testing.T) {
 }
 ```
 
-### Clean Architecture
+다른 프리셋을 쓸 때는 모델 함수만 교체하고 `opts...`를 전달합니다:
 
 ```go
-m := rules.CleanArch()
+m := rules.CleanArch() // 또는 Layered(), Hexagonal(), ModularMonolith()
 opts := []rules.Option{rules.WithModel(m)}
 
-t.Run("layer direction", func(t *testing.T) {
-    report.AssertNoViolations(t, rules.CheckLayerDirection(pkgs, "", "", opts...))
-})
-// ... 나머지 체크도 동일하게 opts... 전달
-```
-
-### Layered (Spring 스타일)
-
-```go
-m := rules.Layered()
-opts := []rules.Option{rules.WithModel(m)}
-
-t.Run("layer direction", func(t *testing.T) {
-    report.AssertNoViolations(t, rules.CheckLayerDirection(pkgs, "", "", opts...))
-})
-// ... 나머지 체크도 동일하게 opts... 전달
-```
-
-### Hexagonal (포트 & 어댑터)
-
-```go
-m := rules.Hexagonal()
-opts := []rules.Option{rules.WithModel(m)}
-
-t.Run("layer direction", func(t *testing.T) {
-    report.AssertNoViolations(t, rules.CheckLayerDirection(pkgs, "", "", opts...))
-})
-// ... 나머지 체크도 동일하게 opts... 전달
-```
-
-### Modular Monolith
-
-```go
-m := rules.ModularMonolith()
-opts := []rules.Option{rules.WithModel(m)}
-
-t.Run("layer direction", func(t *testing.T) {
-    report.AssertNoViolations(t, rules.CheckLayerDirection(pkgs, "", "", opts...))
-})
-// ... 나머지 체크도 동일하게 opts... 전달
+rules.CheckDomainIsolation(pkgs, "", "", opts...)
+rules.CheckLayerDirection(pkgs, "", "", opts...)
+// ... 모든 Check* 함수에 동일하게 opts... 전달
 ```
 
 ### 커스텀 모델

--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ report.AssertNoViolations(t, violations)
 
 Pass `opts...` only when you need a non-default model or severity/exclude options.
 
-### DDD (default)
+### Per-rule control (DDD example)
+
+For finer control over individual checks, compose them manually:
 
 ```go
 func TestArchitecture(t *testing.T) {
@@ -96,124 +98,15 @@ func TestArchitecture(t *testing.T) {
 }
 ```
 
-### Clean Architecture
+For other presets, add `opts` with the model function:
 
 ```go
-func TestArchitecture(t *testing.T) {
-    pkgs, err := analyzer.Load(".", "internal/...", "cmd/...")
-    if err != nil {
-        t.Log(err)
-    }
-    if len(pkgs) == 0 {
-        t.Fatalf("no packages loaded: %v", err)
-    }
+m := rules.CleanArch() // or Layered(), Hexagonal(), ModularMonolith()
+opts := []rules.Option{rules.WithModel(m)}
 
-    m := rules.CleanArch()
-    opts := []rules.Option{rules.WithModel(m)}
-
-    t.Run("domain isolation", func(t *testing.T) {
-        report.AssertNoViolations(t, rules.CheckDomainIsolation(pkgs, "", "", opts...))
-    })
-    t.Run("layer direction", func(t *testing.T) {
-        report.AssertNoViolations(t, rules.CheckLayerDirection(pkgs, "", "", opts...))
-    })
-    t.Run("naming", func(t *testing.T) {
-        report.AssertNoViolations(t, rules.CheckNaming(pkgs, opts...))
-    })
-    t.Run("structure", func(t *testing.T) {
-        report.AssertNoViolations(t, rules.CheckStructure(".", opts...))
-    })
-}
-```
-
-### Layered (Spring-style)
-
-```go
-func TestArchitecture(t *testing.T) {
-    pkgs, err := analyzer.Load(".", "internal/...", "cmd/...")
-    if err != nil {
-        t.Log(err)
-    }
-    if len(pkgs) == 0 {
-        t.Fatalf("no packages loaded: %v", err)
-    }
-
-    m := rules.Layered()
-    opts := []rules.Option{rules.WithModel(m)}
-
-    t.Run("domain isolation", func(t *testing.T) {
-        report.AssertNoViolations(t, rules.CheckDomainIsolation(pkgs, "", "", opts...))
-    })
-    t.Run("layer direction", func(t *testing.T) {
-        report.AssertNoViolations(t, rules.CheckLayerDirection(pkgs, "", "", opts...))
-    })
-    t.Run("naming", func(t *testing.T) {
-        report.AssertNoViolations(t, rules.CheckNaming(pkgs, opts...))
-    })
-    t.Run("structure", func(t *testing.T) {
-        report.AssertNoViolations(t, rules.CheckStructure(".", opts...))
-    })
-}
-```
-
-### Hexagonal (Ports & Adapters)
-
-```go
-func TestArchitecture(t *testing.T) {
-    pkgs, err := analyzer.Load(".", "internal/...", "cmd/...")
-    if err != nil {
-        t.Log(err)
-    }
-    if len(pkgs) == 0 {
-        t.Fatalf("no packages loaded: %v", err)
-    }
-
-    m := rules.Hexagonal()
-    opts := []rules.Option{rules.WithModel(m)}
-
-    t.Run("domain isolation", func(t *testing.T) {
-        report.AssertNoViolations(t, rules.CheckDomainIsolation(pkgs, "", "", opts...))
-    })
-    t.Run("layer direction", func(t *testing.T) {
-        report.AssertNoViolations(t, rules.CheckLayerDirection(pkgs, "", "", opts...))
-    })
-    t.Run("naming", func(t *testing.T) {
-        report.AssertNoViolations(t, rules.CheckNaming(pkgs, opts...))
-    })
-    t.Run("structure", func(t *testing.T) {
-        report.AssertNoViolations(t, rules.CheckStructure(".", opts...))
-    })
-}
-```
-
-### Modular Monolith
-
-```go
-func TestArchitecture(t *testing.T) {
-    pkgs, err := analyzer.Load(".", "internal/...", "cmd/...")
-    if err != nil {
-        t.Log(err)
-    }
-    if len(pkgs) == 0 {
-        t.Fatalf("no packages loaded: %v", err)
-    }
-
-    m := rules.ModularMonolith()
-    opts := []rules.Option{rules.WithModel(m)}
-
-    t.Run("domain isolation", func(t *testing.T) {
-        report.AssertNoViolations(t, rules.CheckDomainIsolation(pkgs, "", "", opts...))
-    })
-    t.Run("layer direction", func(t *testing.T) {
-        report.AssertNoViolations(t, rules.CheckLayerDirection(pkgs, "", "", opts...))
-    })
-    t.Run("naming", func(t *testing.T) {
-        report.AssertNoViolations(t, rules.CheckNaming(pkgs, opts...))
-    })
-    t.Run("structure", func(t *testing.T) {
-        report.AssertNoViolations(t, rules.CheckStructure(".", opts...))
-    })
-}
+rules.CheckDomainIsolation(pkgs, "", "", opts...)
+rules.CheckLayerDirection(pkgs, "", "", opts...)
+// ... same pattern for all Check* functions
 ```
 
 ### Custom Model


### PR DESCRIPTION
Keep one full DDD example for per-rule control, replace the four duplicate preset blocks with a single pattern showing how to swap the model function.  Removes ~140 lines of near-identical code snippets.