### PR TITLE
feat: allow consumer-defined interfaces outside core/repo

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -471,7 +471,14 @@ order.go          올바름
 
 ### `structure.interface-placement` (DDD만)
 
-도메인 내 인터페이스는 `core/repo/`에만 정의해야 하며, 레이어에 흩어지면 안 됩니다.
+Repository 포트 인터페이스(이름이 `Repository` 또는 `Repo`로 끝나는 것)는
+`core/repo/`에만 정의해야 합니다. Consumer-defined interface(사용처에서
+작은 인터페이스를 선언하는 Go 관례)는 `handler/`, `app/`, `svc/` 등
+사용처 어디든 허용됩니다.
+
+`type X = otherdomain.Repo` 처럼 다른 도메인의 repository 인터페이스를
+재노출하는 alias도 함께 감지합니다 — 이런 cross-domain 경계 코드는
+`orchestration/`에 두어야 합니다.
 
 ### `testing.no-handmock`
 

--- a/README.md
+++ b/README.md
@@ -485,7 +485,13 @@ order.go          correct
 
 ### `structure.interface-placement` (DDD only)
 
-Interfaces within a domain must be defined in `core/repo/`, not scattered across layers.
+Repository-port interfaces — names ending in `Repository` or `Repo` — must be
+defined in `core/repo/`, not scattered across layers. Consumer-defined
+interfaces (the Go idiom where a package declares the small interface it
+consumes) are allowed anywhere they are used: `handler/`, `app/`, `svc/`, etc.
+
+Also flags `type X = otherdomain.Repo` aliases that re-export a repository
+interface across domain boundaries — those belong in `orchestration/`.
 
 ### `testing.no-handmock`
 

--- a/plugins/go-arch-guard/skills/go-arch-guard/SKILL.md
+++ b/plugins/go-arch-guard/skills/go-arch-guard/SKILL.md
@@ -298,11 +298,12 @@ fmt.Println(string(data))
 
 ## DDD 전용: Cross-Domain Interface 금지
 
-도메인 내 interface는 **`core/repo/`에만** 정의 가능. cross-domain 데이터 필요 시 → `orchestration/handler/`로 이동.
+Repository 포트 interface(이름이 `Repository`/`Repo`로 끝나는 것)는 **`core/repo/`에만** 정의 가능. Consumer-defined interface(사용처에서 선언하는 Go 관례)는 `handler/`, `app/`, `svc/` 어디든 허용. cross-domain 데이터 필요 시 → `orchestration/handler/`로 이동.
 
 | 우회 시도 | 잡는 규칙 |
 |----------|----------|
-| handler/app/svc에서 interface 정의 | `structure.interface-placement` |
+| handler/app/svc에서 `*Repository`/`*Repo` interface 정의 | `structure.interface-placement` |
+| handler/app/svc에서 `type X = otherdomain.Repo` alias | `structure.interface-placement` |
 | alias.go에서 interface 직접 정의 | `structure.domain-alias-no-interface` |
 | alias.go에서 repo/svc 타입 re-export | `structure.domain-alias-contract-reexport` |
 

--- a/rules/naming.go
+++ b/rules/naming.go
@@ -313,9 +313,19 @@ func isRepoPackageWith(m Model, pkgPath string) bool {
 	return matchPortSublayer(m, pkgPath) != ""
 }
 
