### PR TITLE
refactor(rules): unify internal-package classification; preset-aware naming suffixes

### DIFF
--- a/rules/classify.go
+++ b/rules/classify.go
@@ -1,6 +1,9 @@
 package rules
 
-import "strings"
+import (
+	"slices"
+	"strings"
+)
 
 type internalKind int
 
@@ -58,11 +61,8 @@ func classifyInternalPackage(m Model, pkgPath, internalPrefix string) classified
 	if parts[0] == "" {
 		return classified{Kind: kindUnclassified}
 	}
-	for _, sl := range m.Sublayers {
-		if sl == parts[0] {
-			return classified{Kind: kindDomain, Sublayer: parts[0]}
-		}
+	if slices.Contains(m.Sublayers, parts[0]) {
+		return classified{Kind: kindDomain, Sublayer: parts[0]}
 	}
-
 	return classified{Kind: kindUnclassified}
 }

--- a/rules/classify.go
+++ b/rules/classify.go
@@ -1,0 +1,68 @@
+package rules
+
+import "strings"
+
+type internalKind int
+
+const (
+	kindDomain internalKind = iota
+	kindOrchestration
+	kindShared
+	kindDomainRoot
+	kindCmd
+	kindUnclassified
+)
+
+type classified struct {
+	Kind     internalKind
+	Domain   string
+	Sublayer string
+	IsAlias  bool
+}
+
+// classifyInternalPackage classifies an internal package path into a single
+// canonical kind, domain, and sublayer. It is the single source of truth for
+// understanding where a package sits in the architecture.
+func classifyInternalPackage(m Model, pkgPath, internalPrefix string) classified {
+	if !strings.HasPrefix(pkgPath, internalPrefix) {
+		return classified{Kind: kindUnclassified}
+	}
+
+	// Shared/pkg check first
+	if m.SharedDir != "" && isUnderInternalDir(pkgPath, internalPrefix, m.SharedDir) {
+		return classified{Kind: kindShared}
+	}
+
+	// Orchestration check
+	if m.OrchestrationDir != "" && isUnderInternalDir(pkgPath, internalPrefix, m.OrchestrationDir) {
+		return classified{Kind: kindOrchestration}
+	}
+
+	// Domain-based layout
+	if m.DomainDir != "" {
+		domain := identifyDomainWith(m, pkgPath, internalPrefix)
+		if domain == "" {
+			return classified{Kind: kindUnclassified}
+		}
+		sub := identifySublayerWith(m, pkgPath, internalPrefix, domain)
+		if sub == "" {
+			// Domain root (alias package)
+			return classified{Kind: kindDomainRoot, Domain: domain, IsAlias: true}
+		}
+		return classified{Kind: kindDomain, Domain: domain, Sublayer: sub}
+	}
+
+	// Flat layout: check if it's a known sublayer
+	rel := strings.TrimPrefix(pkgPath, internalPrefix)
+	parts := strings.SplitN(rel, "/", 2)
+	if parts[0] == "" {
+		return classified{Kind: kindUnclassified}
+	}
+	for _, sl := range m.Sublayers {
+		if sl == parts[0] {
+			return classified{Kind: kindDomain, Sublayer: parts[0]}
+		}
+	}
+
+	return classified{Kind: kindUnclassified}
+}

