### PR TITLE
feat: repo port-layer rules, CleanArch gateway, and helpers consolidation

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -434,6 +434,31 @@ order_service.go  올바름
 type Order interface { ... }  // 파일명과 일치
 ```
 
+### `naming.repo-file-extra-interface`
+
+`repo/` 파일에는 인터페이스가 정확히 1개만 있어야 합니다. 추가 인터페이스는 별도 파일로 분리하세요.
+
+```go
+// repo/review.go
+type Review interface { Find() }   // 올바름
+type Helper interface { Assist() } // 위반: helper.go로 이동
+```
+
+### `naming.repo-interface-too-large`
+
+repo 인터페이스의 메서드 수가 `WithMaxRepoInterfaceMethods`로 설정한 상한을 초과하면 위반입니다. 기본 비활성.
+
+```go
+rules.CheckNaming(pkgs, rules.WithMaxRepoInterfaceMethods(10))
+```
+
+```go
+// repo/review.go
+type Review interface {
+    // 메서드 11개 --- 위반 (max 10)
+}
+```
+
 ### `naming.no-layer-suffix`
 
 파일명은 레이어 이름을 불필요하게 반복하면 안 됩니다.
@@ -587,6 +612,7 @@ go run github.com/NamhaeSusan/go-arch-guard/cmd/tui .
 | `rules.WithModel(m)` | 커스텀 모델 적용 |
 | `rules.WithSeverity(rules.Warning)` | 경고로 다운그레이드 |
 | `rules.WithExclude("path/...")` | 하위 트리 건너뛰기 |
+| `rules.WithMaxRepoInterfaceMethods(10)` | repo 인터페이스 메서드 수 제한 |
 
 ## 기계 친화적인 JSON 출력
 

--- a/README.md
+++ b/README.md
@@ -448,6 +448,31 @@ Files in `repo/` (or `core/repo/`) must contain an interface matching the filena
 type Order interface { ... }  // matches filename
 ```
 
+### `naming.repo-file-extra-interface`
+
+Each file in `repo/` must define exactly one interface. Extra interfaces should be split into their own files.
+
+```go
+// repo/review.go
+type Review interface { Find() }   // correct
+type Helper interface { Assist() } // violation: move to helper.go
+```
+
+### `naming.repo-interface-too-large`
+
+Repo interfaces must not exceed the method limit set by `WithMaxRepoInterfaceMethods`. Disabled by default.
+
+```go
+rules.CheckNaming(pkgs, rules.WithMaxRepoInterfaceMethods(10))
+```
+
+```go
+// repo/review.go
+type Review interface {
+    // 11 methods --- violation (max 10)
+}
+```
+
 ### `naming.no-layer-suffix`
 
 Filenames must not redundantly repeat the layer name.
@@ -610,6 +635,7 @@ Features: health-status tree coloring, imports/reverse dependencies/coupling met
 | `rules.WithModel(m)` | apply custom model to checks |
 | `rules.WithSeverity(rules.Warning)` | downgrade to warnings |
 | `rules.WithExclude("path/...")` | skip a subtree |
+| `rules.WithMaxRepoInterfaceMethods(10)` | limit repo interface method count |
 
 ## Machine-readable JSON Output
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -185,7 +185,7 @@ func TestIntegration_CleanArchModel(t *testing.T) {
 	writeIntegrationFile(t, filepath.Join(root, "internal", "domain", "order", "entity", "order.go"),
 		"package entity\n\ntype Order struct{ ID string }\n")
 	writeIntegrationFile(t, filepath.Join(root, "internal", "domain", "order", "gateway", "repo.go"),
-		"package gateway\n\nimport _ \""+module+"/internal/domain/order/entity\"\n")
+		"package gateway\n\nimport \""+module+"/internal/domain/order/entity\"\n\ntype Repo interface { Find() entity.Order }\n")
 	writeIntegrationFile(t, filepath.Join(root, "internal", "domain", "order", "infra", "persistence.go"),
 		"package infra\n\nimport (\n\t_ \""+module+"/internal/domain/order/gateway\"\n\t_ \""+module+"/internal/domain/order/entity\"\n)\n")
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -184,8 +184,8 @@ func TestIntegration_CleanArchModel(t *testing.T) {
 		"package usecase\n\nimport _ \""+module+"/internal/domain/order/entity\"\n")
 	writeIntegrationFile(t, filepath.Join(root, "internal", "domain", "order", "entity", "order.go"),
 		"package entity\n\ntype Order struct{ ID string }\n")
-	writeIntegrationFile(t, filepath.Join(root, "internal", "domain", "order", "gateway", "repo.go"),
-		"package gateway\n\nimport \""+module+"/internal/domain/order/entity\"\n\ntype Repo interface { Find() entity.Order }\n")
+	writeIntegrationFile(t, filepath.Join(root, "internal", "domain", "order", "gateway", "order.go"),
+		"package gateway\n\nimport \""+module+"/internal/domain/order/entity\"\n\ntype Order interface { Find() entity.Order }\n")
 	writeIntegrationFile(t, filepath.Join(root, "internal", "domain", "order", "infra", "persistence.go"),
 		"package infra\n\nimport (\n\t_ \""+module+"/internal/domain/order/gateway\"\n\t_ \""+module+"/internal/domain/order/entity\"\n)\n")
 

--- a/rules/helpers.go
+++ b/rules/helpers.go
@@ -128,6 +128,111 @@ func projectRelativePackagePath(pkgPath, projectModule string) string {
 	return ""
 }
 
