### PR TITLE
refactor(rules): typed callbacks for forbiddenCallRule Message/Fix

### DIFF
--- a/rules/forbidden_call_engine.go
+++ b/rules/forbidden_call_engine.go
@@ -1,7 +1,6 @@
 package rules
 
 import (
-	"fmt"
 	"go/ast"
 	"go/types"
 	"slices"
@@ -17,10 +16,11 @@ type forbiddenCallRule struct {
 	Symbols       []string
 	AllowedLayers []string
 	RuleName      string
-	// Message and Fix are fmt templates formatted with (layer string, allowedLayers []string).
-	// Use %q for the layer and %v for allowedLayers.
-	Message string
-	Fix     string
+	// Message and Fix receive the offending layer and the allowed-layer list.
+	// Typed callbacks replace former fmt-template strings so misuse fails at
+	// compile time instead of producing %!(EXTRA...) output at runtime.
+	Message func(layer string, allowed []string) string
+	Fix     func(layer string, allowed []string) string
 }
 
 // checkForbiddenCallsByLayer walks all CallExprs in internal packages and
@@ -43,8 +43,8 @@ func checkForbiddenCallsByLayer(
 	type compiledRule struct {
 		allowed      map[string]bool
 		ruleName     string
-		message      string
-		fix          string
+		message      func(string, []string) string
+		fix          func(string, []string) string
 		allowedSlice []string
 	}
 	byName := map[string][]compiledRule{}
@@ -103,8 +103,8 @@ func checkForbiddenCallsByLayer(
 						File:     relFile,
 						Line:     pos.Line,
 						Rule:     cr.ruleName,
-						Message:  fmt.Sprintf(cr.message, layer, cr.allowedSlice),
-						Fix:      fmt.Sprintf(cr.fix, layer, cr.allowedSlice),
+						Message:  cr.message(layer, cr.allowedSlice),
+						Fix:      cr.fix(layer, cr.allowedSlice),
 						Severity: cfg.Sev,
 					})
 				}

--- a/rules/signature_type_engine.go
+++ b/rules/signature_type_engine.go
@@ -1,7 +1,6 @@
 package rules
 
 import (
-	"fmt"
 	"go/ast"
 	"go/types"
 	"strings"
@@ -14,7 +13,7 @@ import (
 // pointer/slice/array/map/chan wrappers) matches one of typeNames and
 // the function's package layer is outside allowedLayers.
 //
-// message/fix are fmt templates formatted with (typeID string, allowedLayers []string).
+// message/fix are typed callbacks receiving (typeID, allowedLayers).
 func checkTypeInSignature(
 	pkgs []*packages.Package,
 	projectModule, projectRoot string,
@@ -22,7 +21,8 @@ func checkTypeInSignature(
 	cfg Config,
 	typeNames []string,
 	allowedLayers []string,
-	ruleName, message, fix string,
+	ruleName string,
+	message, fix func(typeID string, allowed []string) string,
 ) []Violation {
 	if len(typeNames) == 0 {
 		return nil
@@ -75,7 +75,8 @@ func checkFieldList(
 	wanted map[string]bool,
 	projectRoot string,
 	cfg Config,
-	ruleName, message, fix string,
+	ruleName string,
+	message, fix func(typeID string, allowed []string) string,
 	allowedLayers []string,
 	out *[]Violation,
 ) {
@@ -97,8 +98,8 @@ func checkFieldList(
 			File:     relFile,
 			Line:     pos.Line,
 			Rule:     ruleName,
-			Message:  fmt.Sprintf(message, id, allowedLayers),
-			Fix:      fmt.Sprintf(fix, id, allowedLayers),
+			Message:  message(id, allowedLayers),
+			Fix:      fix(id, allowedLayers),
 			Severity: cfg.Sev,
 		})
 	}

--- a/rules/tx_boundary.go
+++ b/rules/tx_boundary.go
@@ -1,6 +1,8 @@
 package rules
 
 import (
+	"fmt"
+
 	"golang.org/x/tools/go/packages"
 )
 
@@ -34,8 +36,12 @@ func CheckTxBoundary(
 					Symbols:       tc.StartSymbols,
 					AllowedLayers: allowed,
 					RuleName:      "tx.start-outside-allowed-layer",
-					Message:       "transaction must not start in layer %q; allowed layers: %v",
-					Fix:           "move the transaction-starting call out of %q into an allowed layer: %v",
+					Message: func(layer string, allowed []string) string {
+						return fmt.Sprintf("transaction must not start in layer %q; allowed layers: %v", layer, allowed)
+					},
+					Fix: func(layer string, allowed []string) string {
+						return fmt.Sprintf("move the transaction-starting call out of %q into an allowed layer: %v", layer, allowed)
+					},
 				}})...,
 		)
 	}
@@ -45,8 +51,12 @@ func CheckTxBoundary(
 			checkTypeInSignature(pkgs, projectModule, projectRoot, m, cfg,
 				tc.Types, allowed,
 				"tx.type-in-signature",
-				"tx type %q must not appear in function signature outside allowed layers: %v",
-				"keep %q confined to allowed layers: %v",
+				func(typeID string, allowed []string) string {
+					return fmt.Sprintf("tx type %q must not appear in function signature outside allowed layers: %v", typeID, allowed)
+				},
+				func(typeID string, allowed []string) string {
+					return fmt.Sprintf("keep %q confined to allowed layers: %v", typeID, allowed)
+				},
 			)...,
 		)
 	}


### PR DESCRIPTION
## Summary

Converts the \`Message\` / \`Fix\` fields of \`forbiddenCallRule\` and the matching parameters of \`checkTypeInSignature\` from \`fmt\`-template strings into typed callbacks.

Before:
\`\`\`go
Message: "transaction must not start in layer %q; allowed layers: %v",
\`\`\`

After:
\`\`\`go
Message: func(layer string, allowed []string) string {
    return fmt.Sprintf("transaction must not start in layer %q; allowed layers: %v", layer, allowed)
},
\`\`\`

Behavior: identical. Compile-time safety: the wrong number/order of format args now fails at build time instead of producing \`%!(EXTRA ...)\` garbage in the violation output at runtime.

## Why now

Issue #11 will add two more rules (\`CheckForbiddenInfraUse\`, \`CheckMandatoryWrapper\`) that both reuse these engines. Each new caller authors its own template strings. Keeping the untyped \`fmt\` contract would multiply the misuse surface. Addresses one item from #17.

## Test plan

- [ ] \`go test ./... -count=1\` — all suites green
- [ ] \`make lint\` — 0 issues
- [ ] Existing \`CheckTxBoundary\` tests (7) pass unchanged — confirms no user-visible output change

## Files

- \`rules/forbidden_call_engine.go\` — struct field type change, loop uses callback
- \`rules/signature_type_engine.go\` — parameter type change
- \`rules/tx_boundary.go\` — inline closures instead of strings