### PR TITLE
fix(rules): interface.exported-impl compares signatures, not names

### DIFF
--- a/rules/interface_pattern.go
+++ b/rules/interface_pattern.go
@@ -105,47 +105,62 @@ func checkSingleInterfacePerPackage(pkg *packages.Package, ifaces map[string]*as
 
 // checkExportedImpl detects exported structs that implement an exported interface
 // in the same package — the impl should be unexported.
-// It uses go/types.Implements for full signature comparison.
+//
+// For fully-typed packages it uses go/types.Implements so signatures are
+// compared properly. When the package is ill-typed (pkg.Types nil, or a
+// specific interface/struct type object cannot be recovered from scope), it
+// falls back to AST name-only matching. The fallback preserves the previous
+// behavior's false-positive surface — a looser but strictly better outcome
+// than silently dropping diagnostics during partially broken refactors.
 func checkExportedImpl(pkg *packages.Package, ifaces map[string]*ast.InterfaceType, cfg Config) []Violation {
-	if pkg.Types == nil {
+	structs := collectExportedStructs(pkg)
+	if len(structs) == 0 || len(ifaces) == 0 {
 		return nil
 	}
-	scope := pkg.Types.Scope()
 
-	// Build a map of interface name → *types.Interface for type-level comparison.
-	typedIfaces := make(map[string]*types.Interface, len(ifaces))
-	for name := range ifaces {
-		obj := scope.Lookup(name)
-		if obj == nil {
-			continue
-		}
-		named, ok := obj.Type().(*types.Named)
-		if !ok {
-			continue
-		}
-		iface, ok := named.Underlying().(*types.Interface)
-		if !ok || iface.NumMethods() == 0 {
-			continue
-		}
-		typedIfaces[name] = iface
+	var scope *types.Scope
+	if pkg.Types != nil {
+		scope = pkg.Types.Scope()
 	}
 
-	structs := collectExportedStructs(pkg)
+	// Resolve each interface to a *types.Interface when possible (treats
+	// type aliases via types.Unalias). Interfaces that cannot be resolved are
+	// left for the AST fallback.
+	typedIfaces := make(map[string]*types.Interface, len(ifaces))
+	if scope != nil {
+		for name := range ifaces {
+			if iface := lookupInterface(scope, name); iface != nil && iface.NumMethods() > 0 {
+				typedIfaces[name] = iface
+			}
+		}
+	}
 
 	var violations []Violation
 	for structName := range structs {
-		obj := scope.Lookup(structName)
-		if obj == nil {
-			continue
+		var named *types.Named
+		if scope != nil {
+			if obj := scope.Lookup(structName); obj != nil {
+				named, _ = types.Unalias(obj.Type()).(*types.Named)
+			}
 		}
-		named, ok := obj.Type().(*types.Named)
-		if !ok {
-			continue
-		}
-		// Check both value and pointer receivers.
-		ptrType := types.NewPointer(named)
-		for ifaceName, iface := range typedIfaces {
-			if types.Implements(named, iface) || types.Implements(ptrType, iface) {
+
+		for ifaceName, astIface := range ifaces {
+			matched := false
+			iface, ifaceOK := typedIfaces[ifaceName]
+			typedPathAvailable := named != nil && ifaceOK
+			if typedPathAvailable {
+				// Fully-typed path: signature-aware via types.Implements.
+				ptrType := types.NewPointer(named)
+				matched = types.Implements(named, iface) || types.Implements(ptrType, iface)
+			}
+			// Fallback to AST name-only match when:
+			//   - the type objects could not be recovered, or
+			//   - the package is ill-typed and the typed check said "no match"
+			//     (signatures may be unreliable when types are incomplete).
+			if !matched && (!typedPathAvailable || pkg.IllTyped) {
+				matched = structMatchesInterfaceByName(pkg, structName, astIface)
+			}
+			if matched {
 				violations = append(violations, Violation{
 					File:     relativePackageFile(pkg),
 					Rule:     "interface.exported-impl",
@@ -157,6 +172,40 @@ func checkExportedImpl(pkg *packages.Package, ifaces map[string]*ast.InterfaceTy
 		}
 	}
 	return violations
+}
+
+// lookupInterface resolves name in scope to a *types.Interface, unwrapping
+// type aliases. Returns nil when name is not an interface type.
+func lookupInterface(scope *types.Scope, name string) *types.Interface {
+	obj := scope.Lookup(name)
+	if obj == nil {
+		return nil
+	}
+	t := types.Unalias(obj.Type())
+	if iface, ok := t.Underlying().(*types.Interface); ok {
+		return iface
+	}
+	return nil
+}
+
+// structMatchesInterfaceByName returns true when every method name declared on
+// the interface has a corresponding method declared on structName in pkg's AST.
+// Signatures are not compared — used only as an ill-typed fallback.
+func structMatchesInterfaceByName(pkg *packages.Package, structName string, iface *ast.InterfaceType) bool {
+	if iface == nil || iface.Methods == nil || len(iface.Methods.List) == 0 {
+		return false
+	}
+	methods := collectMethods(pkg)
+	seen := false
+	for _, m := range iface.Methods.List {
+		for _, name := range m.Names {
+			seen = true
+			if !methods[structName+"."+name.Name] {
+				return false
+			}
+		}
+	}
+	return seen
 }
 
 // collectExportedStructs returns names of all exported struct types in a package.

--- a/rules/interface_pattern.go
+++ b/rules/interface_pattern.go
@@ -25,12 +25,18 @@ func CheckInterfacePattern(pkgs []*packages.Package, opts ...Option) []Violation
 		}
 
 		ifaces := collectExportedInterfacesFromPkg(pkg)
+
+		// checkExportedImpl also needs to see alias chains (AST-invisible),
+		// so let it examine the package even when the AST collector returned
+		// nothing — it performs its own types-based augmentation. Other
+		// checks only operate on AST-collected interfaces and can be skipped
+		// when there are none.
+		violations = append(violations, checkExportedImpl(pkg, ifaces, cfg)...)
 		if len(ifaces) == 0 {
 			continue
 		}
 
 		violations = append(violations, checkSingleInterfacePerPackage(pkg, ifaces, cfg)...)
-		violations = append(violations, checkExportedImpl(pkg, ifaces, cfg)...)
 		violations = append(violations, checkConstructorName(pkg, cfg)...)
 		violations = append(violations, checkConstructorReturnsInterface(pkg, ifaces, cfg)...)
 	}
@@ -107,14 +113,22 @@ func checkSingleInterfacePerPackage(pkg *packages.Package, ifaces map[string]*as
 // in the same package — the impl should be unexported.
 //
 // For fully-typed packages it uses go/types.Implements so signatures are
-// compared properly. When the package is ill-typed (pkg.Types nil, or a
-// specific interface/struct type object cannot be recovered from scope), it
-// falls back to AST name-only matching. The fallback preserves the previous
-// behavior's false-positive surface — a looser but strictly better outcome
-// than silently dropping diagnostics during partially broken refactors.
+// compared properly. The set of interfaces to check is the union of two
+// sources:
+//   - AST-collected direct interfaces (e.g. `type Store interface{...}` and
+//     `type Store = interface{...}`), and
+//   - types-resolved aliases whose resolved underlying type is `*types.Interface`
+//     (e.g. alias chains like `type Base = interface{...}; type Store = Base`).
+//
+// A fallback to AST name-only matching is used only when the type objects for
+// a given (struct, iface) pair cannot be recovered from scope. The fallback
+// preserves the previous behavior's false-positive surface for that narrow
+// case, but is strictly better than silently dropping diagnostics. A package
+// being IllTyped elsewhere does NOT gate the fallback — if both type objects
+// resolve cleanly, types.Implements is trusted.
 func checkExportedImpl(pkg *packages.Package, ifaces map[string]*ast.InterfaceType, cfg Config) []Violation {
 	structs := collectExportedStructs(pkg)
-	if len(structs) == 0 || len(ifaces) == 0 {
+	if len(structs) == 0 {
 		return nil
 	}
 
@@ -123,9 +137,7 @@ func checkExportedImpl(pkg *packages.Package, ifaces map[string]*ast.InterfaceTy
 		scope = pkg.Types.Scope()
 	}
 
-	// Resolve each interface to a *types.Interface when possible (treats
-	// type aliases via types.Unalias). Interfaces that cannot be resolved are
-	// left for the AST fallback.
+	// Resolve each AST-collected interface to a *types.Interface when possible.
 	typedIfaces := make(map[string]*types.Interface, len(ifaces))
 	if scope != nil {
 		for name := range ifaces {
@@ -133,6 +145,32 @@ func checkExportedImpl(pkg *packages.Package, ifaces map[string]*ast.InterfaceTy
 				typedIfaces[name] = iface
 			}
 		}
+	}
+
+	// Augment with exported alias chains whose resolved underlying is an
+	// interface but whose AST RHS is not an *ast.InterfaceType (so the
+	// AST-only collector missed them).
+	allIfaces := make(map[string]*ast.InterfaceType, len(ifaces))
+	for k, v := range ifaces {
+		allIfaces[k] = v
+	}
+	if scope != nil {
+		for _, name := range scope.Names() {
+			if _, seen := allIfaces[name]; seen {
+				continue
+			}
+			if !ast.IsExported(name) {
+				continue
+			}
+			if iface := lookupInterface(scope, name); iface != nil && iface.NumMethods() > 0 {
+				allIfaces[name] = nil // no AST body available; typed path only
+				typedIfaces[name] = iface
+			}
+		}
+	}
+
+	if len(allIfaces) == 0 {
+		return nil
 	}
 
 	var violations []Violation
@@ -144,20 +182,20 @@ func checkExportedImpl(pkg *packages.Package, ifaces map[string]*ast.InterfaceTy
 			}
 		}
 
-		for ifaceName, astIface := range ifaces {
-			matched := false
+		for ifaceName, astIface := range allIfaces {
 			iface, ifaceOK := typedIfaces[ifaceName]
 			typedPathAvailable := named != nil && ifaceOK
+
+			matched := false
 			if typedPathAvailable {
-				// Fully-typed path: signature-aware via types.Implements.
+				// Fully-typed path: signature-aware. Trust the result even if
+				// the package is IllTyped elsewhere.
 				ptrType := types.NewPointer(named)
 				matched = types.Implements(named, iface) || types.Implements(ptrType, iface)
-			}
-			// Fallback to AST name-only match when:
-			//   - the type objects could not be recovered, or
-			//   - the package is ill-typed and the typed check said "no match"
-			//     (signatures may be unreliable when types are incomplete).
-			if !matched && (!typedPathAvailable || pkg.IllTyped) {
+			} else {
+				// Fall back to AST name-only matching when either the struct
+				// or the interface cannot be recovered as a typed object.
+				// Requires an AST body to compare against.
 				matched = structMatchesInterfaceByName(pkg, structName, astIface)
 			}
 			if matched {
@@ -175,7 +213,8 @@ func checkExportedImpl(pkg *packages.Package, ifaces map[string]*ast.InterfaceTy
 }
 
 // lookupInterface resolves name in scope to a *types.Interface, unwrapping
-// type aliases. Returns nil when name is not an interface type.
+// type aliases (including alias chains). Returns nil when name is not an
+// interface type.
 func lookupInterface(scope *types.Scope, name string) *types.Interface {
 	obj := scope.Lookup(name)
 	if obj == nil {

--- a/rules/interface_pattern.go
+++ b/rules/interface_pattern.go
@@ -24,14 +24,11 @@ func CheckInterfacePattern(pkgs []*packages.Package, opts ...Option) []Violation
 			continue
 		}
 
-		ifaces := collectExportedInterfacesFromPkg(pkg)
+		// checkExportedImpl is scope-driven (covers alias chains) and is
+		// independent of AST-collected interfaces.
+		violations = append(violations, checkExportedImpl(pkg, cfg)...)
 
-		// checkExportedImpl also needs to see alias chains (AST-invisible),
-		// so let it examine the package even when the AST collector returned
-		// nothing — it performs its own types-based augmentation. Other
-		// checks only operate on AST-collected interfaces and can be skipped
-		// when there are none.
-		violations = append(violations, checkExportedImpl(pkg, ifaces, cfg)...)
+		ifaces := collectExportedInterfacesFromPkg(pkg)
 		if len(ifaces) == 0 {
 			continue
 		}
@@ -109,96 +106,54 @@ func checkSingleInterfacePerPackage(pkg *packages.Package, ifaces map[string]*as
 	}}
 }
 
-// checkExportedImpl detects exported structs that implement an exported interface
-// in the same package — the impl should be unexported.
+// checkExportedImpl detects exported struct types that implement exported
+// interfaces. Uses go/types.Implements; silently skips pairs where either
+// type object cannot be recovered (e.g. IllTyped packages with missing
+// type info). This is intentional — name-only comparison was the bug we
+// were fixing in #17, and running an architecture rule on broken code
+// produces low-signal noise regardless.
 //
-// For fully-typed packages it uses go/types.Implements so signatures are
-// compared properly. The set of interfaces to check is the union of two
-// sources:
-//   - AST-collected direct interfaces (e.g. `type Store interface{...}` and
-//     `type Store = interface{...}`), and
-//   - types-resolved aliases whose resolved underlying type is `*types.Interface`
-//     (e.g. alias chains like `type Base = interface{...}; type Store = Base`).
-//
-// A fallback to AST name-only matching is used only when the type objects for
-// a given (struct, iface) pair cannot be recovered from scope. The fallback
-// preserves the previous behavior's false-positive surface for that narrow
-// case, but is strictly better than silently dropping diagnostics. A package
-// being IllTyped elsewhere does NOT gate the fallback — if both type objects
-// resolve cleanly, types.Implements is trusted.
-func checkExportedImpl(pkg *packages.Package, ifaces map[string]*ast.InterfaceType, cfg Config) []Violation {
+// The set of interfaces considered is scope-driven: any exported name in
+// pkg.Types.Scope() whose unaliased underlying type is *types.Interface.
+// This covers direct definitions, direct aliases, and alias chains.
+func checkExportedImpl(pkg *packages.Package, cfg Config) []Violation {
+	if pkg.Types == nil {
+		return nil
+	}
 	structs := collectExportedStructs(pkg)
 	if len(structs) == 0 {
 		return nil
 	}
+	scope := pkg.Types.Scope()
 
-	var scope *types.Scope
-	if pkg.Types != nil {
-		scope = pkg.Types.Scope()
-	}
-
-	// Resolve each AST-collected interface to a *types.Interface when possible.
-	typedIfaces := make(map[string]*types.Interface, len(ifaces))
-	if scope != nil {
-		for name := range ifaces {
-			if iface := lookupInterface(scope, name); iface != nil && iface.NumMethods() > 0 {
-				typedIfaces[name] = iface
-			}
+	// Collect exported interfaces from scope (covers alias chains too).
+	typedIfaces := make(map[string]*types.Interface)
+	for _, name := range scope.Names() {
+		if !ast.IsExported(name) {
+			continue
+		}
+		if iface := lookupInterface(scope, name); iface != nil && iface.NumMethods() > 0 {
+			typedIfaces[name] = iface
 		}
 	}
-
-	// Augment with exported alias chains whose resolved underlying is an
-	// interface but whose AST RHS is not an *ast.InterfaceType (so the
-	// AST-only collector missed them).
-	allIfaces := make(map[string]*ast.InterfaceType, len(ifaces))
-	for k, v := range ifaces {
-		allIfaces[k] = v
-	}
-	if scope != nil {
-		for _, name := range scope.Names() {
-			if _, seen := allIfaces[name]; seen {
-				continue
-			}
-			if !ast.IsExported(name) {
-				continue
-			}
-			if iface := lookupInterface(scope, name); iface != nil && iface.NumMethods() > 0 {
-				allIfaces[name] = nil // no AST body available; typed path only
-				typedIfaces[name] = iface
-			}
-		}
-	}
-
-	if len(allIfaces) == 0 {
+	if len(typedIfaces) == 0 {
 		return nil
 	}
 
 	var violations []Violation
 	for structName := range structs {
-		var named *types.Named
-		if scope != nil {
-			if obj := scope.Lookup(structName); obj != nil {
-				named, _ = types.Unalias(obj.Type()).(*types.Named)
-			}
+		obj := scope.Lookup(structName)
+		if obj == nil {
+			continue
 		}
+		named, ok := types.Unalias(obj.Type()).(*types.Named)
+		if !ok {
+			continue
+		}
+		ptrType := types.NewPointer(named)
 
-		for ifaceName, astIface := range allIfaces {
-			iface, ifaceOK := typedIfaces[ifaceName]
-			typedPathAvailable := named != nil && ifaceOK
-
-			matched := false
-			if typedPathAvailable {
-				// Fully-typed path: signature-aware. Trust the result even if
-				// the package is IllTyped elsewhere.
-				ptrType := types.NewPointer(named)
-				matched = types.Implements(named, iface) || types.Implements(ptrType, iface)
-			} else {
-				// Fall back to AST name-only matching when either the struct
-				// or the interface cannot be recovered as a typed object.
-				// Requires an AST body to compare against.
-				matched = structMatchesInterfaceByName(pkg, structName, astIface)
-			}
-			if matched {
+		for ifaceName, iface := range typedIfaces {
+			if types.Implements(named, iface) || types.Implements(ptrType, iface) {
 				violations = append(violations, Violation{
 					File:     relativePackageFile(pkg),
 					Rule:     "interface.exported-impl",
@@ -225,26 +180,6 @@ func lookupInterface(scope *types.Scope, name string) *types.Interface {
 		return iface
 	}
 	return nil
-}
-
-// structMatchesInterfaceByName returns true when every method name declared on
-// the interface has a corresponding method declared on structName in pkg's AST.
-// Signatures are not compared — used only as an ill-typed fallback.
-func structMatchesInterfaceByName(pkg *packages.Package, structName string, iface *ast.InterfaceType) bool {
-	if iface == nil || iface.Methods == nil || len(iface.Methods.List) == 0 {
-		return false
-	}
-	methods := collectMethods(pkg)
-	seen := false
-	for _, m := range iface.Methods.List {
-		for _, name := range m.Names {
-			seen = true
-			if !methods[structName+"."+name.Name] {
-				return false
-			}
-		}
-	}
-	return seen
 }
 
 // collectExportedStructs returns names of all exported struct types in a package.

--- a/rules/interface_pattern.go
+++ b/rules/interface_pattern.go
@@ -3,6 +3,7 @@ package rules
 import (
 	"fmt"
 	"go/ast"
+	"go/types"
 	"sort"
 	"strings"
 
@@ -82,20 +83,6 @@ func isExcludedInterfacePatternPkg(m Model, pkg *packages.Package) bool {
 	return false
 }
 
-// interfaceMethodNames extracts method names from an interface type.
-func interfaceMethodNames(iface *ast.InterfaceType) map[string]bool {
-	methods := make(map[string]bool)
-	if iface.Methods == nil {
-		return methods
-	}
-	for _, m := range iface.Methods.List {
-		for _, name := range m.Names {
-			methods[name.Name] = true
-		}
-	}
-	return methods
-}
-
 // checkSingleInterfacePerPackage warns when a package declares more than one
 // exported interface.
 func checkSingleInterfacePerPackage(pkg *packages.Package, ifaces map[string]*ast.InterfaceType, cfg Config) []Violation {
@@ -118,25 +105,47 @@ func checkSingleInterfacePerPackage(pkg *packages.Package, ifaces map[string]*as
 
 // checkExportedImpl detects exported structs that implement an exported interface
 // in the same package — the impl should be unexported.
+// It uses go/types.Implements for full signature comparison.
 func checkExportedImpl(pkg *packages.Package, ifaces map[string]*ast.InterfaceType, cfg Config) []Violation {
-	methods := collectMethods(pkg)
+	if pkg.Types == nil {
+		return nil
+	}
+	scope := pkg.Types.Scope()
+
+	// Build a map of interface name → *types.Interface for type-level comparison.
+	typedIfaces := make(map[string]*types.Interface, len(ifaces))
+	for name := range ifaces {
+		obj := scope.Lookup(name)
+		if obj == nil {
+			continue
+		}
+		named, ok := obj.Type().(*types.Named)
+		if !ok {
+			continue
+		}
+		iface, ok := named.Underlying().(*types.Interface)
+		if !ok || iface.NumMethods() == 0 {
+			continue
+		}
+		typedIfaces[name] = iface
+	}
+
 	structs := collectExportedStructs(pkg)
 
 	var violations []Violation
 	for structName := range structs {
-		for ifaceName, iface := range ifaces {
-			ifaceMethods := interfaceMethodNames(iface)
-			if len(ifaceMethods) == 0 {
-				continue
-			}
-			allMatch := true
-			for mName := range ifaceMethods {
-				if !methods[structName+"."+mName] {
-					allMatch = false
-					break
-				}
-			}
-			if allMatch {
+		obj := scope.Lookup(structName)
+		if obj == nil {
+			continue
+		}
+		named, ok := obj.Type().(*types.Named)
+		if !ok {
+			continue
+		}
+		// Check both value and pointer receivers.
+		ptrType := types.NewPointer(named)
+		for ifaceName, iface := range typedIfaces {
+			if types.Implements(named, iface) || types.Implements(ptrType, iface) {
 				violations = append(violations, Violation{
 					File:     relativePackageFile(pkg),
 					Rule:     "interface.exported-impl",

--- a/rules/interface_pattern_test.go
+++ b/rules/interface_pattern_test.go
@@ -412,8 +412,9 @@ func (s *StoreImpl) Get(id string) string { return "" }
 // TestCheckInterfacePattern_ExportedImpl_IllTypedSignatureMismatch verifies
 // that when a package is IllTyped due to an UNRELATED error but both the
 // interface and struct type objects resolve cleanly, the rule trusts
-// types.Implements and does NOT fall back to name-only. A struct with a
-// matching method name but different signature must not be flagged.
+// types.Implements. A struct with a matching method name but different
+// signature must not be flagged — this is the exact false-positive #17
+// was filed against.
 func TestCheckInterfacePattern_ExportedImpl_IllTypedSignatureMismatch(t *testing.T) {
 	root := t.TempDir()
 	module := "example.com/ip-illtyped-sig-mismatch"

--- a/rules/interface_pattern_test.go
+++ b/rules/interface_pattern_test.go
@@ -327,6 +327,87 @@ func (s *StoreImpl) Find(id string) string { return "" }
 	}
 }
 
+// TestCheckInterfacePattern_ExportedImpl_AliasInterface verifies that an
+// exported alias of an anonymous interface is still treated as an interface,
+// so an exported struct implementing it is flagged. Regression for the
+// Go 1.26 *types.Alias case that was silently skipped.
+func TestCheckInterfacePattern_ExportedImpl_AliasInterface(t *testing.T) {
+	root := t.TempDir()
+	module := "example.com/ip-alias-iface"
+
+	writeTestFile(t, filepath.Join(root, "go.mod"), "module "+module+"\n\ngo 1.21\n")
+
+	writeTestFile(t, filepath.Join(root, "internal", "store", "store.go"),
+		`package store
+
+type Store = interface {
+	Get(id string) string
+}
+
+type StoreImpl struct{}
+
+func (s *StoreImpl) Get(id string) string { return "" }
+`)
+
+	pkgs := loadTestPackages(t, root)
+	vs := rules.CheckInterfacePattern(pkgs, rules.WithModel(rules.ConsumerWorker()))
+
+	found := false
+	for _, v := range vs {
+		if v.Rule == "interface.exported-impl" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected interface.exported-impl violation for alias-based interface")
+	}
+}
+
+// TestCheckInterfacePattern_ExportedImpl_IllTyped verifies that when a package
+// has unrelated type errors (pkg.Types missing or objects unresolvable), the
+// rule still reports via the AST name-based fallback instead of silently
+// dropping coverage.
+func TestCheckInterfacePattern_ExportedImpl_IllTyped(t *testing.T) {
+	root := t.TempDir()
+	module := "example.com/ip-illtyped"
+
+	writeTestFile(t, filepath.Join(root, "go.mod"), "module "+module+"\n\ngo 1.21\n")
+
+	// Exported struct implements the interface (same name + signature), but the
+	// file also contains an unrelated type error so the package is IllTyped.
+	// The fallback must still emit interface.exported-impl.
+	// The method receiver references an undefined parameter type, so the
+	// *types.Named for DBStore lacks a usable Get method and types.Implements
+	// returns false. But AST inspection still shows method name Get matching.
+	// The fallback must emit the violation.
+	writeTestFile(t, filepath.Join(root, "internal", "store", "store.go"),
+		`package store
+
+type Store interface {
+	Get(id string) string
+}
+
+type DBStore struct{}
+
+func (s *DBStore) Get(id UndefinedType) string { return "" }
+`)
+
+	pkgs := loadTestPackages(t, root)
+	vs := rules.CheckInterfacePattern(pkgs, rules.WithModel(rules.ConsumerWorker()))
+
+	found := false
+	for _, v := range vs {
+		if v.Rule == "interface.exported-impl" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected interface.exported-impl violation in ill-typed package (via AST fallback)")
+	}
+}
+
 func TestCheckInterfacePattern_ConstructorReturnsInterfaceValid(t *testing.T) {
 	root := t.TempDir()
 	module := "example.com/ip-ctor-iface-valid"

--- a/rules/interface_pattern_test.go
+++ b/rules/interface_pattern_test.go
@@ -260,6 +260,73 @@ type Store interface {
 	}
 }
 
+// TestCheckInterfacePattern_ExportedImpl_SignatureMismatch verifies that a struct
+// with a method whose name matches an interface method but whose signature differs
+// is NOT flagged as implementing the interface.
+func TestCheckInterfacePattern_ExportedImpl_SignatureMismatch(t *testing.T) {
+	root := t.TempDir()
+	module := "example.com/ip-sig-mismatch"
+
+	writeTestFile(t, filepath.Join(root, "go.mod"), "module "+module+"\n\ngo 1.21\n")
+
+	// StoreImpl.Find has different parameter types than Store.Find — not an impl.
+	writeTestFile(t, filepath.Join(root, "internal", "store", "store.go"),
+		`package store
+
+type Store interface {
+	Find(id string) string
+}
+
+type StoreImpl struct{}
+
+func (s *StoreImpl) Find(limit, offset int) []string { return nil }
+`)
+
+	pkgs := loadTestPackages(t, root)
+	vs := rules.CheckInterfacePattern(pkgs, rules.WithModel(rules.ConsumerWorker()))
+
+	for _, v := range vs {
+		if v.Rule == "interface.exported-impl" {
+			t.Errorf("unexpected interface.exported-impl violation when signatures do not match: %s", v.String())
+		}
+	}
+}
+
+// TestCheckInterfacePattern_ExportedImpl_SignatureMatch verifies that a struct
+// whose method names AND signatures match the interface is still flagged.
+func TestCheckInterfacePattern_ExportedImpl_SignatureMatch(t *testing.T) {
+	root := t.TempDir()
+	module := "example.com/ip-sig-match"
+
+	writeTestFile(t, filepath.Join(root, "go.mod"), "module "+module+"\n\ngo 1.21\n")
+
+	writeTestFile(t, filepath.Join(root, "internal", "store", "store.go"),
+		`package store
+
+type Store interface {
+	Find(id string) string
+}
+
+type StoreImpl struct{}
+
+func (s *StoreImpl) Find(id string) string { return "" }
+`)
+
+	pkgs := loadTestPackages(t, root)
+	vs := rules.CheckInterfacePattern(pkgs, rules.WithModel(rules.ConsumerWorker()))
+
+	found := false
+	for _, v := range vs {
+		if v.Rule == "interface.exported-impl" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected interface.exported-impl violation when signatures match")
+	}
+}
+
 func TestCheckInterfacePattern_ConstructorReturnsInterfaceValid(t *testing.T) {
 	root := t.TempDir()
 	module := "example.com/ip-ctor-iface-valid"

--- a/rules/interface_pattern_test.go
+++ b/rules/interface_pattern_test.go
@@ -2,6 +2,7 @@ package rules_test
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/NamhaeSusan/go-arch-guard/rules"
@@ -364,33 +365,29 @@ func (s *StoreImpl) Get(id string) string { return "" }
 	}
 }
 
-// TestCheckInterfacePattern_ExportedImpl_IllTyped verifies that when a package
-// has unrelated type errors (pkg.Types missing or objects unresolvable), the
-// rule still reports via the AST name-based fallback instead of silently
-// dropping coverage.
-func TestCheckInterfacePattern_ExportedImpl_IllTyped(t *testing.T) {
+// TestCheckInterfacePattern_ExportedImpl_AliasChain verifies that an alias
+// chain whose AST RHS is an Ident (not an InterfaceType) is resolved via
+// go/types. Only `Store` is exported here — the interface lives in an
+// unexported `baseStore` — so the AST-only collector cannot see any exported
+// interface in this file. Without the fix, Store would be silently dropped.
+func TestCheckInterfacePattern_ExportedImpl_AliasChain(t *testing.T) {
 	root := t.TempDir()
-	module := "example.com/ip-illtyped"
+	module := "example.com/ip-alias-chain"
 
 	writeTestFile(t, filepath.Join(root, "go.mod"), "module "+module+"\n\ngo 1.21\n")
 
-	// Exported struct implements the interface (same name + signature), but the
-	// file also contains an unrelated type error so the package is IllTyped.
-	// The fallback must still emit interface.exported-impl.
-	// The method receiver references an undefined parameter type, so the
-	// *types.Named for DBStore lacks a usable Get method and types.Implements
-	// returns false. But AST inspection still shows method name Get matching.
-	// The fallback must emit the violation.
 	writeTestFile(t, filepath.Join(root, "internal", "store", "store.go"),
 		`package store
 
-type Store interface {
+type baseStore = interface {
 	Get(id string) string
 }
 
-type DBStore struct{}
+type Store = baseStore
 
-func (s *DBStore) Get(id UndefinedType) string { return "" }
+type StoreImpl struct{}
+
+func (s *StoreImpl) Get(id string) string { return "" }
 `)
 
 	pkgs := loadTestPackages(t, root)
@@ -399,12 +396,58 @@ func (s *DBStore) Get(id UndefinedType) string { return "" }
 	found := false
 	for _, v := range vs {
 		if v.Rule == "interface.exported-impl" {
-			found = true
-			break
+			// Must be reported against the EXPORTED Store, not the unexported
+			// intermediate baseStore.
+			if strings.Contains(v.Message, `interface "Store"`) {
+				found = true
+				break
+			}
 		}
 	}
 	if !found {
-		t.Error("expected interface.exported-impl violation in ill-typed package (via AST fallback)")
+		t.Error(`expected interface.exported-impl violation against exported alias-chain interface "Store"`)
+	}
+}
+
+// TestCheckInterfacePattern_ExportedImpl_IllTypedSignatureMismatch verifies
+// that when a package is IllTyped due to an UNRELATED error but both the
+// interface and struct type objects resolve cleanly, the rule trusts
+// types.Implements and does NOT fall back to name-only. A struct with a
+// matching method name but different signature must not be flagged.
+func TestCheckInterfacePattern_ExportedImpl_IllTypedSignatureMismatch(t *testing.T) {
+	root := t.TempDir()
+	module := "example.com/ip-illtyped-sig-mismatch"
+
+	writeTestFile(t, filepath.Join(root, "go.mod"), "module "+module+"\n\ngo 1.21\n")
+
+	// Store and StoreImpl resolve cleanly. An unrelated type error in the
+	// same package (undefined identifier used as a type) marks the package
+	// IllTyped. StoreImpl.Find has a different signature than Store.Find —
+	// types.Implements returns false and must be trusted.
+	writeTestFile(t, filepath.Join(root, "internal", "store", "store.go"),
+		`package store
+
+type Store interface {
+	Find(id string) string
+}
+
+type StoreImpl struct{}
+
+func (s *StoreImpl) Find(limit, offset int) []string { return nil }
+
+// Unrelated error: undefined identifier as a type.
+type Broken struct {
+	X UndefinedType
+}
+`)
+
+	pkgs := loadTestPackages(t, root)
+	vs := rules.CheckInterfacePattern(pkgs, rules.WithModel(rules.ConsumerWorker()))
+
+	for _, v := range vs {
+		if v.Rule == "interface.exported-impl" {
+			t.Errorf("unexpected interface.exported-impl violation in ill-typed package with signature mismatch: %s", v.String())
+		}
 	}
 }
 


### PR DESCRIPTION
Closes #17.

## Summary

- `checkExportedImpl` previously used name-only matching via `collectMethods` (a `TypeName.MethodName` string set), which flagged a struct as implementing an interface whenever their method **names** overlapped, ignoring parameter and return types entirely.
- Replaced with `go/types.Implements` which performs full signature comparison. Both value and pointer receiver variants are checked.
- Removed the now-unused `interfaceMethodNames` helper.

## Test plan

- [ ] `TestCheckInterfacePattern_ExportedImpl_SignatureMismatch` — matching method name, different signature → no violation (regression for #17)
- [ ] `TestCheckInterfacePattern_ExportedImpl_SignatureMatch` — matching name AND signature → violation still emitted (preserves existing behavior)
- [ ] All existing `TestCheckInterfacePattern_*` tests unchanged and passing
- [ ] `go test ./... -count=1` — green
- [ ] `make lint` — 0 issues