+// isPortSublayer reports whether the sublayer name is a port/contract layer
+// (pure interface definitions like repo, gateway).
+func isPortSublayer(name string) bool {
+	base := name
+	if i := strings.LastIndex(name, "/"); i >= 0 {
+		base = name[i+1:]
+	}
+	return base == "repo" || base == "gateway"
+}
+
+// isContractSublayer reports whether the sublayer name is a contract layer
+// (port/repo + service interfaces like svc).
+func isContractSublayer(name string) bool {
+	if isPortSublayer(name) {
+		return true
+	}
+	base := name
+	if i := strings.LastIndex(name, "/"); i >= 0 {
+		base = name[i+1:]
+	}
+	return base == "svc"
+}
+
+// hasPortSublayer reports whether the model has any port sublayer.
+func hasPortSublayer(m Model) bool {
+	for _, sl := range m.Sublayers {
+		if isPortSublayer(sl) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchPortSublayer returns the port sublayer name if pkgPath references one, "" otherwise.
+func matchPortSublayer(m Model, pkgPath string) string {
+	for _, sl := range m.Sublayers {
+		if !isPortSublayer(sl) {
+			continue
+		}
+		if strings.HasSuffix(pkgPath, "/"+sl) || strings.Contains(pkgPath, "/"+sl+"/") {
+			return sl
+		}
+	}
+	return ""
+}
+
+// matchContractSublayer returns the contract sublayer name if pkgPath references one, "" otherwise.
+func matchContractSublayer(m Model, pkgPath string) string {
+	for _, sl := range m.Sublayers {
+		if !isContractSublayer(sl) {
+			continue
+		}
+		if strings.HasSuffix(pkgPath, "/"+sl) || strings.Contains(pkgPath, "/"+sl+"/") {
+			return sl
+		}
+	}
+	return ""
+}
+
+// portSublayerName returns the first port sublayer name from the model, or "core/repo" as fallback.
+func portSublayerName(m Model) string {
+	for _, sl := range m.Sublayers {
+		if isPortSublayer(sl) {
+			return sl
+		}
+	}
+	return "core/repo"
+}
+
+// collectInterfacesFromFile returns interface types from a single AST file.
+// If exportedOnly is true, only exported interfaces are returned.
+func collectInterfacesFromFile(file *ast.File, exportedOnly bool) map[string]*ast.InterfaceType {
+	result := make(map[string]*ast.InterfaceType)
+	for _, decl := range file.Decls {
+		gd, ok := decl.(*ast.GenDecl)
+		if !ok {
+			continue
+		}
+		for _, spec := range gd.Specs {
+			ts, ok := spec.(*ast.TypeSpec)
+			if !ok {
+				continue
+			}
+			if exportedOnly && !ts.Name.IsExported() {
+				continue
+			}
+			if iface, ok := ts.Type.(*ast.InterfaceType); ok {
+				result[ts.Name.Name] = iface
+			}
+		}
+	}
+	return result
+}
+
+// collectExportedInterfacesFromPkg returns all exported interfaces across all files in a package.
+func collectExportedInterfacesFromPkg(pkg *packages.Package) map[string]*ast.InterfaceType {
+	result := make(map[string]*ast.InterfaceType)
+	for _, file := range pkg.Syntax {
+		for name, iface := range collectInterfacesFromFile(file, true) {
+			result[name] = iface
+		}
+	}
+	return result
+}
+
 func deduplicateMetaViolations(violations []Violation) []Violation {
 	seen := make(map[string]bool)
 	result := violations[:0]

--- a/rules/helpers.go
+++ b/rules/helpers.go
@@ -3,6 +3,7 @@ package rules
 import (
 	"fmt"
 	"go/ast"
+	"go/token"
 	"path/filepath"
 	"strings"
 
@@ -197,6 +198,50 @@ func portSublayerName(m Model) string {
 	return "core/repo"
 }
 
+// typeSpecInfo holds information about a type spec found during AST inspection.
+type typeSpecInfo struct {
+	Name      string
+	Pos       token.Position
+	IsIface   bool   // direct interface definition
+	AliasFrom string // non-empty if type alias re-exports from this import path
+}
+
+// inspectTypeSpecs walks a file's type specs and returns info about interfaces
+// and type aliases that re-export from other packages.
+func inspectTypeSpecs(file *ast.File, fset *token.FileSet) []typeSpecInfo {
+	var result []typeSpecInfo
+	for _, decl := range file.Decls {
+		gd, ok := decl.(*ast.GenDecl)
+		if !ok {
+			continue
+		}
+		for _, spec := range gd.Specs {
+			ts, ok := spec.(*ast.TypeSpec)
+			if !ok {
+				continue
+			}
+			info := typeSpecInfo{
+				Name: ts.Name.Name,
+				Pos:  fset.Position(ts.Name.Pos()),
+			}
+			if _, isIface := ts.Type.(*ast.InterfaceType); isIface {
+				info.IsIface = true
+			}
+			if ts.Assign != 0 {
+				if sel, ok := ts.Type.(*ast.SelectorExpr); ok {
+					if ident, ok := sel.X.(*ast.Ident); ok {
+						info.AliasFrom = resolveIdentImportPath(file, ident.Name)
+					}
+				}
+			}
+			if info.IsIface || info.AliasFrom != "" {
+				result = append(result, info)
+			}
+		}
+	}
+	return result
+}
+
 // collectInterfacesFromFile returns interface types from a single AST file.
 // If exportedOnly is true, only exported interfaces are returned.
 func collectInterfacesFromFile(file *ast.File, exportedOnly bool) map[string]*ast.InterfaceType {
@@ -228,6 +273,35 @@ func collectExportedInterfacesFromPkg(pkg *packages.Package) map[string]*ast.Int
 	for _, file := range pkg.Syntax {
 		for name, iface := range collectInterfacesFromFile(file, true) {
 			result[name] = iface
+		}
+	}
+	return result
+}
+
+// receiverTypeName extracts the type name from a method receiver expression.
+func receiverTypeName(expr ast.Expr) string {
+	if star, ok := expr.(*ast.StarExpr); ok {
+		expr = star.X
+	}
+	if ident, ok := expr.(*ast.Ident); ok {
+		return ident.Name
+	}
+	return ""
+}
+
+// collectMethods returns a set of "TypeName.MethodName" entries for all methods in the package.
+func collectMethods(pkg *packages.Package) map[string]bool {
+	result := make(map[string]bool)
+	for _, file := range pkg.Syntax {
+		for _, decl := range file.Decls {
+			fd, ok := decl.(*ast.FuncDecl)
+			if !ok || fd.Recv == nil || len(fd.Recv.List) == 0 {
+				continue
+			}
+			typeName := receiverTypeName(fd.Recv.List[0].Type)
+			if typeName != "" {
+				result[typeName+"."+fd.Name.Name] = true
+			}
 		}
 	}
 	return result

--- a/rules/interface_pattern.go
+++ b/rules/interface_pattern.go
@@ -68,8 +68,18 @@ func isExcludedInterfacePatternPkg(m Model, pkg *packages.Package) bool {
 		return true
 	}
 	// after = [domain, <domainName>, <sublayer>, ...]
+	// Check both single segment (e.g. "handler") and nested (e.g. "core/repo")
 	sublayer := after[2]
-	return m.InterfacePatternExclude[sublayer]
+	if m.InterfacePatternExclude[sublayer] {
+		return true
+	}
+	if len(after) >= 4 {
+		nested := after[2] + "/" + after[3]
+		if m.InterfacePatternExclude[nested] {
+			return true
+		}
+	}
+	return false
 }
 
 // collectExportedInterfaces returns all exported interface types in a package.

--- a/rules/interface_pattern.go
+++ b/rules/interface_pattern.go
@@ -23,7 +23,7 @@ func CheckInterfacePattern(pkgs []*packages.Package, opts ...Option) []Violation
 			continue
 		}
 
-		ifaces := collectExportedInterfaces(pkg)
+		ifaces := collectExportedInterfacesFromPkg(pkg)
 		if len(ifaces) == 0 {
 			continue
 		}
@@ -80,29 +80,6 @@ func isExcludedInterfacePatternPkg(m Model, pkg *packages.Package) bool {
 		}
 	}
 	return false
-}
-
-// collectExportedInterfaces returns all exported interface types in a package.
-func collectExportedInterfaces(pkg *packages.Package) map[string]*ast.InterfaceType {
-	result := make(map[string]*ast.InterfaceType)
-	for _, file := range pkg.Syntax {
-		for _, decl := range file.Decls {
-			gd, ok := decl.(*ast.GenDecl)
-			if !ok {
-				continue
-			}
-			for _, spec := range gd.Specs {
-				ts, ok := spec.(*ast.TypeSpec)
-				if !ok || !ts.Name.IsExported() {
-					continue
-				}
-				if iface, ok := ts.Type.(*ast.InterfaceType); ok {
-					result[ts.Name.Name] = iface
-				}
-			}
-		}
-	}
-	return result
 }
 
 // interfaceMethodNames extracts method names from an interface type.

--- a/rules/isolation.go
+++ b/rules/isolation.go
@@ -199,20 +199,20 @@ func CheckDomainIsolation(pkgs []*packages.Package, projectModule string, projec
 	return violations
 }
 
-func isOrchestrationPkgWith(m Model, pkgPath, internalPrefix string) bool {
-	if m.OrchestrationDir == "" {
+func isUnderInternalDir(pkgPath, internalPrefix, dir string) bool {
+	if dir == "" {
 		return false
 	}
 	rel := strings.TrimPrefix(pkgPath, internalPrefix)
-	return rel == m.OrchestrationDir || strings.HasPrefix(rel, m.OrchestrationDir+"/")
+	return rel == dir || strings.HasPrefix(rel, dir+"/")
+}
+
+func isOrchestrationPkgWith(m Model, pkgPath, internalPrefix string) bool {
+	return isUnderInternalDir(pkgPath, internalPrefix, m.OrchestrationDir)
 }
 
 func isPkgPkgWith(m Model, pkgPath, internalPrefix string) bool {
-	if m.SharedDir == "" {
-		return false
-	}
-	rel := strings.TrimPrefix(pkgPath, internalPrefix)
-	return rel == m.SharedDir || strings.HasPrefix(rel, m.SharedDir+"/")
+	return isUnderInternalDir(pkgPath, internalPrefix, m.SharedDir)
 }
 
 func isDomainAliasWith(m Model, importPath, internalPrefix, domain string) bool {

--- a/rules/model.go
+++ b/rules/model.go
@@ -81,7 +81,7 @@ func DDD() Model {
 			"domain": true,
 		},
 		InterfacePatternExclude: map[string]bool{
-			"handler": true, "app": true, "core/model": true, "event": true,
+			"handler": true, "app": true, "core/model": true, "core/repo": true, "event": true,
 		},
 	}
 }

--- a/rules/naming.go
+++ b/rules/naming.go
@@ -174,10 +174,10 @@ func toSnakeCase(filename string) string {
 }
 
 func checkRepoFileInterfaceWith(m Model, pkg *packages.Package, cfg Config) []Violation {
-	if !hasRepoSublayer(m) {
+	if !hasPortSublayer(m) {
 		return nil
 	}
-	if !isAnyRepoPackage(pkg.PkgPath) {
+	if matchPortSublayer(m, pkg.PkgPath) == "" {
 		return nil
 	}
 
@@ -194,7 +194,7 @@ func checkRepoFileInterfaceWith(m Model, pkg *packages.Package, cfg Config) []Vi
 		}
 		expected := snakeToPascal(strings.TrimSuffix(base, ".go"))
 
-		ifaces := collectFileInterfaces(astFile)
+		ifaces := collectInterfacesFromFile(astFile, false)
 
 		// Check: expected interface must exist
 		if _, ok := ifaces[expected]; !ok {
@@ -242,54 +242,6 @@ func checkRepoFileInterfaceWith(m Model, pkg *packages.Package, cfg Config) []Vi
 		}
 	}
 	return violations
-}
-
-func collectFileInterfaces(file *ast.File) map[string]*ast.InterfaceType {
-	result := make(map[string]*ast.InterfaceType)
-	for _, decl := range file.Decls {
-		gd, ok := decl.(*ast.GenDecl)
-		if !ok {
-			continue
-		}
-		for _, spec := range gd.Specs {
-			ts, ok := spec.(*ast.TypeSpec)
-			if !ok {
-				continue
-			}
-			if iface, ok := ts.Type.(*ast.InterfaceType); ok {
-				result[ts.Name.Name] = iface
-			}
-		}
-	}
-	return result
-}
-
-// portSublayers are layers that serve as pure interface (port) definitions.
-var portSublayers = []string{"repo", "gateway"}
-
-func hasRepoSublayer(m Model) bool {
-	for _, sl := range m.Sublayers {
-		for _, ps := range portSublayers {
-			if sl == ps || strings.HasSuffix(sl, "/"+ps) {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-func isAnyRepoPackage(pkgPath string) bool {
-	idx := strings.Index(pkgPath, "/internal/")
-	if idx < 0 {
-		return false
-	}
-	rel := pkgPath[idx+len("/internal/"):]
-	for _, ps := range portSublayers {
-		if strings.HasSuffix(rel, "/"+ps) || strings.Contains(rel, "/"+ps+"/") {
-			return true
-		}
-	}
-	return false
 }
 
 func snakeToPascal(s string) string {
@@ -358,25 +310,7 @@ func isDomainPackageWith(m Model, pkgPath string) bool {
 }
 
 func isRepoPackageWith(m Model, pkgPath string) bool {
-	for _, sl := range m.Sublayers {
-		if sl == "repo" || strings.HasSuffix(sl, "/repo") {
-			// Check if pkgPath ends with this sublayer or is inside it
-			suffix := "/" + sl
-			if strings.HasSuffix(pkgPath, suffix) || strings.Contains(pkgPath, suffix+"/") {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-func repoSublayerName(m Model) string {
-	for _, sl := range m.Sublayers {
-		if sl == "repo" || strings.HasSuffix(sl, "/repo") {
-			return sl
-		}
-	}
-	return "core/repo"
+	return matchPortSublayer(m, pkgPath) != ""
 }
 
 // checkDomainInterfaceRepoOnlyWith flags interface declarations in any domain
@@ -389,7 +323,7 @@ func checkDomainInterfaceRepoOnlyWith(m Model, pkg *packages.Package, cfg Config
 	if !isDomainPackageWith(m, pkg.PkgPath) || isRepoPackageWith(m, pkg.PkgPath) {
 		return nil
 	}
-	repoName := repoSublayerName(m)
+	repoName := portSublayerName(m)
 	var violations []Violation
 	for _, file := range pkg.Syntax {
 		filePath := relativePathForPackage(pkg, pkg.Fset.Position(file.Pos()).Filename)
@@ -531,14 +465,7 @@ func collectMockStructs(fset *token.FileSet, file *ast.File) map[string]int {
 }
 
 func isRepoImportPath(m Model, impPath string) bool {
-	for _, sl := range m.Sublayers {
-		if sl == "repo" || strings.HasSuffix(sl, "/repo") {
-			if strings.Contains(impPath, "/"+sl) {
-				return true
-			}
-		}
-	}
-	return false
+	return matchPortSublayer(m, impPath) != ""
 }
 
 func isTypePatternFile(m Model, dir, filename string) bool {

--- a/rules/naming.go
+++ b/rules/naming.go
@@ -264,23 +264,32 @@ func collectFileInterfaces(file *ast.File) map[string]*ast.InterfaceType {
 	return result
 }
 
+// portSublayers are layers that serve as pure interface (port) definitions.
+var portSublayers = []string{"repo", "gateway"}
+
 func hasRepoSublayer(m Model) bool {
 	for _, sl := range m.Sublayers {
-		if sl == "repo" || strings.HasSuffix(sl, "/repo") {
-			return true
+		for _, ps := range portSublayers {
+			if sl == ps || strings.HasSuffix(sl, "/"+ps) {
+				return true
+			}
 		}
 	}
 	return false
 }
 
 func isAnyRepoPackage(pkgPath string) bool {
-	// Only match repo packages within the project's internal/ tree.
 	idx := strings.Index(pkgPath, "/internal/")
 	if idx < 0 {
 		return false
 	}
 	rel := pkgPath[idx+len("/internal/"):]
-	return strings.HasSuffix(rel, "/repo") || strings.Contains(rel, "/repo/")
+	for _, ps := range portSublayers {
+		if strings.HasSuffix(rel, "/"+ps) || strings.Contains(rel, "/"+ps+"/") {
+			return true
+		}
+	}
+	return false
 }
 
 func snakeToPascal(s string) string {

--- a/rules/naming.go
+++ b/rules/naming.go
@@ -1,11 +1,13 @@
 package rules
 
 import (
+	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/token"
 	"path"
 	"path/filepath"
+	"sort"
 	"strings"
 	"unicode"
 
@@ -191,18 +193,75 @@ func checkRepoFileInterfaceWith(m Model, pkg *packages.Package, cfg Config) []Vi
 			continue
 		}
 		expected := snakeToPascal(strings.TrimSuffix(base, ".go"))
-		if hasInterface(astFile, expected) {
-			continue
+
+		ifaces := collectFileInterfaces(astFile)
+
+		// Check: expected interface must exist
+		if _, ok := ifaces[expected]; !ok {
+			violations = append(violations, Violation{
+				File:     relPath,
+				Rule:     "naming.repo-file-interface",
+				Message:  `file "` + base + `" in repo/ must contain interface "` + expected + `"`,
+				Fix:      `add "type ` + expected + ` interface { ... }" or rename the file`,
+				Severity: cfg.Sev,
+			})
 		}
-		violations = append(violations, Violation{
-			File:     relPath,
-			Rule:     "naming.repo-file-interface",
-			Message:  `file "` + base + `" in repo/ must contain interface "` + expected + `"`,
-			Fix:      `add "type ` + expected + ` interface { ... }" or rename the file`,
-			Severity: cfg.Sev,
-		})
+
+		// Check: only one interface per file
+		if len(ifaces) > 1 {
+			var extra []string
+			for name := range ifaces {
+				if name != expected {
+					extra = append(extra, name)
+				}
+			}
+			sort.Strings(extra)
+			violations = append(violations, Violation{
+				File:     relPath,
+				Rule:     "naming.repo-file-extra-interface",
+				Message:  `file "` + base + `" in repo/ must define only "` + expected + `", found extra: ` + strings.Join(extra, ", "),
+				Fix:      "move each extra interface to its own file (e.g. " + strings.ToLower(extra[0]) + ".go)",
+				Severity: cfg.Sev,
+			})
+		}
+
+		// Check: interface method count
+		if cfg.MaxRepoInterfaceMethods > 0 {
+			for name, iface := range ifaces {
+				methodCount := len(iface.Methods.List)
+				if methodCount > cfg.MaxRepoInterfaceMethods {
+					violations = append(violations, Violation{
+						File:     relPath,
+						Rule:     "naming.repo-interface-too-large",
+						Message:  fmt.Sprintf(`interface "%s" has %d methods (max %d)`, name, methodCount, cfg.MaxRepoInterfaceMethods),
+						Fix:      "split into smaller, focused interfaces",
+						Severity: cfg.Sev,
+					})
+				}
+			}
+		}
 	}
 	return violations
+}
+
+func collectFileInterfaces(file *ast.File) map[string]*ast.InterfaceType {
+	result := make(map[string]*ast.InterfaceType)
+	for _, decl := range file.Decls {
+		gd, ok := decl.(*ast.GenDecl)
+		if !ok {
+			continue
+		}
+		for _, spec := range gd.Specs {
+			ts, ok := spec.(*ast.TypeSpec)
+			if !ok {
+				continue
+			}
+			if iface, ok := ts.Type.(*ast.InterfaceType); ok {
+				result[ts.Name.Name] = iface
+			}
+		}
+	}
+	return result
 }
 
 func hasRepoSublayer(m Model) bool {
@@ -235,27 +294,6 @@ func snakeToPascal(s string) string {
 		b.WriteString(p[1:])
 	}
 	return b.String()
-}
-
-func hasInterface(file *ast.File, name string) bool {
-	for _, decl := range file.Decls {
-		gd, ok := decl.(*ast.GenDecl)
-		if !ok {
-			continue
-		}
-		for _, spec := range gd.Specs {
-			ts, ok := spec.(*ast.TypeSpec)
-			if !ok {
-				continue
-			}
-			if ts.Name.Name == name {
-				if _, isIface := ts.Type.(*ast.InterfaceType); isIface {
-					return true
-				}
-			}
-		}
-	}
-	return false
 }
 
 var bannedLayerSuffixes = []string{

--- a/rules/naming.go
+++ b/rules/naming.go
@@ -330,47 +330,27 @@ func checkDomainInterfaceRepoOnlyWith(m Model, pkg *packages.Package, cfg Config
 		if cfg.IsExcluded(filePath) {
 			continue
 		}
-		for _, decl := range file.Decls {
-			gd, ok := decl.(*ast.GenDecl)
-			if !ok {
-				continue
+		for _, info := range inspectTypeSpecs(file, pkg.Fset) {
+			relFile := relativePathForPackage(pkg, info.Pos.Filename)
+			if info.IsIface {
+				violations = append(violations, Violation{
+					File:     relFile,
+					Line:     info.Pos.Line,
+					Rule:     "naming.domain-interface-repo-only",
+					Message:  `interface "` + info.Name + `" must be defined in ` + repoName + `/, not in ` + path.Base(path.Dir(pkg.PkgPath)) + `/`,
+					Fix:      "move interface to " + repoName + "/",
+					Severity: cfg.Sev,
+				})
 			}
-			for _, spec := range gd.Specs {
-				ts, ok := spec.(*ast.TypeSpec)
-				if !ok {
-					continue
-				}
-				// Direct interface definition
-				if _, isIface := ts.Type.(*ast.InterfaceType); isIface {
-					pos := pkg.Fset.Position(ts.Name.Pos())
-					violations = append(violations, Violation{
-						File:     relativePathForPackage(pkg, pos.Filename),
-						Line:     pos.Line,
-						Rule:     "naming.domain-interface-repo-only",
-						Message:  `interface "` + ts.Name.Name + `" must be defined in ` + repoName + `/, not in ` + path.Base(path.Dir(pkg.PkgPath)) + `/`,
-						Fix:      "move interface to " + repoName + "/",
-						Severity: cfg.Sev,
-					})
-				}
-				// Type alias from repo sublayer (re-exporting interface)
-				if ts.Assign != 0 {
-					if sel, ok := ts.Type.(*ast.SelectorExpr); ok {
-						if ident, ok := sel.X.(*ast.Ident); ok {
-							impPath := resolveIdentImportPath(file, ident.Name)
-							if isRepoImportPath(m, impPath) {
-								pos := pkg.Fset.Position(ts.Name.Pos())
-								violations = append(violations, Violation{
-									File:     relativePathForPackage(pkg, pos.Filename),
-									Line:     pos.Line,
-									Rule:     "naming.domain-interface-repo-only",
-									Message:  `type alias "` + ts.Name.Name + `" re-exports interface from ` + repoName + ` — suspected cross-domain dependency; use ` + m.OrchestrationDir + `/ instead`,
-									Fix:      "remove alias and move cross-domain coordination to " + m.OrchestrationDir + "/",
-									Severity: cfg.Sev,
-								})
-							}
-						}
-					}
-				}
+			if info.AliasFrom != "" && isRepoPackageWith(m, info.AliasFrom) {
+				violations = append(violations, Violation{
+					File:     relFile,
+					Line:     info.Pos.Line,
+					Rule:     "naming.domain-interface-repo-only",
+					Message:  `type alias "` + info.Name + `" re-exports interface from ` + repoName + ` — suspected cross-domain dependency; use ` + m.OrchestrationDir + `/ instead`,
+					Fix:      "remove alias and move cross-domain coordination to " + m.OrchestrationDir + "/",
+					Severity: cfg.Sev,
+				})
 			}
 		}
 	}
@@ -464,10 +444,6 @@ func collectMockStructs(fset *token.FileSet, file *ast.File) map[string]int {
 	return result
 }
 
-func isRepoImportPath(m Model, impPath string) bool {
-	return matchPortSublayer(m, impPath) != ""
-}
-
 func isTypePatternFile(m Model, dir, filename string) bool {
 	name := strings.TrimSuffix(filename, ".go")
 	for _, tp := range m.TypePatterns {
@@ -476,14 +452,4 @@ func isTypePatternFile(m Model, dir, filename string) bool {
 		}
 	}
 	return false
-}
-
-func receiverTypeName(expr ast.Expr) string {
-	if star, ok := expr.(*ast.StarExpr); ok {
-		expr = star.X
-	}
-	if ident, ok := expr.(*ast.Ident); ok {
-		return ident.Name
-	}
-	return ""
 }

--- a/rules/naming_test.go
+++ b/rules/naming_test.go
@@ -181,3 +181,66 @@ func TestCheckNaming_FlatLayout_WorkerFileAllowed(t *testing.T) {
 		}
 	}
 }
+
+func TestCheckNaming_RepoFileExtraInterface(t *testing.T) {
+	root := t.TempDir()
+	module := "example.com/repomulti"
+
+	writeTestFile(t, filepath.Join(root, "go.mod"), "module "+module+"\n\ngo 1.21\n")
+	writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "alias.go"),
+		"package order\n")
+	writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "core", "model", "order.go"),
+		"package model\n\ntype Order struct{}\n")
+	// review.go defines Review (correct) plus an extra Helper interface
+	writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "core", "repo", "review.go"),
+		"package repo\n\ntype Review interface { Find() }\ntype Helper interface { Assist() }\n")
+
+	pkgs := loadTestPackages(t, root)
+	violations := rules.CheckNaming(pkgs)
+	found := false
+	for _, v := range violations {
+		if v.Rule == "naming.repo-file-extra-interface" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected naming.repo-file-extra-interface violation for extra interface in repo/review.go")
+	}
+}
+
+func TestCheckNaming_RepoInterfaceTooLarge(t *testing.T) {
+	root := t.TempDir()
+	module := "example.com/repobig"
+
+	writeTestFile(t, filepath.Join(root, "go.mod"), "module "+module+"\n\ngo 1.21\n")
+	writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "alias.go"),
+		"package order\n")
+	writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "core", "model", "order.go"),
+		"package model\n\ntype Order struct{}\n")
+	// review.go has an interface with 11 methods
+	writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "core", "repo", "review.go"),
+		"package repo\n\ntype Review interface {\n"+
+			"\tA()\n\tB()\n\tC()\n\tD()\n\tE()\n"+
+			"\tF()\n\tG()\n\tH()\n\tI()\n\tJ()\n\tK()\n}\n")
+
+	pkgs := loadTestPackages(t, root)
+	violations := rules.CheckNaming(pkgs, rules.WithMaxRepoInterfaceMethods(10))
+
+	found := false
+	for _, v := range violations {
+		if v.Rule == "naming.repo-interface-too-large" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected naming.repo-interface-too-large violation for 11-method interface")
+	}
+
+	// Without option, no violation
+	violations2 := rules.CheckNaming(pkgs)
+	for _, v := range violations2 {
+		if v.Rule == "naming.repo-interface-too-large" {
+			t.Error("should not flag repo-interface-too-large without WithMaxRepoInterfaceMethods option")
+		}
+	}
+}

--- a/rules/rule.go
+++ b/rules/rule.go
@@ -42,9 +42,10 @@ func (v Violation) String() string {
 type Option func(*Config)
 
 type Config struct {
-	Sev             Severity
-	ExcludePatterns []string
-	archModel       *Model
+	Sev                     Severity
+	ExcludePatterns         []string
+	archModel               *Model
+	MaxRepoInterfaceMethods int
 }
 
 func (c Config) model() Model {
@@ -68,6 +69,10 @@ func WithSeverity(s Severity) Option {
 
 func WithModel(m Model) Option {
 	return func(c *Config) { c.archModel = &m }
+}
+
+func WithMaxRepoInterfaceMethods(n int) Option {
+	return func(c *Config) { c.MaxRepoInterfaceMethods = n }
 }
 
 func WithExclude(patterns ...string) Option {

--- a/rules/run_all.go
+++ b/rules/run_all.go
@@ -12,6 +12,12 @@ func RunAll(pkgs []*packages.Package, projectModule string, projectRoot string, 
 	projectModule = resolveModule(pkgs, projectModule)
 	projectRoot = resolveRoot(pkgs, projectRoot)
 
+	// Apply defaults: limit repo interface methods for models with repo sublayers.
+	cfg := NewConfig(opts...)
+	if cfg.MaxRepoInterfaceMethods == 0 && hasRepoSublayer(cfg.model()) {
+		opts = append([]Option{WithMaxRepoInterfaceMethods(10)}, opts...)
+	}
+
 	var violations []Violation
 	violations = append(violations, CheckDomainIsolation(pkgs, projectModule, projectRoot, opts...)...)
 	violations = append(violations, CheckLayerDirection(pkgs, projectModule, projectRoot, opts...)...)

--- a/rules/run_all.go
+++ b/rules/run_all.go
@@ -14,7 +14,7 @@ func RunAll(pkgs []*packages.Package, projectModule string, projectRoot string, 
 
 	// Apply defaults: limit repo interface methods for models with repo sublayers.
 	cfg := NewConfig(opts...)
-	if cfg.MaxRepoInterfaceMethods == 0 && hasRepoSublayer(cfg.model()) {
+	if cfg.MaxRepoInterfaceMethods == 0 && hasPortSublayer(cfg.model()) {
 		opts = append([]Option{WithMaxRepoInterfaceMethods(10)}, opts...)
 	}
 

--- a/rules/structure.go
+++ b/rules/structure.go
@@ -449,22 +449,6 @@ func matchesDomainLayerWith(m Model, rel, name string) bool {
 	return len(parts) == 4 && parts[0] == "internal" && parts[1] == m.DomainDir && parts[2] != "" && parts[3] == name
 }
 
-// matchContractSublayer returns the sublayer name if impPath references a
-// contract sublayer (one ending in /repo, /svc, or named repo, svc).
-// These are the sublayers that define interfaces/contracts and should not
-// be re-exported via alias.go. Returns "" if no match.
-func matchContractSublayer(m Model, impPath string) string {
-	for _, sl := range m.Sublayers {
-		if sl == "repo" || sl == "svc" ||
-			strings.HasSuffix(sl, "/repo") || strings.HasSuffix(sl, "/svc") {
-			if strings.Contains(impPath, "/"+sl) {
-				return sl
-			}
-		}
-	}
-	return ""
-}
-
 func hasNonTestGoFiles(dir string) bool {
 	entries, err := os.ReadDir(dir)
 	if err != nil {

--- a/rules/structure.go
+++ b/rules/structure.go
@@ -2,7 +2,6 @@ package rules
 
 import (
 	"fmt"
-	"go/ast"
 	"go/parser"
 	"go/token"
 	"io/fs"
@@ -220,43 +219,27 @@ func checkDomainAliasNoInterface(domainDir string, m Model, cfg Config) []Violat
 		if err != nil {
 			continue
 		}
-		for _, decl := range file.Decls {
-			gd, ok := decl.(*ast.GenDecl)
-			if !ok {
-				continue
+		aliasFile := relPath + "/" + m.AliasFileName
+		for _, info := range inspectTypeSpecs(file, fset) {
+			if info.IsIface {
+				violations = append(violations, Violation{
+					File:     aliasFile,
+					Line:     info.Pos.Line,
+					Rule:     "structure.domain-alias-no-interface",
+					Message:  m.AliasFileName + ` re-exports interface "` + info.Name + `" — suspected cross-domain dependency; use ` + m.OrchestrationDir + `/ instead`,
+					Fix:      "move cross-domain coordination to " + m.OrchestrationDir + "/handler/ or " + m.OrchestrationDir + "/",
+					Severity: cfg.Sev,
+				})
 			}
-			for _, spec := range gd.Specs {
-				ts, ok := spec.(*ast.TypeSpec)
-				if !ok {
-					continue
-				}
-				if _, isIface := ts.Type.(*ast.InterfaceType); isIface {
-					violations = append(violations, Violation{
-						File:     relPath + "/" + m.AliasFileName,
-						Line:     fset.Position(ts.Name.Pos()).Line,
-						Rule:     "structure.domain-alias-no-interface",
-						Message:  m.AliasFileName + ` re-exports interface "` + ts.Name.Name + `" — suspected cross-domain dependency; use ` + m.OrchestrationDir + `/ instead`,
-						Fix:      "move cross-domain coordination to " + m.OrchestrationDir + "/handler/ or " + m.OrchestrationDir + "/",
-						Severity: cfg.Sev,
-					})
-				}
-				if ts.Assign != 0 {
-					if sel, ok := ts.Type.(*ast.SelectorExpr); ok {
-						if ident, ok := sel.X.(*ast.Ident); ok {
-							impPath := resolveIdentImportPath(file, ident.Name)
-							if src := matchContractSublayer(m, impPath); src != "" {
-								violations = append(violations, Violation{
-									File:     relPath + "/" + m.AliasFileName,
-									Line:     fset.Position(ts.Name.Pos()).Line,
-									Rule:     "structure.domain-alias-contract-reexport",
-									Message:  m.AliasFileName + ` re-exports "` + ts.Name.Name + `" from ` + src + ` — suspected cross-domain dependency; use ` + m.OrchestrationDir + `/ instead`,
-									Fix:      "move cross-domain coordination to " + m.OrchestrationDir + "/handler/ or " + m.OrchestrationDir + "/",
-									Severity: cfg.Sev,
-								})
-							}
-						}
-					}
-				}
+			if src := matchContractSublayer(m, info.AliasFrom); src != "" {
+				violations = append(violations, Violation{
+					File:     aliasFile,
+					Line:     info.Pos.Line,
+					Rule:     "structure.domain-alias-contract-reexport",
+					Message:  m.AliasFileName + ` re-exports "` + info.Name + `" from ` + src + ` — suspected cross-domain dependency; use ` + m.OrchestrationDir + `/ instead`,
+					Fix:      "move cross-domain coordination to " + m.OrchestrationDir + "/handler/ or " + m.OrchestrationDir + "/",
+					Severity: cfg.Sev,
+				})
 			}
 		}
 	}

--- a/rules/type_pattern.go
+++ b/rules/type_pattern.go
@@ -99,20 +99,3 @@ func hasExportedType(file *ast.File, name string) bool {
 	}
 	return false
 }
-
-func collectMethods(pkg *packages.Package) map[string]bool {
-	result := make(map[string]bool)
-	for _, file := range pkg.Syntax {
-		for _, decl := range file.Decls {
-			fd, ok := decl.(*ast.FuncDecl)
-			if !ok || fd.Recv == nil || len(fd.Recv.List) == 0 {
-				continue
-			}
-			typeName := receiverTypeName(fd.Recv.List[0].Type)
-			if typeName != "" {
-				result[typeName+"."+fd.Name.Name] = true
-			}
-		}
-	}
-	return result
-}


### PR DESCRIPTION
## Summary

### New rules
- `naming.repo-file-extra-interface` — each port-layer file must define exactly one interface matching the filename
- `naming.repo-interface-too-large` — port-layer interfaces must not exceed method limit (`WithMaxRepoInterfaceMethods`, default 10 in `RunAll`)

### Bug fixes
- Add `core/repo` to DDD `InterfacePatternExclude` — repo is where port interfaces live
- Fix nested sublayer matching in `isExcludedInterfacePatternPkg` (`core/repo` was not matched)

### Generalization
- Extend all repo file rules to CleanArch `gateway` via unified `portSublayers` concept
- `RunAll` defaults `WithMaxRepoInterfaceMethods(10)` for models with port sublayers

### Consolidation (2 refactor passes)
- Extract `isPortSublayer`, `isContractSublayer`, `hasPortSublayer`, `matchPortSublayer`, `matchContractSublayer`, `portSublayerName` into helpers.go — single source of truth for port/contract detection
- Extract `inspectTypeSpecs` — shared AST inspection for interface + alias detection (was duplicated in naming.go and structure.go)
- Extract `collectInterfacesFromFile`, `collectExportedInterfacesFromPkg` — shared interface collection (was duplicated in naming.go and interface_pattern.go)
- Move `collectMethods`, `receiverTypeName` to helpers.go (was in type_pattern.go/naming.go)
- Extract `isUnderInternalDir` from `isOrchestrationPkgWith`/`isPkgPkgWith`
- Remove `isRepoImportPath` (identical to `isRepoPackageWith`)

**Net: +419 / -237** (new rules + tests account for most additions; refactoring is net-negative)

## Test plan
- [x] `go test ./...` — all pass
- [x] `make lint` — 0 issues
- [x] New tests: `TestCheckNaming_RepoFileExtraInterface`, `TestCheckNaming_RepoInterfaceTooLarge`
- [x] Verified against trelab-drb-server: 4 extra-interface + 3 too-large violations detected correctly