--- a/rules/classify_integration_test.go
+++ b/rules/classify_integration_test.go
@@ -1,0 +1,158 @@
+package rules_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/NamhaeSusan/go-arch-guard/rules"
+)
+
+// These tests prove that CheckLayerDirection and CheckDomainIsolation
+// route through the unified classifier. Each scenario exercises a path
+// the classifier must handle (shared, orchestration, domain, domain-root,
+// unclassified).
+
+func TestCheckLayerDirection_Classifier_SharedSkipped(t *testing.T) {
+	root := t.TempDir()
+	mod := "example.com/cls-shared"
+
+	writeTestFile(t, filepath.Join(root, "go.mod"), "module "+mod+"\n\ngo 1.21\n")
+	// pkg/ is classified as kindShared: source of pkg/ is ignored by layer rule.
+	writeTestFile(t, filepath.Join(root, "internal", "pkg", "errors", "e.go"),
+		"package errors\n")
+	// Domain file that imports pkg/ — core is PkgRestricted, so inner-imports-pkg
+	// must still fire. This proves import side classification still reaches
+	// kindShared through the classifier.
+	writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "alias.go"),
+		"package order\n")
+	writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "core", "model", "m.go"),
+		"package model\n\nimport _ \""+mod+"/internal/pkg/errors\"\n")
+
+	pkgs := loadTestPackages(t, root)
+	violations := rules.CheckLayerDirection(pkgs, mod, root)
+
+	found := false
+	for _, v := range violations {
+		if v.Rule == "layer.inner-imports-pkg" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected layer.inner-imports-pkg for core/model importing pkg/errors")
+		for _, v := range violations {
+			t.Log(v.String())
+		}
+	}
+}
+
+func TestCheckLayerDirection_Classifier_UnclassifiedSrcIsSkipped(t *testing.T) {
+	root := t.TempDir()
+	mod := "example.com/cls-unclass"
+
+	writeTestFile(t, filepath.Join(root, "go.mod"), "module "+mod+"\n\ngo 1.21\n")
+	// internal/config is neither domain/, orchestration/, nor pkg/ — kindUnclassified.
+	// It imports a domain package. layer.go must skip unclassified sources.
+	writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "alias.go"),
+		"package order\n")
+	writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "core", "model", "m.go"),
+		"package model\n")
+	writeTestFile(t, filepath.Join(root, "internal", "config", "c.go"),
+		"package config\n\nimport _ \""+mod+"/internal/domain/order/core/model\"\n")
+
+	pkgs := loadTestPackages(t, root)
+	violations := rules.CheckLayerDirection(pkgs, mod, root)
+
+	for _, v := range violations {
+		if v.File == "internal/config/c.go" {
+			t.Errorf("unclassified source must be skipped by layer rule, got %s", v.String())
+		}
+	}
+}
+
+func TestCheckDomainIsolation_Classifier_StrayImportsDomain(t *testing.T) {
+	root := t.TempDir()
+	mod := "example.com/cls-iso-stray"
+
+	writeTestFile(t, filepath.Join(root, "go.mod"), "module "+mod+"\n\ngo 1.21\n")
+	writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "alias.go"),
+		"package order\n")
+	writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "core", "model", "m.go"),
+		"package model\n")
+	// internal/config is kindUnclassified; importing a domain must trip
+	// stray-imports-domain via the classifier.
+	writeTestFile(t, filepath.Join(root, "internal", "config", "c.go"),
+		"package config\n\nimport _ \""+mod+"/internal/domain/order/core/model\"\n")
+
+	pkgs := loadTestPackages(t, root)
+	violations := rules.CheckDomainIsolation(pkgs, mod, root)
+
+	found := false
+	for _, v := range violations {
+		if v.Rule == "isolation.stray-imports-domain" &&
+			strings.Contains(v.Message, "order") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected isolation.stray-imports-domain for config importing domain")
+		for _, v := range violations {
+			t.Log(v.String())
+		}
+	}
+}
+
+func TestCheckDomainIsolation_Classifier_OrchestrationDeepImport(t *testing.T) {
+	root := t.TempDir()
+	mod := "example.com/cls-iso-orch"
+
+	writeTestFile(t, filepath.Join(root, "go.mod"), "module "+mod+"\n\ngo 1.21\n")
+	writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "alias.go"),
+		"package order\n")
+	writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "core", "model", "m.go"),
+		"package model\n")
+	// orchestration/ importing a domain sub-package (not the alias) must fire
+	// orchestration-deep-import when RequireAlias is true (DDD default).
+	writeTestFile(t, filepath.Join(root, "internal", "orchestration", "o.go"),
+		"package orchestration\n\nimport _ \""+mod+"/internal/domain/order/core/model\"\n")
+
+	pkgs := loadTestPackages(t, root)
+	violations := rules.CheckDomainIsolation(pkgs, mod, root)
+
+	found := false
+	for _, v := range violations {
+		if v.Rule == "isolation.orchestration-deep-import" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected isolation.orchestration-deep-import via classifier")
+		for _, v := range violations {
+			t.Log(v.String())
+		}
+	}
+}
+
+func TestCheckDomainIsolation_Classifier_DomainRootAllowed(t *testing.T) {
+	root := t.TempDir()
+	mod := "example.com/cls-iso-root"
+
+	writeTestFile(t, filepath.Join(root, "go.mod"), "module "+mod+"\n\ngo 1.21\n")
+	// Domain root (alias.go) importing its own sublayer must be allowed —
+	// the classifier identifies it as kindDomainRoot with matching Domain.
+	writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "alias.go"),
+		"package order\n\nimport _ \""+mod+"/internal/domain/order/core/model\"\n")
+	writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "core", "model", "m.go"),
+		"package model\n")
+
+	pkgs := loadTestPackages(t, root)
+	violations := rules.CheckDomainIsolation(pkgs, mod, root)
+	for _, v := range violations {
+		if v.File == "internal/domain/order/alias.go" {
+			t.Errorf("domain root importing own sublayer must be allowed, got %s", v.String())
+		}
+	}
+}