-// checkDomainInterfaceRepoOnlyWith flags interface declarations in any domain
-// sublayer other than repo/. In DDD models, interfaces (ports) belong in the
-// repo sublayer; handler/, app/, core/svc/ etc. should not define interfaces.
+// isRepoPortName reports whether the given name follows the repository-port
+// naming convention (ends in "Repository" or "Repo"). Only repo-port interfaces
+// must live in the repo sublayer; consumer-defined interfaces (the Go idiom
+// where a package declares the small interface it consumes) are allowed in
+// app/, handler/, svc/ etc. at the site where they are used.
+func isRepoPortName(name string) bool {
+	return strings.HasSuffix(name, "Repository") || strings.HasSuffix(name, "Repo")
+}
+
+// checkDomainInterfaceRepoOnlyWith flags repository-port interface declarations
+// (names ending in "Repository"/"Repo") declared outside the repo sublayer, and
+// type aliases that re-export an interface from another domain's repo package.
+// Consumer-defined interfaces are allowed wherever they are used.
 func checkDomainInterfaceRepoOnlyWith(m Model, pkg *packages.Package, cfg Config) []Violation {
 	if !m.RequireAlias {
 		return nil
@@ -332,13 +342,13 @@ func checkDomainInterfaceRepoOnlyWith(m Model, pkg *packages.Package, cfg Config
 		}
 		for _, info := range inspectTypeSpecs(file, pkg.Fset) {
 			relFile := relativePathForPackage(pkg, info.Pos.Filename)
-			if info.IsIface {
+			if info.IsIface && isRepoPortName(info.Name) {
 				violations = append(violations, Violation{
 					File:     relFile,
 					Line:     info.Pos.Line,
 					Rule:     "structure.interface-placement",
-					Message:  `interface "` + info.Name + `" must be defined in ` + repoName + `/, not in ` + path.Base(path.Dir(pkg.PkgPath)) + `/`,
-					Fix:      "move interface to " + repoName + "/",
+					Message:  `interface "` + info.Name + `" matches repository-port naming and must be defined in ` + repoName + `/, not in ` + path.Base(path.Dir(pkg.PkgPath)) + `/`,
+					Fix:      "move to " + repoName + "/, or rename if it's a consumer-defined interface",
 					Severity: cfg.Sev,
 				})
 			}

--- a/rules/naming_test.go
+++ b/rules/naming_test.go
@@ -21,11 +21,14 @@ func TestCheckNaming(t *testing.T) {
 		}
 	})
 
-	t.Run("detects interface outside core/repo in domain", func(t *testing.T) {
+	t.Run("flags repository-port interfaces outside core/repo", func(t *testing.T) {
 		pkgs := loadInvalid(t)
 		violations := rules.CheckNaming(pkgs)
-		// handler: Service + auditLogger (direct), app: AdminOps (direct) + OrderRepo (alias)
-		wantIfaces := map[string]bool{"Service": false, "auditLogger": false, "AdminOps": false, "OrderRepo": false}
+		// handler: OrderRepository (direct repo-port interface)
+		// app: OrderRepo (alias re-exporting core/repo interface)
+		wantIfaces := map[string]bool{"OrderRepository": false, "OrderRepo": false}
+		// These consumer-defined interfaces must NOT be flagged.
+		forbidIfaces := map[string]bool{"Service": true, "auditLogger": true, "AdminOps": true}
 		for _, v := range violations {
 			if v.Rule != "structure.interface-placement" {
 				continue
@@ -33,6 +36,11 @@ func TestCheckNaming(t *testing.T) {
 			for name := range wantIfaces {
 				if strings.Contains(v.Message, `"`+name+`"`) {
 					wantIfaces[name] = true
+				}
+			}
+			for name := range forbidIfaces {
+				if strings.Contains(v.Message, `"`+name+`"`) {
+					t.Errorf("consumer-defined interface %q should NOT be flagged by structure.interface-placement: %s", name, v.String())
 				}
 			}
 		}

--- a/testdata/invalid/internal/domain/order/app/service.go
+++ b/testdata/invalid/internal/domain/order/app/service.go
@@ -5,7 +5,7 @@ import (
 	"github.com/kimtaeyun/testproject-dc-invalid/internal/domain/order/core/repo"
 )
 
-// VIOLATION: app package defines interface
+// OK: consumer-defined interface is allowed in app.
 type AdminOps interface {
 	GetUserByID(id string) (string, error)
 }

--- a/testdata/invalid/internal/domain/order/handler/http/bad_service.go
+++ b/testdata/invalid/internal/domain/order/handler/http/bad_service.go
@@ -1,11 +1,16 @@
 package http
 
-// VIOLATION: handler defines exported interface (should use *app.Service)
+// OK: consumer-defined interface (non-repo naming) is allowed in handler.
 type Service interface {
 	DoSomething() error
 }
 
-// VIOLATION: handler defines unexported interface (hidden cross-domain dependency)
+// OK: unexported consumer interface is allowed in handler.
 type auditLogger interface {
 	Record(action string) error
+}
+
+// VIOLATION: repository-port interface ("*Repository") must live in core/repo/.
+type OrderRepository interface {
+	Find(id string) error
 }


### PR DESCRIPTION
## Summary

Refocus `structure.interface-placement` on its actual goal: keep repository-port interfaces (names ending in `Repository`/`Repo`) in `core/repo/`. Consumer-defined interfaces — the Go idiom where a package declares the small interface it consumes — are now allowed in `handler/`, `app/`, `svc/` wherever they are used.

The alias re-export detection (`type X = otherdomain.Repo` across domain boundaries) is preserved.

### Why

The previous rule blocked legitimate Go patterns: a gin middleware in \`internal/domain/audit/handler/http/\` cannot declare its own small \`Recorder\` interface, even though consumer-defined interfaces at the point of use are idiomatic Go. The rule's actual intent is to prevent repository ports from leaking across layers, not to ban all interfaces.

### Changes

- \`rules/naming.go\`: add \`isRepoPortName\` helper, wrap the \`IsIface\` violation path so only repo-pattern names are flagged. Alias re-export path unchanged.
- \`rules/naming_test.go\`: updated expectations — \`OrderRepository\` (new fixture) + \`OrderRepo\` alias are flagged; \`Service\`, \`auditLogger\`, \`AdminOps\` are explicitly asserted as NOT flagged.
- Test fixtures updated to reflect the new semantics.
- README (en/ko) + SKILL.md updated.

## Test plan

- [x] \`go test ./rules/ -run TestCheckNaming\` passes
- [x] \`go test ./...\` passes
- [x] Downstream: drb-server's audit middleware refactor (separate PR) passes all architecture checks