### PR TITLE
docs: reframe Rule Scope — neutral infrastructure for team conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Concept
 
-Go 프로젝트의 아키텍처 규칙(의존성, 네이밍, 구조)을 정적 분석으로 검증하는 라이브러리이며, AI 코딩 에이전트가 쉽게 스캐폴딩하고 유지할 수 있는 표면을 제공한다.
+Go 프로젝트의 아키텍처 규칙(의존성, 네이밍, 구조)을 정적 분석으로 검증하는 라이브러리. 팀이 커밋한 컨벤션을 vibe coding 중에 깨지지 않게 지켜주는 **중립 인프라**이며, AI 코딩 에이전트가 쉽게 스캐폴딩하고 유지할 수 있는 표면을 제공한다.
 
 AI 에이전트 친화적인 기본 surface:
 - `scaffold.ArchitectureTest(...)` — 프리셋별 `architecture_test.go` 생성
@@ -46,66 +46,54 @@ Phase 3: Documentation agent -> Update docs
 
 ### Rule Scope (CRITICAL)
 
-This library exists to add **coarse guardrails for vibe coding**, not to encode architecture purity or invent a new language on top of Go.
+This library is neutral infrastructure for enforcing **team-owned conventions**.
+The question "is this convention worth enforcing?" is a team decision, not a
+library decision. If a team commits to a convention — however micro — and
+violations can be detected mechanically with low false positives, the library
+should be able to express it.
 
-- The goal is to block **big-picture exceptions** that are easy to introduce during vibe coding:
-  - unwanted package placement
-  - broad import-direction violations
-  - naming that breaks the intended project shape
-- The goal is **not** to enforce theoretical purity or micro-level architectural doctrine.
-- Prefer rules that control the **overall flow and boundaries** of the codebase.
-- Avoid rules that try to police every corner case, implementation detail, or semantic nuance.
+#### What the library ships
 
-#### Explicit Non-Goals
+- Rule primitives that encode common vibe-coding failure modes (cross-domain
+  imports, layer direction, placement drift, container interfaces, tx boundary,
+  etc.)
+- Presets (DDD, CleanArch, Hexagonal, ModularMonolith, ConsumerWorker, Batch,
+  EventPipeline) that bundle sensible defaults for common team shapes.
+- Extension points so teams can add their own rules or tune existing ones.
 
-Do **not** add or push for rules based on arguments like:
+#### What the team decides
 
-- "domain core must be pure"
-- "alias.go must strictly control exposure"
-- "cmd reverse dependency must be blocked"
-- "this import is philosophically wrong even though Go already handles it"
+- Which conventions are worth enforcing in their codebase. "Domain core must
+  be pure" or "alias.go is the only exposed surface" are legitimate team
+  choices; the library provides rules for those if they are mechanically
+  detectable.
+- Severity per rule — `Error` (blocks builds) or `Warning` (advisory). Override
+  via `WithSeverity`.
+- False-positive tolerance. A rule that's noisy in one project may be a clean
+  win in another.
 
-If Go already rejects something by itself, such as import cycles, do not treat that as a special architecture rule target unless the user explicitly asks for it.
+#### Practical gates (apply to every rule, regardless of scope)
 
-When proposing or implementing new rules, optimize for:
+- **Mechanically detectable** — AST- or types-based, no guessing at intent.
+- **Low false-positive risk** — a rule that fires on legitimate code is worse
+  than no rule. This is the firmest gate; "micro" scope is fine, "noisy" is
+  not.
+- **Static analysis only** — no runtime dependencies.
+- **Independent** — no hidden ordering or state sharing between rules.
 
-- obvious, large-scale guardrails
-- low surprise
-- low false-positive risk
-- practical usefulness during vibe coding
+#### When to add a rule to the recommended bundle
 
-Do **not** optimize for:
+- A pattern that breaks during vibe coding as a project scales up, and a team
+  convention that catches it.
+- Motivation (the *why*, not just the *what*) documented in godoc or
+  `docs/`.
+- Severity chosen per how firmly the pattern actually breaks things in
+  practice. The library does not require "parallel uncontrolled surface" as
+  the sole trigger for `Error` severity — teams may promote a rule to `Error`
+  when the convention is firm.
 
