### PR TITLE
fix(rules): unknown nested sublayers + blast IQR=0 edge case

### DIFF
--- a/rules/blast.go
+++ b/rules/blast.go
@@ -113,12 +113,25 @@ func AnalyzeBlastRadius(pkgs []*packages.Package, projectModule string, projectR
 	q1 := percentile(tdValues, 25)
 	q3 := percentile(tdValues, 75)
 	iqr := q3 - q1
+
+	const iqrZeroFloor = 3 // minimum transitive dependents to flag when IQR=0
+
+	var threshold float64
 	if iqr == 0 {
-		return nil
-	}
-	threshold := q3 + 1.5*iqr
-	if threshold < 2 {
-		threshold = 2
+		// All packages have the same td value. The IQR method can't detect
+		// outliers, but a single package with a much higher count is still a
+		// hotspot. Fall back: emit for the max value only if it strictly exceeds
+		// q3 and meets the floor.
+		max := float64(tdValues[len(tdValues)-1])
+		if max <= q3 || max < iqrZeroFloor {
+			return nil
+		}
+		threshold = q3 // anything > q3 (i.e. == max) is the outlier
+	} else {
+		threshold = q3 + 1.5*iqr
+		if threshold < 2 {
+			threshold = 2
+		}
 	}
 
 	// 6. Emit violations

--- a/rules/blast_test.go
+++ b/rules/blast_test.go
@@ -1,6 +1,7 @@
 package rules_test
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -64,6 +65,43 @@ func TestAnalyzeBlastRadius_RespectsExclude(t *testing.T) {
 	for _, v := range violations {
 		if strings.Contains(v.File, "internal/pkg") {
 			t.Error("excluded package should not appear in violations")
+		}
+	}
+}
+
+// TestAnalyzeBlastRadius_IQRZeroSingleOutlier is a regression test for the bug where
+// iqr == 0 caused an early return nil, silently missing a single outlier package.
+func TestAnalyzeBlastRadius_IQRZeroSingleOutlier(t *testing.T) {
+	root := t.TempDir()
+	mod := "example.com/iqr-zero"
+
+	writeTestFile(t, filepath.Join(root, "go.mod"), "module "+mod+"\n\ngo 1.21\n")
+
+	// hub is imported by a, b, c, d — 4 transitive dependents; leaves have 0
+	writeTestFile(t, filepath.Join(root, "internal", "hub", "hub.go"),
+		"package hub\n\nfunc Hub() {}\n")
+	for _, leaf := range []string{"a", "b", "c", "d"} {
+		writeTestFile(t, filepath.Join(root, "internal", leaf, leaf+".go"),
+			"package "+leaf+"\n\nimport _ \""+mod+"/internal/hub\"\n")
+	}
+	// fifth leaf has no imports — leaf e is isolated
+	writeTestFile(t, filepath.Join(root, "internal", "e", "e.go"),
+		"package e\n\nfunc E() {}\n")
+
+	pkgs := loadTestPackages(t, root)
+	violations := rules.AnalyzeBlastRadius(pkgs, mod, root)
+
+	found := false
+	for _, v := range violations {
+		if v.Rule == "blast.high-coupling" && strings.Contains(v.File, "hub") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected blast.high-coupling violation for hub (IQR=0 single-outlier case)")
+		for _, v := range violations {
+			t.Log(v.String())
 		}
 	}
 }

--- a/rules/layer.go
+++ b/rules/layer.go
@@ -144,8 +144,29 @@ func identifySublayerWith(m Model, pkgPath, internalPrefix, domain string) strin
 		if slices.Contains(m.Sublayers, nested) {
 			return nested
 		}
+		// If parts[0] is a root sublayer that has known nested sublayers defined
+		// (e.g. "core" has "core/model", "core/repo"), then an unrecognised nested
+		// path like "core/extra" must surface as unknown rather than collapsing to
+		// the root "core". Sublayers without nested siblings (e.g. "handler",
+		// "infra") keep their old behaviour of ignoring subdirectories.
+		if hasNestedSublayers(m, parts[0]) {
+			return nested
+		}
 	}
 	return parts[0]