--- a/rules/classify_test.go
+++ b/rules/classify_test.go
@@ -1,0 +1,165 @@
+package rules
+
+import "testing"
+
+func TestClassifyInternalPackage(t *testing.T) {
+	m := DDD()
+	internalPrefix := "example.com/myapp/internal/"
+
+	tests := []struct {
+		name     string
+		pkgPath  string
+		wantKind internalKind
+		wantDom  string
+		wantSub  string
+		wantAls  bool
+	}{
+		{
+			name:     "domain sublayer",
+			pkgPath:  "example.com/myapp/internal/domain/order/app",
+			wantKind: kindDomain,
+			wantDom:  "order",
+			wantSub:  "app",
+		},
+		{
+			name:     "domain root (alias package)",
+			pkgPath:  "example.com/myapp/internal/domain/order",
+			wantKind: kindDomainRoot,
+			wantDom:  "order",
+			wantSub:  "",
+			wantAls:  true,
+		},
+		{
+			name:     "orchestration package",
+			pkgPath:  "example.com/myapp/internal/orchestration",
+			wantKind: kindOrchestration,
+		},
+		{
+			name:     "orchestration sub-package",
+			pkgPath:  "example.com/myapp/internal/orchestration/handler",
+			wantKind: kindOrchestration,
+		},
+		{
+			name:     "shared/pkg package",
+			pkgPath:  "example.com/myapp/internal/pkg",
+			wantKind: kindShared,
+		},
+		{
+			name:     "shared sub-package",
+			pkgPath:  "example.com/myapp/internal/pkg/errors",
+			wantKind: kindShared,
+		},
+		{
+			name:     "unclassified package",
+			pkgPath:  "example.com/myapp/internal/unknown",
+			wantKind: kindUnclassified,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyInternalPackage(m, tc.pkgPath, internalPrefix)
+			if got.Kind != tc.wantKind {
+				t.Errorf("Kind = %v, want %v", got.Kind, tc.wantKind)
+			}
+			if got.Domain != tc.wantDom {
+				t.Errorf("Domain = %q, want %q", got.Domain, tc.wantDom)
+			}
+			if got.Sublayer != tc.wantSub {
+				t.Errorf("Sublayer = %q, want %q", got.Sublayer, tc.wantSub)
+			}
+			if got.IsAlias != tc.wantAls {
+				t.Errorf("IsAlias = %v, want %v", got.IsAlias, tc.wantAls)
+			}
+		})
+	}
+}
+
+func TestClassifyInternalPackage_FlatLayout(t *testing.T) {
+	m := ConsumerWorker()
+	internalPrefix := "example.com/myapp/internal/"
+
+	tests := []struct {
+		name     string
+		pkgPath  string
+		wantKind internalKind
+		wantSub  string
+	}{
+		{
+			name:     "worker layer",
+			pkgPath:  "example.com/myapp/internal/worker",
+			wantKind: kindDomain,
+			wantSub:  "worker",
+		},
+		{
+			name:     "service layer",
+			pkgPath:  "example.com/myapp/internal/service",
+			wantKind: kindDomain,
+			wantSub:  "service",
+		},
+		{
+			name:     "shared/pkg",
+			pkgPath:  "example.com/myapp/internal/pkg",
+			wantKind: kindShared,
+		},
+		{
+			name:     "unknown layer",
+			pkgPath:  "example.com/myapp/internal/mystery",
+			wantKind: kindUnclassified,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyInternalPackage(m, tc.pkgPath, internalPrefix)
+			if got.Kind != tc.wantKind {
+				t.Errorf("Kind = %v, want %v", got.Kind, tc.wantKind)
+			}
+			if got.Sublayer != tc.wantSub {
+				t.Errorf("Sublayer = %q, want %q", got.Sublayer, tc.wantSub)
+			}
+		})
+	}
+}
+
+func TestClassifyInternalPackage_EventPipeline(t *testing.T) {
+	m := EventPipeline()
+	internalPrefix := "example.com/myapp/internal/"
+
+	tests := []struct {
+		name     string
+		pkgPath  string
+		wantKind internalKind
+		wantSub  string
+	}{
+		{
+			name:     "command layer",
+			pkgPath:  "example.com/myapp/internal/command",
+			wantKind: kindDomain,
+			wantSub:  "command",
+		},
+		{
+			name:     "aggregate layer",
+			pkgPath:  "example.com/myapp/internal/aggregate",
+			wantKind: kindDomain,
+			wantSub:  "aggregate",
+		},
+		{
+			name:     "shared/pkg",
+			pkgPath:  "example.com/myapp/internal/pkg",
+			wantKind: kindShared,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyInternalPackage(m, tc.pkgPath, internalPrefix)
+			if got.Kind != tc.wantKind {
+				t.Errorf("Kind = %v, want %v", got.Kind, tc.wantKind)
+			}
+			if got.Sublayer != tc.wantSub {
+				t.Errorf("Sublayer = %q, want %q", got.Sublayer, tc.wantSub)
+			}
+		})
+	}
+}

