### PR TITLE
fix(analyzer): reject packages with broken dependencies

### DIFF
--- a/analyzer/loader.go
+++ b/analyzer/loader.go
@@ -42,7 +42,7 @@ func Load(dir string, patterns ...string) ([]*packages.Package, error) {
 	var result []*packages.Package
 	var loadErrs []string
 	for _, pkg := range pkgs {
-		if depErr := firstNonTypeErrorInDeps(pkg); depErr != "" {
+		if depErr := firstFatalErrorInDeps(pkg); depErr != "" {
 			loadErrs = append(loadErrs, depErr)
 			continue
 		}
@@ -76,17 +76,19 @@ func Load(dir string, patterns ...string) ([]*packages.Package, error) {
 	return result, nil
 }
 
-// firstNonTypeErrorInDeps traverses the transitive import graph of pkg
-// (excluding pkg itself) and returns the first non-TypeError error string
-// found in any dependency. An empty string means all deps are clean.
-func firstNonTypeErrorInDeps(root *packages.Package) string {
+// firstFatalErrorInDeps traverses the transitive import graph of pkg
+// (excluding pkg itself) and returns the first fatal error (ParseError or
+// ListError) found in any dependency. TypeError and UnknownError are
+// tolerated to avoid false positives from transient toolchain/export-data
+// issues. An empty string means all deps are clean.
+func firstFatalErrorInDeps(root *packages.Package) string {
 	var found string
 	packages.Visit([]*packages.Package{root}, nil, func(dep *packages.Package) {
 		if found != "" || dep == root {
 			return
 		}
 		for _, e := range dep.Errors {
-			if e.Kind != packages.TypeError {
+			if e.Kind == packages.ParseError || e.Kind == packages.ListError {
 				found = fmt.Sprintf("dependency %s: %s", dep.PkgPath, e.Error())
 				return
 			}

--- a/analyzer/loader.go
+++ b/analyzer/loader.go
@@ -42,13 +42,18 @@ func Load(dir string, patterns ...string) ([]*packages.Package, error) {
 	var result []*packages.Package
 	var loadErrs []string
 	for _, pkg := range pkgs {
+		if depErr := firstNonTypeErrorInDeps(pkg); depErr != "" {
+			loadErrs = append(loadErrs, depErr)
+			continue
+		}
 		if len(pkg.Errors) == 0 {
 			result = append(result, pkg)
 			continue
 		}
-		// Tolerate pure type-check failures (e.g., undefined identifier) because
-		// downstream rules can still inspect the AST/imports. Reject parse and
-		// list errors since those leave TypesInfo unreliable.
+		// Tolerate pure type-check failures on the root package itself (e.g.,
+		// undefined identifier) because downstream rules can still inspect the
+		// AST/imports. Reject parse and list errors since those leave TypesInfo
+		// unreliable.
 		onlyTypeErrors := pkg.IllTyped
 		for _, e := range pkg.Errors {
 			if e.Kind != packages.TypeError {
@@ -60,7 +65,7 @@ func Load(dir string, patterns ...string) ([]*packages.Package, error) {
 			result = append(result, pkg)
 			continue
 		}
-		// Syntax or load errors are reported and packages skipped.
+		// Syntax or load errors on the root package are reported and it is skipped.
 		for _, e := range pkg.Errors {
 			loadErrs = append(loadErrs, e.Error())
 		}
@@ -69,4 +74,23 @@ func Load(dir string, patterns ...string) ([]*packages.Package, error) {
 		return result, fmt.Errorf("packages with errors were skipped: %s", strings.Join(loadErrs, "; "))
 	}
 	return result, nil
+}
+
+// firstNonTypeErrorInDeps traverses the transitive import graph of pkg
+// (excluding pkg itself) and returns the first non-TypeError error string
+// found in any dependency. An empty string means all deps are clean.
+func firstNonTypeErrorInDeps(root *packages.Package) string {
+	var found string
+	packages.Visit([]*packages.Package{root}, nil, func(dep *packages.Package) {
+		if found != "" || dep == root {
+			return
+		}
+		for _, e := range dep.Errors {
+			if e.Kind != packages.TypeError {
+				found = fmt.Sprintf("dependency %s: %s", dep.PkgPath, e.Error())
+				return
+			}
+		}
+	})
+	return found
 }

--- a/analyzer/loader.go
+++ b/analyzer/loader.go
@@ -77,10 +77,18 @@ func Load(dir string, patterns ...string) ([]*packages.Package, error) {
 }
 
 // firstFatalErrorInDeps traverses the transitive import graph of pkg
-// (excluding pkg itself) and returns the first fatal error (ParseError or
-// ListError) found in any dependency. TypeError and UnknownError are
-// tolerated to avoid false positives from transient toolchain/export-data
-// issues. An empty string means all deps are clean.
+// (excluding pkg itself) and returns the first fatal error found in any
+// dependency. Any non-TypeError in a dep is treated as fatal:
+//   - ParseError / ListError are clearly fatal.
+//   - UnknownError is also treated as fatal because go/packages uses it for
+//     missing-or-unreadable export data and toolchain/source skew, which
+//     leave the root's TypesInfo incomplete. With NeedTypes|NeedTypesInfo|
+//     NeedDeps enabled, downstream rules consume TypesInfo and would silently
+//     misreport if we tolerated UnknownError here.
+//
+// Only TypeError in a dep is tolerated, mirroring the root-package policy:
+// rules can still inspect AST/imports meaningfully when a dep has a pure
+// type-check failure. An empty string means all deps are clean.
 func firstFatalErrorInDeps(root *packages.Package) string {
 	var found string
 	packages.Visit([]*packages.Package{root}, nil, func(dep *packages.Package) {
@@ -88,7 +96,7 @@ func firstFatalErrorInDeps(root *packages.Package) string {
 			return
 		}
 		for _, e := range dep.Errors {
-			if e.Kind == packages.ParseError || e.Kind == packages.ListError {
+			if e.Kind != packages.TypeError {
 				found = fmt.Sprintf("dependency %s: %s", dep.PkgPath, e.Error())
 				return
 			}

--- a/analyzer/loader_test.go
+++ b/analyzer/loader_test.go
@@ -52,4 +52,46 @@ func TestLoad(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("skips root package whose transitive dependency has a syntax error", func(t *testing.T) {
+		pkgs, err := analyzer.Load("../testdata/load_broken_dep_transitive", "internal/...")
+		if err == nil {
+			t.Fatal("expected error describing skipped packages with broken transitive dependencies")
+		}
+		// root -> middle -> broken: both root and middle must be skipped;
+		// the unrelated clean package must still be returned.
+		var sawClean bool
+		for _, pkg := range pkgs {
+			switch pkg.PkgPath {
+			case "github.com/kimtaeyun/testproject-load-broken-dep-transitive/internal/root":
+				t.Error("root (transitive broken dep) should have been skipped")
+			case "github.com/kimtaeyun/testproject-load-broken-dep-transitive/internal/middle":
+				t.Error("middle (direct broken dep) should have been skipped")
+			case "github.com/kimtaeyun/testproject-load-broken-dep-transitive/internal/clean":
+				sawClean = true
+			}
+		}
+		if !sawClean {
+			t.Error("expected unrelated clean package to still be loaded")
+		}
+	})
+
+	t.Run("skips root package whose dependency has a list error", func(t *testing.T) {
+		pkgs, err := analyzer.Load("../testdata/load_missing_dep", "internal/...")
+		if err == nil {
+			t.Fatal("expected error describing skipped packages with missing dependencies")
+		}
+		var sawClean bool
+		for _, pkg := range pkgs {
+			switch pkg.PkgPath {
+			case "github.com/kimtaeyun/testproject-load-missing-dep/internal/root":
+				t.Error("root (missing dep, ListError) should have been skipped")
+			case "github.com/kimtaeyun/testproject-load-missing-dep/internal/clean":
+				sawClean = true
+			}
+		}
+		if !sawClean {
+			t.Error("expected unrelated clean package to still be loaded")
+		}
+	})
 }

--- a/analyzer/loader_test.go
+++ b/analyzer/loader_test.go
@@ -39,4 +39,17 @@ func TestLoad(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("skips root package whose dependency has a syntax error", func(t *testing.T) {
+		pkgs, err := analyzer.Load("../testdata/load_broken_dep", "internal/...")
+		if err == nil {
+			t.Fatal("expected error describing skipped packages with broken dependencies")
+		}
+		// The root package imports a broken dep; it must not appear in results.
+		for _, pkg := range pkgs {
+			if pkg.PkgPath == "github.com/kimtaeyun/testproject-load-broken-dep/internal/root" {
+				t.Error("root package with broken dependency should have been skipped")
+			}
+		}
+	})
 }

--- a/testdata/load_broken_dep/go.mod
+++ b/testdata/load_broken_dep/go.mod
@@ -1,0 +1,3 @@
+module github.com/kimtaeyun/testproject-load-broken-dep
+
+go 1.25.0

--- a/testdata/load_broken_dep/internal/dep/broken.go
+++ b/testdata/load_broken_dep/internal/dep/broken.go
@@ -1,0 +1,3 @@
+package dep
+
+func Broken( {

--- a/testdata/load_broken_dep/internal/root/service.go
+++ b/testdata/load_broken_dep/internal/root/service.go
@@ -1,0 +1,7 @@
+package root
+
+import _ "github.com/kimtaeyun/testproject-load-broken-dep/internal/dep"
+
+func Valid() string {
+	return "ok"
+}

--- a/testdata/load_broken_dep_transitive/go.mod
+++ b/testdata/load_broken_dep_transitive/go.mod
@@ -1,0 +1,3 @@
+module github.com/kimtaeyun/testproject-load-broken-dep-transitive
+
+go 1.25.0

--- a/testdata/load_broken_dep_transitive/internal/broken/broken.go
+++ b/testdata/load_broken_dep_transitive/internal/broken/broken.go
@@ -1,0 +1,3 @@
+package broken
+
+func Broken( {

--- a/testdata/load_broken_dep_transitive/internal/clean/clean.go
+++ b/testdata/load_broken_dep_transitive/internal/clean/clean.go
@@ -1,0 +1,5 @@
+package clean
+
+func Clean() string {
+	return "clean"
+}

--- a/testdata/load_broken_dep_transitive/internal/middle/middle.go
+++ b/testdata/load_broken_dep_transitive/internal/middle/middle.go
@@ -1,0 +1,7 @@
+package middle
+
+import _ "github.com/kimtaeyun/testproject-load-broken-dep-transitive/internal/broken"
+
+func Middle() string {
+	return "middle"
+}

--- a/testdata/load_broken_dep_transitive/internal/root/root.go
+++ b/testdata/load_broken_dep_transitive/internal/root/root.go
@@ -1,0 +1,7 @@
+package root
+
+import _ "github.com/kimtaeyun/testproject-load-broken-dep-transitive/internal/middle"
+
+func Root() string {
+	return "root"
+}

--- a/testdata/load_missing_dep/go.mod
+++ b/testdata/load_missing_dep/go.mod
@@ -1,0 +1,3 @@
+module github.com/kimtaeyun/testproject-load-missing-dep
+
+go 1.25.0

--- a/testdata/load_missing_dep/internal/clean/clean.go
+++ b/testdata/load_missing_dep/internal/clean/clean.go
@@ -1,0 +1,5 @@
+package clean
+
+func Clean() string {
+	return "clean"
+}

--- a/testdata/load_missing_dep/internal/root/root.go
+++ b/testdata/load_missing_dep/internal/root/root.go
@@ -1,0 +1,7 @@
+package root
+
+import _ "github.com/kimtaeyun/testproject-load-missing-dep/internal/nonexistent"
+
+func Root() string {
+	return "root"
+}


### PR DESCRIPTION
Closes #14.

## Summary

- `loader.go` previously only checked errors on the root package itself; a root package with no local errors but a broken transitive dependency (parse/list error) was admitted silently, causing downstream rules to produce wrong results
- Added `firstNonTypeErrorInDeps` which uses `packages.Visit` to traverse the transitive import graph and surface the first non-TypeError in any dependency
- Root packages whose deps contain parse or list errors are now rejected and included in the skipped-packages error, just like root packages with their own syntax errors
- Type errors in dependencies are still tolerated (same policy as root packages)

## Test plan

- [x] New testdata fixture `testdata/load_broken_dep`: a root package that imports a dependency with a syntax error
- [x] New regression test `skips root package whose dependency has a syntax error` — confirmed failing before fix, passing after
- [x] Existing tests for `load_syntax_error` and `load_type_error` still pass unchanged
- [x] `go test ./... -count=1` — green
- [x] `make lint` — 0 issues