+}
+
+// hasNestedSublayers reports whether root has at least one known nested sublayer
+// defined (e.g. "core" has "core/model", "core/repo"). Sublayers that only
+// appear as a root entry (e.g. "handler", "infra") return false.
+func hasNestedSublayers(m Model, root string) bool {
+	prefix := root + "/"
+	for _, s := range m.Sublayers {
+		if strings.HasPrefix(s, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func identifyDomainWith(m Model, pkgPath, internalPrefix string) string {

--- a/rules/layer_test.go
+++ b/rules/layer_test.go
@@ -223,6 +223,42 @@ func TestCheckLayerDirection_FlatLayout_Violation(t *testing.T) {
 	}
 }
 
+// TestCheckLayerDirection_NestedUnknownSublayer is a regression test for the bug where
+// identifySublayerWith collapsed "core/extra" into "core", masking the unknown sublayer.
+func TestCheckLayerDirection_NestedUnknownSublayer(t *testing.T) {
+	root := t.TempDir()
+	mod := "example.com/nested-unknown"
+
+	writeTestFile(t, filepath.Join(root, "go.mod"),
+		"module "+mod+"\n\ngo 1.21\n")
+
+	// internal/domain/x/core/extra — "core/extra" is not a known sublayer in DDD()
+	writeTestFile(t, filepath.Join(root, "internal", "domain", "x", "core", "extra", "e.go"),
+		"package extra\n\ntype Extra struct{}\n")
+	// A legitimate package so the domain has more than just the unknown package
+	writeTestFile(t, filepath.Join(root, "internal", "domain", "x", "core", "model", "m.go"),
+		"package model\n\ntype Item struct{}\n")
+	writeTestFile(t, filepath.Join(root, "internal", "domain", "x", "app", "s.go"),
+		"package app\n\nimport _ \""+mod+"/internal/domain/x/core/model\"\n")
+
+	pkgs := loadTestPackages(t, root)
+	violations := rules.CheckLayerDirection(pkgs, mod, root)
+
+	found := false
+	for _, v := range violations {
+		if v.Rule == "layer.unknown-sublayer" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected layer.unknown-sublayer violation for internal/domain/x/core/extra")
+		for _, v := range violations {
+			t.Log(v.String())
+		}
+	}
+}
+
 func TestCheckLayerDirection_FlatLayout_PkgImport(t *testing.T) {
 	root := t.TempDir()
 	mod := "example.com/flat-pkg"


### PR DESCRIPTION
Closes #16.

## Summary

- **Bug 1 (`layer.go`)**: `identifySublayerWith` was collapsing `core/extra` into `core` when the nested path wasn't in `m.Sublayers`, silently treating it as the known `core` sublayer. Fix: introduce `hasNestedSublayers` helper — if a root sublayer has known nested siblings (e.g. `core` has `core/model`, `core/repo`, `core/svc`), an unrecognised nested path is returned as-is so the caller emits `layer.unknown-sublayer`. Sublayers with no nested siblings (e.g. `handler`, `infra`) keep the original collapse-to-root behaviour so `handler/http` and `infra/persistence` remain valid.
- **Bug 2 (`blast.go`)**: `AnalyzeBlastRadius` returned `nil` immediately when `iqr == 0`, missing distributions like `[0,0,0,0,10]`. Fix: when IQR=0, fall back to flagging the max value if it strictly exceeds `q3` and meets a floor of 3 transitive dependents.

## Test plan

- [ ] `TestCheckLayerDirection_NestedUnknownSublayer` — regression for `internal/domain/x/core/extra` emitting `layer.unknown-sublayer`
- [ ] `TestAnalyzeBlastRadius_IQRZeroSingleOutlier` — regression for hub package in `[0,0,0,0,4]` distribution emitting `blast.high-coupling`
- [ ] All existing tests pass unchanged
- [ ] `go test ./... -count=1` green
- [ ] `make lint` 0 issues