--- a/rules/forbidden_call_engine.go
+++ b/rules/forbidden_call_engine.go
@@ -119,24 +119,14 @@ func checkForbiddenCallsByLayer(
 // using domain or flat identification depending on the model.
 // Returns "" if the package is not under any known layer.
 func layerOfPackage(m Model, pkgPath, internalPrefix string) string {
-	if !strings.HasPrefix(pkgPath, internalPrefix) {
+	c := classifyInternalPackage(m, pkgPath, internalPrefix)
+	if c.Kind != kindDomain {
 		return ""
 	}
-	if m.DomainDir != "" {
-		domain := identifyDomainWith(m, pkgPath, internalPrefix)
-		if domain == "" {
-			return ""
-		}
-		sub := identifySublayerWith(m, pkgPath, internalPrefix, domain)
-		if sub == "" {
-			return ""
-		}
-		if !slices.Contains(m.Sublayers, sub) {
-			return ""
-		}
-		return sub
+	if !slices.Contains(m.Sublayers, c.Sublayer) {
+		return ""
 	}
-	return identifyFlatSublayer(m, pkgPath, internalPrefix)
+	return c.Sublayer
 }
 
 // resolveCalleeID returns the fully-qualified identifier of a CallExpr's

--- a/rules/interface_container_test.go
+++ b/rules/interface_container_test.go
@@ -317,4 +317,3 @@ type holder struct {
 		t.Error("expected container-only violation")
 	}
 }
-

--- a/rules/isolation.go
+++ b/rules/isolation.go
@@ -40,11 +40,11 @@ func CheckDomainIsolation(pkgs []*packages.Package, projectModule string, projec
 				if !strings.HasPrefix(impPath, internalPrefix) {
 					continue
 				}
-				impDomain := identifyDomainWith(m, impPath, internalPrefix)
-				if impDomain == "" {
-					continue
-				}
-				if isDomainAliasWith(m, impPath, internalPrefix, impDomain) {
+				imp := classifyInternalPackage(m, impPath, internalPrefix)
+				// Only domain sub-packages (kindDomain) trigger cmd-deep-import.
+				// Domain root (alias) is allowed; shared/orchestration/unclassified
+				// are not domain imports and fall outside this rule.
+				if imp.Kind != kindDomain {
 					continue
 				}
 				file, line := findImportPosition(pkg, impPath, projectRoot)
@@ -53,7 +53,7 @@ func CheckDomainIsolation(pkgs []*packages.Package, projectModule string, projec
 					Line:     line,
 					Rule:     "isolation.cmd-deep-import",
 					Message:  fmt.Sprintf("cmd/ must only import domain alias, not sub-package %q", impPath),
-					Fix:      fmt.Sprintf("import the domain alias package instead: %s%s/%s", internalPrefix, m.DomainDir, impDomain),
+					Fix:      fmt.Sprintf("import the domain alias package instead: %s%s/%s", internalPrefix, m.DomainDir, imp.Domain),
 					Severity: cfg.Sev,
 				})
 			}
@@ -64,30 +64,35 @@ func CheckDomainIsolation(pkgs []*packages.Package, projectModule string, projec
 			continue
 		}
 
-		srcDomain := identifyDomainWith(m, pkg.PkgPath, internalPrefix)
-		srcIsOrchestration := isOrchestrationPkgWith(m, pkg.PkgPath, internalPrefix)
-		srcIsPkg := isPkgPkgWith(m, pkg.PkgPath, internalPrefix)
+		src := classifyInternalPackage(m, pkg.PkgPath, internalPrefix)
+		// kindUnclassified sources are packages under internal/ that don't fit
+		// any known bucket (domain/, orchestration/, shared/). They may still
+		// import domains/orchestration and must be checked as "stray" sources.
 
 		for impPath := range pkg.Imports {
 			if !strings.HasPrefix(impPath, internalPrefix) {
 				continue
 			}
 
-			impDomain := identifyDomainWith(m, impPath, internalPrefix)
+			imp := classifyInternalPackage(m, impPath, internalPrefix)
 
-			// Rule 2: import pkg/ → always allowed
-			if isPkgPkgWith(m, impPath, internalPrefix) {
+			// Rule 2: import pkg/ → always allowed for anyone except pkg/ itself
+			// (pkg/ → pkg/ is just intra-shared and still allowed).
+			if imp.Kind == kindShared && src.Kind != kindShared {
 				continue
 			}
 
-			// Rule 1: same domain → always allowed
-			if srcDomain != "" && impDomain == srcDomain {
+			// Rule 1: same domain → always allowed (kindDomain or kindDomainRoot
+			// in the same domain).
+			if (src.Kind == kindDomain || src.Kind == kindDomainRoot) &&
+				(imp.Kind == kindDomain || imp.Kind == kindDomainRoot) &&
+				src.Domain != "" && src.Domain == imp.Domain {
 				continue
 			}
 
-			// Orchestration rules
-			if srcIsOrchestration {
-				if impDomain == "" {
+			// Orchestration sources
+			if src.Kind == kindOrchestration {
+				if imp.Kind != kindDomain && imp.Kind != kindDomainRoot {
 					continue
 				}
 				// When alias is not required, orchestration may import
@@ -95,9 +100,10 @@ func CheckDomainIsolation(pkgs []*packages.Package, projectModule string, projec
 				if !m.RequireAlias {
 					continue
 				}
-				if isDomainAliasWith(m, impPath, internalPrefix, impDomain) {
+				if imp.Kind == kindDomainRoot {
 					continue
 				}
+				// imp is a domain sub-package (kindDomain) and alias is required.
 				label := m.OrchestrationDir
 				if isOrchestrationHandlerWith(m, pkg.PkgPath, internalPrefix) {
 					label = m.OrchestrationDir + " handler"
@@ -108,27 +114,27 @@ func CheckDomainIsolation(pkgs []*packages.Package, projectModule string, projec
 					Line:     line,
 					Rule:     "isolation.orchestration-deep-import",
 					Message:  fmt.Sprintf("%s must only import domain alias, not sub-package %q", label, impPath),
-					Fix:      fmt.Sprintf("import the domain alias package instead: %s%s/%s", internalPrefix, m.DomainDir, impDomain),
+					Fix:      fmt.Sprintf("import the domain alias package instead: %s%s/%s", internalPrefix, m.DomainDir, imp.Domain),
 					Severity: cfg.Sev,
 				})
 				continue
 			}
 
 			// pkg/ must stay domain-unaware and orchestration-unaware
-			if srcIsPkg {
-				if impDomain != "" {
+			if src.Kind == kindShared {
+				if imp.Kind == kindDomain || imp.Kind == kindDomainRoot {
 					file, line := findImportPosition(pkg, impPath, projectRoot)
 					violations = append(violations, Violation{
 						File:     file,
 						Line:     line,
 						Rule:     "isolation.pkg-imports-domain",
-						Message:  fmt.Sprintf("%s/ must not import domain %q", m.SharedDir, impDomain),
+						Message:  fmt.Sprintf("%s/ must not import domain %q", m.SharedDir, imp.Domain),
 						Fix:      fmt.Sprintf("%s/ should only contain shared utilities with no domain or orchestration dependencies", m.SharedDir),
 						Severity: cfg.Sev,
 					})
 					continue
 				}
-				if isOrchestrationPkgWith(m, impPath, internalPrefix) {
+				if imp.Kind == kindOrchestration {
 					file, line := findImportPosition(pkg, impPath, projectRoot)
 					violations = append(violations, Violation{
 						File:     file,
@@ -142,14 +148,14 @@ func CheckDomainIsolation(pkgs []*packages.Package, projectModule string, projec
 				}
 			}
 
-			if isOrchestrationPkgWith(m, impPath, internalPrefix) {
-				if srcDomain != "" {
+			if imp.Kind == kindOrchestration {
+				if src.Kind == kindDomain || src.Kind == kindDomainRoot {
 					file, line := findImportPosition(pkg, impPath, projectRoot)
 					violations = append(violations, Violation{
 						File:     file,
 						Line:     line,
 						Rule:     "isolation.domain-imports-orchestration",
-						Message:  fmt.Sprintf("domain %q must not import %s", srcDomain, m.OrchestrationDir),
+						Message:  fmt.Sprintf("domain %q must not import %s", src.Domain, m.OrchestrationDir),
 						Fix:      fmt.Sprintf("move cross-domain coordination to internal/%s callers instead of domain internals", m.OrchestrationDir),
 						Severity: cfg.Sev,
 					})
@@ -168,27 +174,31 @@ func CheckDomainIsolation(pkgs []*packages.Package, projectModule string, projec
 			}
 
 			// Rule 7: domain A importing domain B → violation
-			if srcDomain != "" && impDomain != "" && srcDomain != impDomain {
+			if (src.Kind == kindDomain || src.Kind == kindDomainRoot) &&
+				(imp.Kind == kindDomain || imp.Kind == kindDomainRoot) &&
+				src.Domain != "" && imp.Domain != "" && src.Domain != imp.Domain {
 				file, line := findImportPosition(pkg, impPath, projectRoot)
 				violations = append(violations, Violation{
 					File:     file,
 					Line:     line,
 					Rule:     "isolation.cross-domain",
-					Message:  fmt.Sprintf("domain %q must not import domain %q", srcDomain, impDomain),
+					Message:  fmt.Sprintf("domain %q must not import domain %q", src.Domain, imp.Domain),
 					Fix:      fmt.Sprintf("use %s/ for cross-domain orchestration or move shared types to %s/", m.OrchestrationDir, m.SharedDir),
 					Severity: cfg.Sev,
 				})
 				continue
 			}
 
-			// Rule 8: non-domain internal packages other than orchestration/cmd/pkg must not import domains
-			if srcDomain == "" && impDomain != "" {
+			// Rule 8: unclassified internal packages must not import domains
+			// (kindUnclassified is handled explicitly here, not silently skipped).
+			if src.Kind == kindUnclassified &&
+				(imp.Kind == kindDomain || imp.Kind == kindDomainRoot) {
 				file, line := findImportPosition(pkg, impPath, projectRoot)
 				violations = append(violations, Violation{
 					File:     file,
 					Line:     line,
 					Rule:     "isolation.stray-imports-domain",
-					Message:  fmt.Sprintf("package %q must not import domain %q", pkg.PkgPath, impDomain),
+					Message:  fmt.Sprintf("package %q must not import domain %q", pkg.PkgPath, imp.Domain),
 					Fix:      fmt.Sprintf("move domain orchestration to internal/%s or app wiring to cmd/", m.OrchestrationDir),
 					Severity: cfg.Sev,
 				})
@@ -205,18 +215,6 @@ func isUnderInternalDir(pkgPath, internalPrefix, dir string) bool {
 	}
 	rel := strings.TrimPrefix(pkgPath, internalPrefix)
 	return rel == dir || strings.HasPrefix(rel, dir+"/")
-}
-
-func isOrchestrationPkgWith(m Model, pkgPath, internalPrefix string) bool {
-	return isUnderInternalDir(pkgPath, internalPrefix, m.OrchestrationDir)
-}
-
-func isPkgPkgWith(m Model, pkgPath, internalPrefix string) bool {
-	return isUnderInternalDir(pkgPath, internalPrefix, m.SharedDir)
-}
-
-func isDomainAliasWith(m Model, importPath, internalPrefix, domain string) bool {
-	return importPath == internalPrefix+m.DomainDir+"/"+domain
 }
 
 func isOrchestrationHandlerWith(m Model, pkgPath, internalPrefix string) bool {

--- a/rules/layer.go
+++ b/rules/layer.go
@@ -31,12 +31,15 @@ func CheckLayerDirection(pkgs []*packages.Package, projectModule string, project
 			continue
 		}
 
-		srcDomain := identifyDomainWith(m, pkg.PkgPath, internalPrefix)
-		if srcDomain == "" {
+		src := classifyInternalPackage(m, pkg.PkgPath, internalPrefix)
+		// The layer rule only reasons about domain-shaped sources. Domain
+		// root / orchestration / shared / unclassified are not subject to
+		// direction checks here; they are handled by isolation or skipped.
+		if src.Kind != kindDomain {
 			continue
 		}
-
-		srcSublayer := identifySublayerWith(m, pkg.PkgPath, internalPrefix, srcDomain)
+		srcDomain := src.Domain
+		srcSublayer := src.Sublayer
 		if srcSublayer != "" && !isKnownSublayerIn(m, srcSublayer) {
 			violations = append(violations, Violation{
 				File:     relativePackageFile(pkg),
@@ -53,7 +56,10 @@ func CheckLayerDirection(pkgs []*packages.Package, projectModule string, project
 				continue
 			}
 
-			if isPkgPkgWith(m, impPath, internalPrefix) {
+			imp := classifyInternalPackage(m, impPath, internalPrefix)
+
+			switch imp.Kind {
+			case kindShared:
 				if m.PkgRestricted[srcSublayer] {
 					file, line := findImportPosition(pkg, impPath, projectRoot)
 					violations = append(violations, Violation{
@@ -66,26 +72,19 @@ func CheckLayerDirection(pkgs []*packages.Package, projectModule string, project
 					})
 				}
 				continue
-			}
-
-			// Skip imports to orchestration/
-			if isOrchestrationPkgWith(m, impPath, internalPrefix) {
+			case kindOrchestration, kindUnclassified:
+				// Orchestration imports are governed by isolation rules.
+				// Unclassified imports have no direction to enforce.
 				continue
 			}
 
-			impDomain := identifyDomainWith(m, impPath, internalPrefix)
-			// Only check intra-domain imports
-			if impDomain != srcDomain {
+			// From here: imp.Kind is kindDomain or kindDomainRoot.
+			// Only check intra-domain imports.
+			if imp.Domain != srcDomain {
 				continue
 			}
 
-			impSublayer := identifySublayerWith(m, impPath, internalPrefix, impDomain)
-
-			// Domain root (alias.go) is a facade — it may import any sublayer
-			// within its own domain. Cross-domain isolation is enforced elsewhere.
-			if srcSublayer == "" {
-				continue
-			}
+			impSublayer := imp.Sublayer
 
 			if impSublayer != "" && !isKnownSublayerIn(m, impSublayer) {
 				file, line := findImportPosition(pkg, impPath, projectRoot)
@@ -171,17 +170,24 @@ func checkFlatLayerDirection(pkgs []*packages.Package, m Model, cfg Config, proj
 			continue
 		}
 
-		srcSublayer := identifyFlatSublayer(m, pkg.PkgPath, internalPrefix)
-		if srcSublayer == "" {
+		src := classifyInternalPackage(m, pkg.PkgPath, internalPrefix)
+		// Flat layout: layer rule applies to packages classified as a known
+		// sublayer (kindDomain in flat mode). Shared and unclassified are
+		// skipped intentionally.
+		if src.Kind != kindDomain {
 			continue
 		}
+		srcSublayer := src.Sublayer
 
 		for impPath := range pkg.Imports {
 			if !strings.HasPrefix(impPath, internalPrefix) {
 				continue
 			}
 
-			if isPkgPkgWith(m, impPath, internalPrefix) {
+			imp := classifyInternalPackage(m, impPath, internalPrefix)
+
+			switch imp.Kind {
+			case kindShared:
 				if m.PkgRestricted[srcSublayer] {
 					file, line := findImportPosition(pkg, impPath, projectRoot)
 					violations = append(violations, Violation{
@@ -194,9 +200,12 @@ func checkFlatLayerDirection(pkgs []*packages.Package, m Model, cfg Config, proj
 					})
 				}
 				continue
+			case kindOrchestration, kindUnclassified:
+				// No direction to enforce for these kinds in flat layout.
+				continue
 			}
 
-			impSublayer := identifyFlatSublayer(m, impPath, internalPrefix)
+			impSublayer := imp.Sublayer
 			if impSublayer == "" || srcSublayer == impSublayer {
 				continue
 			}
@@ -221,18 +230,6 @@ func checkFlatLayerDirection(pkgs []*packages.Package, m Model, cfg Config, proj
 		}
 	}
 	return violations
-}
-
-func identifyFlatSublayer(m Model, pkgPath, internalPrefix string) string {
-	rel := strings.TrimPrefix(pkgPath, internalPrefix)
-	parts := strings.SplitN(rel, "/", 2)
-	if parts[0] == "" {
-		return ""
-	}
-	if slices.Contains(m.Sublayers, parts[0]) {
-		return parts[0]
-	}
-	return ""
 }
 
 func relativePackageFile(pkg *packages.Package) string {

--- a/rules/naming.go
+++ b/rules/naming.go
@@ -257,17 +257,52 @@ func snakeToPascal(s string) string {
 	return b.String()
 }
 
+// layerSuffixes returns the banned filename suffixes for the given model.
+// It unions two sources:
+//  1. m.Sublayers — split nested sublayers like "core/repo" into components
+//     ("core", "repo") so custom models (NewModel(WithSublayers([...])))
+//     automatically ban their own layer names as suffixes.
+//  2. m.LayerDirNames — explicit overrides / extra names teams want banned
+//     (e.g. legacy "_controller", "_persistence" in DDD).
 func layerSuffixes(m Model) []string {
 	seen := make(map[string]bool)
 	var out []string
-	for dir := range m.LayerDirNames {
+	add := func(dir string) {
+		if dir == "" {
+			return
+		}
 		suffix := "_" + dir
 		if !seen[suffix] {
 			seen[suffix] = true
 			out = append(out, suffix)
 		}
 	}
+	for _, sl := range m.Sublayers {
+		for _, part := range strings.Split(sl, "/") {
+			add(part)
+		}
+	}
+	for dir := range m.LayerDirNames {
+		add(dir)
+	}
 	return out
+}
+
+// layerDirEligible reports whether a directory is a layer directory whose
+// files should be subject to the no-layer-suffix check. Derived from the
+// union of m.Sublayers components and m.LayerDirNames.
+func layerDirEligible(m Model, dir string) bool {
+	if m.LayerDirNames[dir] {
+		return true
+	}
+	for _, sl := range m.Sublayers {
+		for _, part := range strings.Split(sl, "/") {
+			if part == dir {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func checkNoLayerSuffixWith(m Model, pkg *packages.Package, cfg Config) []Violation {
@@ -288,7 +323,7 @@ func checkNoLayerSuffixWith(m Model, pkg *packages.Package, cfg Config) []Violat
 			continue
 		}
 		dir := filepath.Base(filepath.Dir(f))
-		if !m.LayerDirNames[dir] {
+		if !layerDirEligible(m, dir) {
 			continue
 		}
 		// Skip files matching a TypePattern prefix (e.g. worker_xxx.go in worker/)

--- a/rules/naming.go
+++ b/rules/naming.go
@@ -257,13 +257,21 @@ func snakeToPascal(s string) string {
 	return b.String()
 }
 
-var bannedLayerSuffixes = []string{
-	"_svc", "_service", "_repo", "_repository",
-	"_handler", "_controller", "_model", "_entity",
-	"_store", "_persistence",
+func layerSuffixes(m Model) []string {
+	seen := make(map[string]bool)
+	var out []string
+	for dir := range m.LayerDirNames {
+		suffix := "_" + dir
+		if !seen[suffix] {
+			seen[suffix] = true
+			out = append(out, suffix)
+		}
+	}
+	return out
 }
 
 func checkNoLayerSuffixWith(m Model, pkg *packages.Package, cfg Config) []Violation {
+	banned := layerSuffixes(m)
 	var violations []Violation
 	seen := make(map[string]bool)
 	for _, f := range pkg.GoFiles {
@@ -288,7 +296,7 @@ func checkNoLayerSuffixWith(m Model, pkg *packages.Package, cfg Config) []Violat
 			continue
 		}
 		name := strings.TrimSuffix(base, ".go")
-		for _, suffix := range bannedLayerSuffixes {
+		for _, suffix := range banned {
 			if trimmed, ok := strings.CutSuffix(name, suffix); ok {
 				suggested := trimmed + ".go"
 				violations = append(violations, Violation{

--- a/rules/naming_suffix_test.go
+++ b/rules/naming_suffix_test.go
@@ -70,6 +70,50 @@ func TestCheckNaming_ModularMonolith_ApplicationSuffix(t *testing.T) {
 	}
 }
 
+func TestCheckNaming_CustomModel_UsecaseSuffix(t *testing.T) {
+	root := t.TempDir()
+	module := "example.com/custom-naming"
+
+	// Custom model with sublayer "usecase" that isn't in DDD's LayerDirNames.
+	m := rules.NewModel(
+		rules.WithDomainDir(""),
+		rules.WithOrchestrationDir(""),
+		rules.WithSublayers([]string{"usecase", "gateway", "model"}),
+		rules.WithDirection(map[string][]string{
+			"usecase": {"gateway", "model"},
+			"gateway": {"model"},
+			"model":   {},
+		}),
+		rules.WithPkgRestricted(map[string]bool{"model": true}),
+	)
+
+	writeTestFile(t, filepath.Join(root, "go.mod"), "module "+module+"\n\ngo 1.21\n")
+	// foo_usecase.go in usecase/ must trigger no-layer-suffix even though
+	// DDD's LayerDirNames does not include "usecase".
+	writeTestFile(t, filepath.Join(root, "internal", "usecase", "foo_usecase.go"),
+		"package usecase\n\ntype Foo struct{}\n")
+
+	pkgs, err := analyzer.Load(root, "internal/...")
+	if err != nil {
+		t.Fatal(err)
+	}
+	violations := rules.CheckNaming(pkgs, rules.WithModel(m))
+
+	found := false
+	for _, v := range violations {
+		if v.Rule == "naming.no-layer-suffix" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected naming.no-layer-suffix violation for foo_usecase.go in custom model with WithSublayers")
+		for _, v := range violations {
+			t.Log(v.String())
+		}
+	}
+}
+
 func TestCheckNaming_DDD_HandlerSuffix_StillWorks(t *testing.T) {
 	root := t.TempDir()
 	module := "example.com/ddd-naming"

--- a/rules/naming_suffix_test.go
+++ b/rules/naming_suffix_test.go
@@ -1,0 +1,102 @@
+package rules_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/NamhaeSusan/go-arch-guard/analyzer"
+	"github.com/NamhaeSusan/go-arch-guard/rules"
+)
+
+func TestCheckNaming_EventPipeline_CommandSuffix(t *testing.T) {
+	root := t.TempDir()
+	module := "example.com/evpipe-naming"
+	m := rules.EventPipeline()
+
+	writeTestFile(t, filepath.Join(root, "go.mod"), "module "+module+"\n\ngo 1.21\n")
+	// order_command.go in command/ must trigger no-layer-suffix
+	writeTestFile(t, filepath.Join(root, "internal", "command", "order_command.go"),
+		"package command\n\ntype PlaceOrder struct{}\n")
+
+	pkgs, err := analyzer.Load(root, "internal/...")
+	if err != nil {
+		t.Fatal(err)
+	}
+	violations := rules.CheckNaming(pkgs, rules.WithModel(m))
+
+	found := false
+	for _, v := range violations {
+		if v.Rule == "naming.no-layer-suffix" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected naming.no-layer-suffix violation for order_command.go in EventPipeline preset")
+		for _, v := range violations {
+			t.Log(v.String())
+		}
+	}
+}
+
+func TestCheckNaming_ModularMonolith_ApplicationSuffix(t *testing.T) {
+	root := t.TempDir()
+	module := "example.com/modmonolith-naming"
+	m := rules.ModularMonolith()
+
+	writeTestFile(t, filepath.Join(root, "go.mod"), "module "+module+"\n\ngo 1.21\n")
+	// order_application.go in application/ must trigger no-layer-suffix
+	writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "application", "order_application.go"),
+		"package application\n\ntype OrderUsecase struct{}\n")
+
+	pkgs, err := analyzer.Load(root, "internal/...")
+	if err != nil {
+		t.Fatal(err)
+	}
+	violations := rules.CheckNaming(pkgs, rules.WithModel(m))
+
+	found := false
+	for _, v := range violations {
+		if v.Rule == "naming.no-layer-suffix" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected naming.no-layer-suffix violation for order_application.go in ModularMonolith preset")
+		for _, v := range violations {
+			t.Log(v.String())
+		}
+	}
+}
+
+func TestCheckNaming_DDD_HandlerSuffix_StillWorks(t *testing.T) {
+	root := t.TempDir()
+	module := "example.com/ddd-naming"
+	m := rules.DDD()
+
+	writeTestFile(t, filepath.Join(root, "go.mod"), "module "+module+"\n\ngo 1.21\n")
+	// order_handler.go in handler/ must trigger no-layer-suffix
+	writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "handler", "order_handler.go"),
+		"package handler\n\ntype HTTP struct{}\n")
+
+	pkgs, err := analyzer.Load(root, "internal/...")
+	if err != nil {
+		t.Fatal(err)
+	}
+	violations := rules.CheckNaming(pkgs, rules.WithModel(m))
+
+	found := false
+	for _, v := range violations {
+		if v.Rule == "naming.no-layer-suffix" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected naming.no-layer-suffix violation for order_handler.go in DDD preset")
+		for _, v := range violations {
+			t.Log(v.String())
+		}
+	}
+}


### PR DESCRIPTION
Closes #19.

## Summary

- **`classifyInternalPackage` helper** (`rules/classify.go`): single classifier that maps any internal package path to a canonical `internalKind` (domain, domainRoot, orchestration, shared, unclassified), domain name, sublayer name, and alias flag. Unit tests cover DDD, ConsumerWorker (flat), and EventPipeline layouts.
- **Preset-aware naming suffixes** (`rules/naming.go`): replaced the hardcoded `bannedLayerSuffixes` list with `layerSuffixes(m)` which derives the banned suffix set from `Model.LayerDirNames`. This means every preset (including EventPipeline's `command`/`aggregate`/`projection`/`eventstore`/`readstore` and ModularMonolith's `api`/`application`/`infrastructure`) automatically bans their own layer names as file suffixes — single source of truth.
- **New tests**: `naming_suffix_test.go` adds EventPipeline + `_command` suffix and ModularMonolith + `_application` suffix coverage. `classify_test.go` covers all kinds as unit tests.

## Test plan

- [ ] `go test ./... -count=1` green (all 7 packages)
- [ ] `make lint` — 0 issues
- [ ] `TestCheckNaming_EventPipeline_CommandSuffix` catches `_command` suffix in EventPipeline
- [ ] `TestCheckNaming_ModularMonolith_ApplicationSuffix` catches `_application` suffix in ModularMonolith
- [ ] `TestCheckNaming_FlatLayout_WorkerFileAllowed` still passes (TypePattern exemption intact)
- [ ] All existing naming/layer/isolation tests pass without regression