-- ideology
-- purity
-- corner-case control
-- over-modeling package internals
-
-#### Warning Category vs Hard Rules
-
-The Non-Goals above apply to **hard-enforcing rules** (Error severity) that block builds. They do **not** apply to **Warning-severity smell detectors** that inform without blocking, as long as the smell:
-
-- is **mechanically detectable** with low false-positive risk,
-- correlates with a real vibe-coding regression (not theoretical purity),
-- has a clearly stated motivation in `docs/` or the rule's godoc,
-- defaults to `Warning` severity (callers can opt into `Error` via `WithSeverity`),
-- and is independent of any specific project layout.
-
-A Warning surfaces a smell to the developer without forcing a fix. This is different from "policing implementation details" because the developer remains in control. Examples that fit this category:
-
-- `interface.container-only` — interface declared but used only as a struct field, never as a function parameter or return type. This catches the wiring-layer workaround pattern where a developer declares a local interface just to give a struct field a type.
-
-When adding a new Warning-severity rule, document the motivation (the *why*, not just the *what*) and prefer to point at the *cause* of the smell rather than the *symptom*.
-
-#### When a Hard Rule Is Justified
-
-A hard rule (Error severity) is justified when:
-
-- the violation creates a parallel or uncontrolled architectural surface that bypasses an existing controlled surface (e.g. `alias.go`),
-- the project has explicitly committed to that controlled surface as a convention,
-- the violation is mechanically detectable with low false-positive risk,
-- and the fix is clear (use the controlled surface instead).
-
-Example:
-
-- `interface.cross-domain-anonymous` — anonymous interface declared outside both the source domain and the orchestration layer whose method signatures touch a foreign domain's types. The project convention is that cross-domain abstractions are owned by the orchestration package; declaring such an abstraction in `cmd/` (or other wiring code) creates a parallel uncontrolled cross-domain surface. Severity Error because the convention is firm and the fix is clear: move the adapter into `internal/orchestration/` and have wiring code call orchestration constructors instead. Orchestration packages are themselves exempt because cross-domain coordination is by design there.
+Example: `interface.cross-domain-anonymous` is shipped as `Error` because the
+fix is clear (move the adapter into `internal/orchestration/`) and the
+convention — cross-domain abstractions owned by the orchestration package —
+is firm in every preset that enables it. Teams that use a different
+orchestration convention can downgrade or exclude it.


### PR DESCRIPTION
## Summary

Reframes \`CLAUDE.md\`'s Rule Scope section. The previous stance — "coarse guardrails only, avoid micro / purity" — is replaced with a team-owned-convention framing. The library is now neutral infrastructure: if a team commits to a convention, however micro, and violations are mechanically detectable with low false positives, the library should be able to express it.

## Why

Vibe coding projects scale up. Patterns that look "too micro" to enforce at 1k LOC become the cracks that split open at 100k LOC. Whether a pattern is worth enforcing is a team decision, not something the library should pre-judge. The old policy ruled out entire categories of rules ("domain core must be pure", "alias.go strict control") on ideological grounds; this was preventing otherwise-valid team conventions from being expressed.

## Changes

- **Removes** the "Explicit Non-Goals" list. Those arguments (purity, alias.go control, cmd reverse dependency) now fall under team judgment.
- **Removes** the "parallel uncontrolled surface" requirement for Error severity. Teams promote rules to Error when their convention is firm; the library does not gate that decision.
- **Keeps** the practical gates: mechanical detectability, low false positive risk, static analysis only, rule independence. These remain firm because they affect every team the same way.
- **Clarifies** what the library ships (rule primitives + presets + extension points) vs what the team decides (which conventions, severity, false-positive tolerance).
- Concept section: adds a single-line note that the library is neutral infrastructure.

## Downstream implications

- Open issue #17 (policy: revisit interface_pattern severity) partially moots under the new framing. The "Error severity too strict" argument against \`interface_pattern\` rules was based on the old Rule Scope; under the new policy, those severity choices are team decisions. The \`exported-impl\` name-only-comparison **bug** in that issue still stands and should be fixed separately.
- Issues #14, #15, #16, #18, #19 are unaffected (they target concrete correctness or refactor gaps).

## Test plan

- [ ] No code change. Review the document for internal consistency.
- [ ] Ensure tone still matches the CLAUDE.md Workflow / Post-Implementation sections (they are unchanged).