### PR TITLE
refactor(rules): Model flat-layout InternalTopLevel + port/contract semantic fields

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -189,6 +189,10 @@ m := rules.NewModel(
 | `WithLegacyPkgNames([]string{...})` | 마이그레이션 경고 패키지명 |
 | `WithLayerDirNames(map[string]bool{...})` | 네이밍 체크 시 "레이어" 디렉토리 이름 |
 | `WithInterfacePatternExclude(map[string]bool{...})` | 인터페이스 패턴 검사 제외 레이어 |
+| `WithPortLayers([]string{...})` | 포트 레이어(순수 인터페이스 정의)로 분류할 서브레이어. 비어있지 않으면 authoritative (정확히 일치해야 함). |
+| `WithContractLayers([]string{...})` | 계약 레이어(포트 + svc류)로 분류할 서브레이어. `ContractLayers ⊇ PortLayers`; 헬퍼는 두 목록을 union하여 판정한다. |
+
+`NewModel`은 `DDD()` 기본값에서 시작하므로, 커스텀 모델은 별도 지정이 없으면 `PortLayers=["core/repo"]`, `ContractLayers=["core/repo","core/svc"]`를 상속한다. basename fallback(`repo`/`gateway`/`svc`)을 다시 쓰려면 **두 목록을 모두** 명시적으로 비워야 한다: `WithPortLayers(nil), WithContractLayers(nil)`. 한쪽만 비우면 authoritative exact-match 경로가 유지된다 (자세한 내용은 `NewModel` godoc 참조).
 
 ## 격리 규칙
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,10 @@ All model options:
 | `WithLegacyPkgNames([]string{...})` | package names that trigger migration warnings |
 | `WithLayerDirNames(map[string]bool{...})` | directory names considered "layer-like" for naming checks |
 | `WithInterfacePatternExclude(map[string]bool{...})` | layers to skip for interface pattern checks |
+| `WithPortLayers([]string{...})` | sublayers classified as port layers (pure interface definitions). Authoritative when non-empty (exact match only). |
+| `WithContractLayers([]string{...})` | sublayers classified as contract layers (ports + svc-like). `ContractLayers ⊇ PortLayers`; helpers union the two lists at check time. |
+
+`NewModel` starts from `DDD()` defaults, so custom models inherit `PortLayers=["core/repo"]` and `ContractLayers=["core/repo","core/svc"]` unless overridden. To restore the basename fallback (`repo`/`gateway`/`svc`), clear BOTH lists explicitly: `WithPortLayers(nil), WithContractLayers(nil)`. Clearing only one keeps the authoritative exact-match path active (see the `NewModel` godoc).
 
 ## Isolation Rules
 

--- a/plugins/go-arch-guard/skills/go-arch-guard/SKILL.md
+++ b/plugins/go-arch-guard/skills/go-arch-guard/SKILL.md
@@ -246,7 +246,9 @@ m := rules.NewModel(
 )
 ```
 
-전체 옵션: `WithSublayers`, `WithDirection`, `WithPkgRestricted`, `WithDomainDir`, `WithOrchestrationDir`, `WithSharedDir`, `WithRequireAlias`, `WithAliasFileName`, `WithRequireModel`, `WithModelPath`, `WithDTOAllowedLayers`, `WithBannedPkgNames`, `WithLegacyPkgNames`, `WithLayerDirNames`, `WithInterfacePatternExclude`
+전체 옵션: `WithSublayers`, `WithDirection`, `WithPkgRestricted`, `WithDomainDir`, `WithOrchestrationDir`, `WithSharedDir`, `WithRequireAlias`, `WithAliasFileName`, `WithRequireModel`, `WithModelPath`, `WithDTOAllowedLayers`, `WithBannedPkgNames`, `WithLegacyPkgNames`, `WithLayerDirNames`, `WithInterfacePatternExclude`, `WithPortLayers`, `WithContractLayers`
+
+> **Port/Contract 레이어 상속:** `NewModel`은 `DDD()` 기본값에서 시작하므로 커스텀 모델은 `PortLayers=["core/repo"]`, `ContractLayers=["core/repo","core/svc"]`를 상속합니다. 한쪽이라도 비어있지 않으면 helper는 두 목록을 union하여 authoritative(정확히 일치) 판정합니다. basename fallback(`repo`/`gateway`/`svc`)을 복원하려면 **두 목록 모두** 명시적으로 `nil`로 설정해야 합니다: `rules.WithPortLayers(nil), rules.WithContractLayers(nil)`.
 
 ---
 

--- a/rules/helpers_sublayer.go
+++ b/rules/helpers_sublayer.go
@@ -9,8 +9,7 @@ import (
 // When m.PortLayers is non-empty it is authoritative (exact match only, no
 // basename leakage) so callers that set WithPortLayers get exactly what they
 // asked for. When it is empty, fall back to the hardcoded basename heuristic
-// ("repo", "gateway"). WithSublayers clears inherited PortLayers so custom
-// sublayer callers start from empty unless they explicitly set WithPortLayers.
+// ("repo", "gateway").
 func isPortSublayerFor(m Model, name string) bool {
 	if len(m.PortLayers) > 0 {
 		return slices.Contains(m.PortLayers, name)
@@ -23,12 +22,14 @@ func isPortSublayerFor(m Model, name string) bool {
 }
 
 // isContractSublayerFor reports whether name is a contract layer according to
-// the model. When m.ContractLayers is non-empty it is authoritative. Otherwise
-// we defer to isPortSublayerFor then fall back to the hardcoded "svc" basename
-// heuristic for backward compatibility.
+// the model. Contract ⊇ Port, so when either PortLayers or ContractLayers is
+// non-empty the helper unions the two lists (authoritative, no basename leak).
+// When both are empty, fall back to the hardcoded basename heuristic
+// (port names plus "svc").
 func isContractSublayerFor(m Model, name string) bool {
-	if len(m.ContractLayers) > 0 {
-		return slices.Contains(m.ContractLayers, name)
+	if len(m.ContractLayers) > 0 || len(m.PortLayers) > 0 {
+		return slices.Contains(m.ContractLayers, name) ||
+			slices.Contains(m.PortLayers, name)
 	}
 	if isPortSublayerFor(m, name) {
 		return true

--- a/rules/helpers_sublayer.go
+++ b/rules/helpers_sublayer.go
@@ -6,11 +6,13 @@ import (
 )
 
 // isPortSublayerFor reports whether name is a port layer according to the model.
-// When m.PortLayers is non-empty it is authoritative; otherwise falls back to
-// hardcoded legacy names ("repo", "gateway") for backward compatibility.
+// The model's explicit PortLayers list is checked first; when it does not match,
+// the basename fallback to legacy names ("repo", "gateway") is still applied so
+// DDD-inherited custom models (which carry PortLayers=["core/repo"]) continue
+// to recognize renamed sublayers like "core/ports/repo".
 func isPortSublayerFor(m Model, name string) bool {
-	if len(m.PortLayers) > 0 {
-		return slices.Contains(m.PortLayers, name)
+	if slices.Contains(m.PortLayers, name) {
+		return true
 	}
 	base := name
 	if i := strings.LastIndex(name, "/"); i >= 0 {
@@ -20,11 +22,11 @@ func isPortSublayerFor(m Model, name string) bool {
 }
 
 // isContractSublayerFor reports whether name is a contract layer according to the model.
-// When m.ContractLayers is non-empty it is authoritative; otherwise falls back to
-// hardcoded legacy names ("repo", "gateway", "svc") for backward compatibility.
+// Same layering as isPortSublayerFor: explicit ContractLayers match first, then port
+// semantics, then basename fallback to "svc" so custom models keep working.
 func isContractSublayerFor(m Model, name string) bool {
-	if len(m.ContractLayers) > 0 {
-		return slices.Contains(m.ContractLayers, name)
+	if slices.Contains(m.ContractLayers, name) {
+		return true
 	}
 	if isPortSublayerFor(m, name) {
 		return true

--- a/rules/helpers_sublayer.go
+++ b/rules/helpers_sublayer.go
@@ -6,13 +6,14 @@ import (
 )
 
 // isPortSublayerFor reports whether name is a port layer according to the model.
-// The model's explicit PortLayers list is checked first; when it does not match,
-// the basename fallback to legacy names ("repo", "gateway") is still applied so
-// DDD-inherited custom models (which carry PortLayers=["core/repo"]) continue
-// to recognize renamed sublayers like "core/ports/repo".
+// When m.PortLayers is non-empty it is authoritative (exact match only, no
+// basename leakage) so callers that set WithPortLayers get exactly what they
+// asked for. When it is empty, fall back to the hardcoded basename heuristic
+// ("repo", "gateway"). WithSublayers clears inherited PortLayers so custom
+// sublayer callers start from empty unless they explicitly set WithPortLayers.
 func isPortSublayerFor(m Model, name string) bool {
-	if slices.Contains(m.PortLayers, name) {
-		return true
+	if len(m.PortLayers) > 0 {
+		return slices.Contains(m.PortLayers, name)
 	}
 	base := name
 	if i := strings.LastIndex(name, "/"); i >= 0 {
@@ -21,12 +22,13 @@ func isPortSublayerFor(m Model, name string) bool {
 	return base == "repo" || base == "gateway"
 }
 
-// isContractSublayerFor reports whether name is a contract layer according to the model.
-// Same layering as isPortSublayerFor: explicit ContractLayers match first, then port
-// semantics, then basename fallback to "svc" so custom models keep working.
+// isContractSublayerFor reports whether name is a contract layer according to
+// the model. When m.ContractLayers is non-empty it is authoritative. Otherwise
+// we defer to isPortSublayerFor then fall back to the hardcoded "svc" basename
+// heuristic for backward compatibility.
 func isContractSublayerFor(m Model, name string) bool {
-	if slices.Contains(m.ContractLayers, name) {
-		return true
+	if len(m.ContractLayers) > 0 {
+		return slices.Contains(m.ContractLayers, name)
 	}
 	if isPortSublayerFor(m, name) {
 		return true

--- a/rules/helpers_sublayer.go
+++ b/rules/helpers_sublayer.go
@@ -5,9 +5,13 @@ import (
 	"strings"
 )
 
-// isPortSublayer reports whether the sublayer name is a port/contract layer
-// (pure interface definitions like repo, gateway).
-func isPortSublayer(name string) bool {
+// isPortSublayerFor reports whether name is a port layer according to the model.
+// When m.PortLayers is non-empty it is authoritative; otherwise falls back to
+// hardcoded legacy names ("repo", "gateway") for backward compatibility.
+func isPortSublayerFor(m Model, name string) bool {
+	if len(m.PortLayers) > 0 {
+		return slices.Contains(m.PortLayers, name)
+	}
 	base := name
 	if i := strings.LastIndex(name, "/"); i >= 0 {
 		base = name[i+1:]
@@ -15,10 +19,14 @@ func isPortSublayer(name string) bool {
 	return base == "repo" || base == "gateway"
 }
 
-// isContractSublayer reports whether the sublayer name is a contract layer
-// (port/repo + service interfaces like svc).
-func isContractSublayer(name string) bool {
-	if isPortSublayer(name) {
+// isContractSublayerFor reports whether name is a contract layer according to the model.
+// When m.ContractLayers is non-empty it is authoritative; otherwise falls back to
+// hardcoded legacy names ("repo", "gateway", "svc") for backward compatibility.
+func isContractSublayerFor(m Model, name string) bool {
+	if len(m.ContractLayers) > 0 {
+		return slices.Contains(m.ContractLayers, name)
+	}
+	if isPortSublayerFor(m, name) {
 		return true
 	}
 	base := name
@@ -30,13 +38,15 @@ func isContractSublayer(name string) bool {
 
 // hasPortSublayer reports whether the model has any port sublayer.
 func hasPortSublayer(m Model) bool {
-	return slices.ContainsFunc(m.Sublayers, isPortSublayer)
+	return slices.ContainsFunc(m.Sublayers, func(sl string) bool {
+		return isPortSublayerFor(m, sl)
+	})
 }
 
 // matchPortSublayer returns the port sublayer name if pkgPath references one, "" otherwise.
 func matchPortSublayer(m Model, pkgPath string) string {
 	for _, sl := range m.Sublayers {
-		if !isPortSublayer(sl) {
+		if !isPortSublayerFor(m, sl) {
 			continue
 		}
 		if strings.HasSuffix(pkgPath, "/"+sl) || strings.Contains(pkgPath, "/"+sl+"/") {
@@ -49,7 +59,7 @@ func matchPortSublayer(m Model, pkgPath string) string {
 // matchContractSublayer returns the contract sublayer name if pkgPath references one, "" otherwise.
 func matchContractSublayer(m Model, pkgPath string) string {
 	for _, sl := range m.Sublayers {
-		if !isContractSublayer(sl) {
+		if !isContractSublayerFor(m, sl) {
 			continue
 		}
 		if strings.HasSuffix(pkgPath, "/"+sl) || strings.Contains(pkgPath, "/"+sl+"/") {
@@ -62,7 +72,7 @@ func matchContractSublayer(m Model, pkgPath string) string {
 // portSublayerName returns the first port sublayer name from the model, or "core/repo" as fallback.
 func portSublayerName(m Model) string {
 	for _, sl := range m.Sublayers {
-		if isPortSublayer(sl) {
+		if isPortSublayerFor(m, sl) {
 			return sl
 		}
 	}

--- a/rules/model.go
+++ b/rules/model.go
@@ -411,8 +411,18 @@ func NewModel(opts ...ModelOption) Model {
 	return m
 }
 
+// WithSublayers replaces the model's Sublayers list. Because NewModel inherits
+// PortLayers/ContractLayers from DDD defaults, WithSublayers also clears those
+// lists so custom sublayer callers do not leak DDD's port/contract names into
+// an unrelated architecture. After WithSublayers, port/contract classification
+// falls back to the built-in basename heuristic; callers can set explicit
+// lists via WithPortLayers / WithContractLayers *after* WithSublayers.
 func WithSublayers(sublayers []string) ModelOption {
-	return func(m *Model) { m.Sublayers = sublayers }
+	return func(m *Model) {
+		m.Sublayers = sublayers
+		m.PortLayers = nil
+		m.ContractLayers = nil
+	}
 }
 
 func WithDirection(direction map[string][]string) ModelOption {

--- a/rules/model.go
+++ b/rules/model.go
@@ -23,13 +23,15 @@ type Model struct {
 	// PortLayers lists sublayer names that are port layers (pure interface
 	// definitions like repo, gateway, store). When non-empty, helpers treat
 	// this list as authoritative (exact match only, no basename leakage).
+	// When empty, basename fallback ("repo"/"gateway") runs only if
+	// ContractLayers is also empty — see ContractLayers for details.
 	PortLayers []string
 	// ContractLayers lists sublayer names that are contract layers
-	// (port layers + svc-like layers). Semantically ContractLayers ⊇ PortLayers:
-	// every port is a contract. Helpers union PortLayers and ContractLayers
-	// when classifying contract membership, so callers do not need to repeat
-	// the port names here. When both lists are empty, the basename fallback
-	// ("repo"/"gateway"/"svc") is used.
+	// (port layers + svc-like layers). ContractLayers ⊇ PortLayers
+	// semantically; helpers union the two lists at check time so callers do
+	// not need to repeat port names here. When EITHER list is non-empty the
+	// union is authoritative (exact match only). Basename fallback
+	// ("repo"/"gateway"/"svc") runs only when BOTH lists are empty.
 	ContractLayers []string
 }
 
@@ -389,9 +391,15 @@ func EventPipeline() Model {
 
 // NewModel starts from DDD() defaults and applies options in order.
 // Options that don't touch PortLayers/ContractLayers inherit DDD's values
-// (currently ["core/repo"] / ["core/repo", "core/svc"]). Call WithPortLayers(nil)
-// or WithContractLayers(nil) to clear inherited port/contract semantics
-// explicitly — the helpers then fall back to the basename heuristic.
+// (currently ["core/repo"] / ["core/repo", "core/svc"]).
+//
+// To restore the basename fallback ("repo"/"gateway"/"svc") for port/contract
+// detection, callers must clear BOTH lists:
+//
+//	NewModel(WithPortLayers(nil), WithContractLayers(nil), ...)
+//
+// Clearing only one keeps the authoritative exact-match path active (the
+// helpers union PortLayers and ContractLayers when either is non-empty).
 func NewModel(opts ...ModelOption) Model {
 	m := DDD()
 	for _, o := range opts {

--- a/rules/model.go
+++ b/rules/model.go
@@ -20,11 +20,16 @@ type Model struct {
 	LayerDirNames           map[string]bool
 	TypePatterns            []TypePattern
 	InterfacePatternExclude map[string]bool // layers to skip for interface pattern checks
-	// PortLayers lists sublayer names that are port/contract layers (e.g. repo, gateway, store).
-	// When non-empty, helpers use this list instead of the hardcoded defaults.
+	// PortLayers lists sublayer names that are port layers (pure interface
+	// definitions like repo, gateway, store). When non-empty, helpers treat
+	// this list as authoritative (exact match only, no basename leakage).
 	PortLayers []string
-	// ContractLayers lists sublayer names that are contract layers (port layers + svc-like layers).
-	// When non-empty, helpers use this list instead of the hardcoded defaults.
+	// ContractLayers lists sublayer names that are contract layers
+	// (port layers + svc-like layers). Semantically ContractLayers ⊇ PortLayers:
+	// every port is a contract. Helpers union PortLayers and ContractLayers
+	// when classifying contract membership, so callers do not need to repeat
+	// the port names here. When both lists are empty, the basename fallback
+	// ("repo"/"gateway"/"svc") is used.
 	ContractLayers []string
 }
 
@@ -382,7 +387,11 @@ func EventPipeline() Model {
 	}
 }
 
-// NewModel creates a Model starting from DDD defaults, then applies options.
+// NewModel starts from DDD() defaults and applies options in order.
+// Options that don't touch PortLayers/ContractLayers inherit DDD's values
+// (currently ["core/repo"] / ["core/repo", "core/svc"]). Call WithPortLayers(nil)
+// or WithContractLayers(nil) to clear inherited port/contract semantics
+// explicitly — the helpers then fall back to the basename heuristic.
 func NewModel(opts ...ModelOption) Model {
 	m := DDD()
 	for _, o := range opts {
@@ -411,18 +420,11 @@ func NewModel(opts ...ModelOption) Model {
 	return m
 }
 
-// WithSublayers replaces the model's Sublayers list. Because NewModel inherits
-// PortLayers/ContractLayers from DDD defaults, WithSublayers also clears those
-// lists so custom sublayer callers do not leak DDD's port/contract names into
-// an unrelated architecture. After WithSublayers, port/contract classification
-// falls back to the built-in basename heuristic; callers can set explicit
-// lists via WithPortLayers / WithContractLayers *after* WithSublayers.
+// WithSublayers replaces the model's Sublayers list. PortLayers/ContractLayers
+// are NOT cleared: callers who need a clean slate should pass WithPortLayers(nil)
+// and/or WithContractLayers(nil) explicitly (see NewModel godoc).
 func WithSublayers(sublayers []string) ModelOption {
-	return func(m *Model) {
-		m.Sublayers = sublayers
-		m.PortLayers = nil
-		m.ContractLayers = nil
-	}
+	return func(m *Model) { m.Sublayers = sublayers }
 }
 
 func WithDirection(direction map[string][]string) ModelOption {

--- a/rules/model.go
+++ b/rules/model.go
@@ -392,14 +392,17 @@ func NewModel(opts ...ModelOption) Model {
 	if m.DomainDir != "" {
 		// Domain layout: top-level is domain/, orchestration/, shared/.
 		tl[m.DomainDir] = true
-		if m.OrchestrationDir != "" {
-			tl[m.OrchestrationDir] = true
-		}
 	} else {
 		// Flat layout: each sublayer lives directly under internal/.
 		for _, sl := range m.Sublayers {
 			tl[sl] = true
 		}
+	}
+	// OrchestrationDir is independent of layout: non-empty values always
+	// stay in InternalTopLevel so flat layouts can opt into an orchestration
+	// directory (e.g. internal/workflow/).
+	if m.OrchestrationDir != "" {
+		tl[m.OrchestrationDir] = true
 	}
 	if m.SharedDir != "" {
 		tl[m.SharedDir] = true

--- a/rules/model.go
+++ b/rules/model.go
@@ -20,6 +20,12 @@ type Model struct {
 	LayerDirNames           map[string]bool
 	TypePatterns            []TypePattern
 	InterfacePatternExclude map[string]bool // layers to skip for interface pattern checks
+	// PortLayers lists sublayer names that are port/contract layers (e.g. repo, gateway, store).
+	// When non-empty, helpers use this list instead of the hardcoded defaults.
+	PortLayers []string
+	// ContractLayers lists sublayer names that are contract layers (port layers + svc-like layers).
+	// When non-empty, helpers use this list instead of the hardcoded defaults.
+	ContractLayers []string
 }
 
 // TypePattern defines an AST-based naming/structure convention for a directory.
@@ -83,6 +89,8 @@ func DDD() Model {
 		InterfacePatternExclude: map[string]bool{
 			"handler": true, "app": true, "core/model": true, "core/repo": true, "event": true,
 		},
+		PortLayers:     []string{"core/repo"},
+		ContractLayers: []string{"core/repo", "core/svc"},
 	}
 }
 
@@ -124,6 +132,8 @@ func CleanArch() Model {
 		InterfacePatternExclude: map[string]bool{
 			"handler": true, "entity": true,
 		},
+		PortLayers:     []string{"gateway"},
+		ContractLayers: []string{"gateway"},
 	}
 }
 
@@ -380,10 +390,16 @@ func NewModel(opts ...ModelOption) Model {
 	}
 	tl := make(map[string]bool)
 	if m.DomainDir != "" {
+		// Domain layout: top-level is domain/, orchestration/, shared/.
 		tl[m.DomainDir] = true
-	}
-	if m.OrchestrationDir != "" {
-		tl[m.OrchestrationDir] = true
+		if m.OrchestrationDir != "" {
+			tl[m.OrchestrationDir] = true
+		}
+	} else {
+		// Flat layout: each sublayer lives directly under internal/.
+		for _, sl := range m.Sublayers {
+			tl[sl] = true
+		}
 	}
 	if m.SharedDir != "" {
 		tl[m.SharedDir] = true
@@ -450,4 +466,12 @@ func WithLayerDirNames(names map[string]bool) ModelOption {
 
 func WithInterfacePatternExclude(exclude map[string]bool) ModelOption {
 	return func(m *Model) { m.InterfacePatternExclude = exclude }
+}
+
+func WithPortLayers(layers []string) ModelOption {
+	return func(m *Model) { m.PortLayers = layers }
+}
+
+func WithContractLayers(layers []string) ModelOption {
+	return func(m *Model) { m.ContractLayers = layers }
 }

--- a/rules/model_test.go
+++ b/rules/model_test.go
@@ -645,3 +645,63 @@ func TestNewModel_InheritedPortLayers_BasenameFallback(t *testing.T) {
 		t.Errorf("matchPortSublayer with basename fallback = %q, want %q", got, "core/ports/repo")
 	}
 }
+
+// Regression (review #3): Explicit WithPortLayers is authoritative — sublayers
+// whose basename is "repo" or "gateway" must NOT leak into port semantics when
+// the caller opted into a custom PortLayers list.
+func TestWithPortLayers_ExactMatchIsAuthoritative(t *testing.T) {
+	m := NewModel(
+		WithSublayers([]string{"worker", "store", "model", "legacy/repo"}),
+		WithDirection(map[string][]string{
+			"worker":      {"store", "model"},
+			"store":       {"model"},
+			"model":       {},
+			"legacy/repo": {"model"},
+		}),
+		WithPortLayers([]string{"store"}),
+	)
+	if !isPortSublayerFor(m, "store") {
+		t.Error("explicit PortLayers: 'store' must be a port sublayer")
+	}
+	if isPortSublayerFor(m, "legacy/repo") {
+		t.Error("explicit PortLayers is authoritative: 'legacy/repo' must NOT be a port sublayer")
+	}
+	if matchPortSublayer(m, "example.com/app/internal/legacy/repo") != "" {
+		t.Error("explicit PortLayers is authoritative: matchPortSublayer must not find 'legacy/repo'")
+	}
+}
+
+// Regression (review #3): Explicit WithContractLayers is authoritative too —
+// "svc"-basename sublayers must not leak when caller set a custom list.
+func TestWithContractLayers_ExactMatchIsAuthoritative(t *testing.T) {
+	m := NewModel(
+		WithSublayers([]string{"worker", "store", "model", "legacy/svc"}),
+		WithDirection(map[string][]string{
+			"worker":     {"store", "model"},
+			"store":      {"model"},
+			"model":      {},
+			"legacy/svc": {"model"},
+		}),
+		WithContractLayers([]string{"store"}),
+	)
+	if !isContractSublayerFor(m, "store") {
+		t.Error("explicit ContractLayers: 'store' must be a contract sublayer")
+	}
+	if isContractSublayerFor(m, "legacy/svc") {
+		t.Error("explicit ContractLayers is authoritative: 'legacy/svc' must NOT be a contract sublayer")
+	}
+}
+
+// Regression (review #3): WithSublayers alone must clear inherited DDD
+// PortLayers/ContractLayers so basename fallback applies.
+func TestWithSublayers_ClearsInheritedPortContractLayers(t *testing.T) {
+	m := NewModel(
+		WithSublayers([]string{"worker", "store", "model"}),
+	)
+	if len(m.PortLayers) != 0 {
+		t.Errorf("WithSublayers must clear inherited PortLayers, got %v", m.PortLayers)
+	}
+	if len(m.ContractLayers) != 0 {
+		t.Errorf("WithSublayers must clear inherited ContractLayers, got %v", m.ContractLayers)
+	}
+}

--- a/rules/model_test.go
+++ b/rules/model_test.go
@@ -422,3 +422,172 @@ func validateModelConsistency(t *testing.T, m Model) {
 		t.Errorf("InternalTopLevel missing SharedDir %q", m.SharedDir)
 	}
 }
+
+// Item A: flat-layout NewModel must promote Sublayers into InternalTopLevel.
+func TestNewModel_FlatLayout_PromotesSublayers(t *testing.T) {
+	m := NewModel(
+		WithDomainDir(""),
+		WithOrchestrationDir(""),
+		WithSharedDir("pkg"),
+		WithSublayers([]string{"worker", "service", "store", "model"}),
+		WithDirection(map[string][]string{
+			"worker":  {"service", "model"},
+			"service": {"store", "model"},
+			"store":   {"model"},
+			"model":   {},
+		}),
+	)
+	for _, sl := range []string{"worker", "service", "store", "model", "pkg"} {
+		if !m.InternalTopLevel[sl] {
+			t.Errorf("flat-layout NewModel: InternalTopLevel missing %q", sl)
+		}
+	}
+	if m.InternalTopLevel["domain"] {
+		t.Error("flat-layout NewModel: InternalTopLevel must not contain old DomainDir")
+	}
+	if m.InternalTopLevel["orchestration"] {
+		t.Error("flat-layout NewModel: InternalTopLevel must not contain old OrchestrationDir")
+	}
+}
+
+// Item A: when DomainDir is set, domain-layout behavior is unchanged.
+func TestNewModel_DomainLayout_UnchangedBehavior(t *testing.T) {
+	m := NewModel(
+		WithDomainDir("domain"),
+		WithOrchestrationDir("orchestration"),
+		WithSharedDir("pkg"),
+		WithSublayers([]string{"handler", "app", "core"}),
+		WithDirection(map[string][]string{
+			"handler": {"app"},
+			"app":     {"core"},
+			"core":    {},
+		}),
+	)
+	if !m.InternalTopLevel["domain"] {
+		t.Error("domain-layout: InternalTopLevel must include DomainDir")
+	}
+	if !m.InternalTopLevel["orchestration"] {
+		t.Error("domain-layout: InternalTopLevel must include OrchestrationDir")
+	}
+	if !m.InternalTopLevel["pkg"] {
+		t.Error("domain-layout: InternalTopLevel must include SharedDir")
+	}
+	// Sublayers must NOT be promoted in domain layout.
+	if m.InternalTopLevel["handler"] {
+		t.Error("domain-layout: InternalTopLevel must not include sublayer 'handler'")
+	}
+}
+
+// Item B: Model has PortLayers and ContractLayers fields.
+func TestModel_PortLayersContractLayersFields(t *testing.T) {
+	m := Model{
+		PortLayers:     []string{"store", "port"},
+		ContractLayers: []string{"store", "port", "svc"},
+	}
+	if len(m.PortLayers) != 2 {
+		t.Errorf("PortLayers len = %d, want 2", len(m.PortLayers))
+	}
+	if len(m.ContractLayers) != 3 {
+		t.Errorf("ContractLayers len = %d, want 3", len(m.ContractLayers))
+	}
+}
+
+// Item B: WithPortLayers and WithContractLayers options exist.
+func TestNewModel_WithPortLayersContractLayers(t *testing.T) {
+	m := NewModel(
+		WithPortLayers([]string{"store", "port"}),
+		WithContractLayers([]string{"store", "port", "svc"}),
+	)
+	if !slices.Contains(m.PortLayers, "store") {
+		t.Error("PortLayers must contain 'store'")
+	}
+	if !slices.Contains(m.ContractLayers, "svc") {
+		t.Error("ContractLayers must contain 'svc'")
+	}
+}
+
+// Item B: presets populate PortLayers/ContractLayers for DDD.
+func TestDDD_HasPortAndContractLayers(t *testing.T) {
+	m := DDD()
+	if !slices.Contains(m.PortLayers, "core/repo") {
+		t.Error("DDD PortLayers must contain 'core/repo'")
+	}
+	if !slices.Contains(m.ContractLayers, "core/svc") {
+		t.Error("DDD ContractLayers must contain 'core/svc'")
+	}
+}
+
+// Item B: presets populate PortLayers/ContractLayers for CleanArch.
+func TestCleanArch_HasPortLayers(t *testing.T) {
+	m := CleanArch()
+	if !slices.Contains(m.PortLayers, "gateway") {
+		t.Error("CleanArch PortLayers must contain 'gateway'")
+	}
+}
+
+// Item B: Hexagonal uses no explicit PortLayers (falls back to hardcoded defaults).
+// The port sublayer in Hexagonal does not follow the DDD repo-file-interface pattern.
+func TestHexagonal_PortLayersEmpty(t *testing.T) {
+	m := Hexagonal()
+	if len(m.PortLayers) != 0 {
+		t.Errorf("Hexagonal PortLayers must be empty (use fallback), got %v", m.PortLayers)
+	}
+}
+
+// Item B: isPortSublayer consults model PortLayers when non-empty.
+func TestIsPortSublayer_ConsultsModel(t *testing.T) {
+	m := Model{
+		Sublayers:  []string{"store", "model"},
+		PortLayers: []string{"store"},
+	}
+	if !isPortSublayerFor(m, "store") {
+		t.Error("isPortSublayerFor must return true for 'store' when PortLayers=['store']")
+	}
+	if isPortSublayerFor(m, "model") {
+		t.Error("isPortSublayerFor must return false for 'model' when PortLayers=['store']")
+	}
+	// legacy default: model without PortLayers falls back to hardcoded names
+	mFallback := Model{Sublayers: []string{"core/repo"}}
+	if !isPortSublayerFor(mFallback, "core/repo") {
+		t.Error("fallback: isPortSublayerFor must return true for 'core/repo' when PortLayers is empty")
+	}
+}
+
+// Item B: isContractSublayer consults model ContractLayers when non-empty.
+func TestIsContractSublayer_ConsultsModel(t *testing.T) {
+	m := Model{
+		Sublayers:      []string{"store", "svc", "model"},
+		PortLayers:     []string{"store"},
+		ContractLayers: []string{"store", "svc"},
+	}
+	if !isContractSublayerFor(m, "store") {
+		t.Error("isContractSublayerFor must return true for 'store'")
+	}
+	if !isContractSublayerFor(m, "svc") {
+		t.Error("isContractSublayerFor must return true for 'svc'")
+	}
+	if isContractSublayerFor(m, "model") {
+		t.Error("isContractSublayerFor must return false for 'model'")
+	}
+	// legacy default: model without ContractLayers falls back to hardcoded names
+	mFallback := Model{Sublayers: []string{"core/repo"}}
+	if !isContractSublayerFor(mFallback, "core/repo") {
+		t.Error("fallback: isContractSublayerFor must return true for 'core/repo'")
+	}
+}
+
+// Item B: matchPortSublayer uses PortLayers from the model.
+func TestMatchPortSublayer_CustomLayer(t *testing.T) {
+	m := Model{
+		Sublayers:  []string{"store", "model"},
+		PortLayers: []string{"store"},
+	}
+	got := matchPortSublayer(m, "github.com/example/myapp/internal/store")
+	if got != "store" {
+		t.Errorf("matchPortSublayer = %q, want %q", got, "store")
+	}
+	got = matchPortSublayer(m, "github.com/example/myapp/internal/model")
+	if got != "" {
+		t.Errorf("matchPortSublayer = %q, want %q", got, "")
+	}
+}

--- a/rules/model_test.go
+++ b/rules/model_test.go
@@ -591,3 +591,57 @@ func TestMatchPortSublayer_CustomLayer(t *testing.T) {
 		t.Errorf("matchPortSublayer = %q, want %q", got, "")
 	}
 }
+
+// Regression (review #1): custom flat model with a non-empty OrchestrationDir
+// must keep that directory allowed at internal/ top level.
+func TestNewModel_FlatLayout_PreservesOrchestrationDir(t *testing.T) {
+	m := NewModel(
+		WithDomainDir(""),
+		WithOrchestrationDir("workflow"),
+		WithSharedDir("pkg"),
+		WithSublayers([]string{"worker", "service", "store", "model"}),
+		WithDirection(map[string][]string{
+			"worker":  {"service", "model"},
+			"service": {"store", "model"},
+			"store":   {"model"},
+			"model":   {},
+		}),
+	)
+	if !m.InternalTopLevel["workflow"] {
+		t.Error("flat-layout NewModel must preserve non-empty OrchestrationDir in InternalTopLevel")
+	}
+	for _, sl := range []string{"worker", "service", "store", "model", "pkg"} {
+		if !m.InternalTopLevel[sl] {
+			t.Errorf("flat-layout NewModel: InternalTopLevel missing %q", sl)
+		}
+	}
+}
+
+// Regression (review #2): NewModel inherits PortLayers/ContractLayers from DDD.
+// A custom model that renames core/repo to core/ports/repo (without explicitly
+// setting the new fields) must still get port/contract semantics via the
+// basename fallback.
+func TestNewModel_InheritedPortLayers_BasenameFallback(t *testing.T) {
+	m := NewModel(
+		WithSublayers([]string{"handler", "app", "core/ports/repo", "core/svcs/svc", "core/model"}),
+		WithDirection(map[string][]string{
+			"handler":         {"app"},
+			"app":             {"core/ports/repo", "core/svcs/svc", "core/model"},
+			"core/ports/repo": {"core/model"},
+			"core/svcs/svc":   {"core/model"},
+			"core/model":      {},
+		}),
+	)
+	if !isPortSublayerFor(m, "core/ports/repo") {
+		t.Error("basename fallback: 'core/ports/repo' must still be a port sublayer")
+	}
+	if !isContractSublayerFor(m, "core/ports/repo") {
+		t.Error("basename fallback: 'core/ports/repo' must still be a contract sublayer")
+	}
+	if !isContractSublayerFor(m, "core/svcs/svc") {
+		t.Error("basename fallback: 'core/svcs/svc' must still be a contract sublayer")
+	}
+	if got := matchPortSublayer(m, "example.com/app/internal/domain/order/core/ports/repo"); got != "core/ports/repo" {
+		t.Errorf("matchPortSublayer with basename fallback = %q, want %q", got, "core/ports/repo")
+	}
+}

--- a/rules/model_test.go
+++ b/rules/model_test.go
@@ -736,3 +736,28 @@ func TestIsContractSublayerFor_UnionsPortLayers(t *testing.T) {
 		t.Error("'model' (in neither list) must not be a contract sublayer")
 	}
 }
+
+// Regression (review #5): clearing only one of PortLayers/ContractLayers
+// keeps the union exact-match path active — basename fallback must NOT run.
+// Matches NewModel godoc: "To restore the basename fallback, clear BOTH lists."
+func TestIsContractSublayerFor_PartialClear_NoBasenameFallback(t *testing.T) {
+	// PortLayers cleared, ContractLayers still populated → union path.
+	m1 := Model{
+		Sublayers:      []string{"legacy/repo", "svc", "model"},
+		PortLayers:     nil,
+		ContractLayers: []string{"svc"},
+	}
+	if isContractSublayerFor(m1, "legacy/repo") {
+		t.Error("partial-clear (PortLayers=nil, ContractLayers set): 'legacy/repo' must NOT fall back to basename")
+	}
+
+	// ContractLayers cleared, PortLayers still populated → union path.
+	m2 := Model{
+		Sublayers:      []string{"legacy/svc", "store", "model"},
+		PortLayers:     []string{"store"},
+		ContractLayers: nil,
+	}
+	if isContractSublayerFor(m2, "legacy/svc") {
+		t.Error("partial-clear (ContractLayers=nil, PortLayers set): 'legacy/svc' must NOT fall back to basename")
+	}
+}

--- a/rules/model_test.go
+++ b/rules/model_test.go
@@ -617,11 +617,10 @@ func TestNewModel_FlatLayout_PreservesOrchestrationDir(t *testing.T) {
 	}
 }
 
-// Regression (review #2): NewModel inherits PortLayers/ContractLayers from DDD.
-// A custom model that renames core/repo to core/ports/repo (without explicitly
-// setting the new fields) must still get port/contract semantics via the
-// basename fallback.
-func TestNewModel_InheritedPortLayers_BasenameFallback(t *testing.T) {
+// Regression: a custom NewModel that renames core/repo to core/ports/repo
+// can opt into basename fallback by explicitly clearing inherited DDD
+// PortLayers/ContractLayers with WithPortLayers(nil)/WithContractLayers(nil).
+func TestNewModel_ExplicitClear_BasenameFallback(t *testing.T) {
 	m := NewModel(
 		WithSublayers([]string{"handler", "app", "core/ports/repo", "core/svcs/svc", "core/model"}),
 		WithDirection(map[string][]string{
@@ -631,6 +630,8 @@ func TestNewModel_InheritedPortLayers_BasenameFallback(t *testing.T) {
 			"core/svcs/svc":   {"core/model"},
 			"core/model":      {},
 		}),
+		WithPortLayers(nil),
+		WithContractLayers(nil),
 	)
 	if !isPortSublayerFor(m, "core/ports/repo") {
 		t.Error("basename fallback: 'core/ports/repo' must still be a port sublayer")
@@ -692,16 +693,46 @@ func TestWithContractLayers_ExactMatchIsAuthoritative(t *testing.T) {
 	}
 }
 
-// Regression (review #3): WithSublayers alone must clear inherited DDD
-// PortLayers/ContractLayers so basename fallback applies.
-func TestWithSublayers_ClearsInheritedPortContractLayers(t *testing.T) {
+// Regression (review #4): Option order must not silently wipe explicit
+// user config. WithPortLayers before WithSublayers must survive — WithSublayers
+// does not clear PortLayers/ContractLayers.
+func TestNewModel_WithPortLayersBeforeWithSublayers_Survives(t *testing.T) {
 	m := NewModel(
-		WithSublayers([]string{"worker", "store", "model"}),
+		WithPortLayers([]string{"store"}),
+		WithSublayers([]string{"usecase", "store", "model"}),
+		WithDirection(map[string][]string{
+			"usecase": {"store", "model"},
+			"store":   {"model"},
+			"model":   {},
+		}),
 	)
-	if len(m.PortLayers) != 0 {
-		t.Errorf("WithSublayers must clear inherited PortLayers, got %v", m.PortLayers)
+	if !slices.Contains(m.PortLayers, "store") {
+		t.Errorf("WithPortLayers before WithSublayers was wiped: PortLayers=%v", m.PortLayers)
 	}
-	if len(m.ContractLayers) != 0 {
-		t.Errorf("WithSublayers must clear inherited ContractLayers, got %v", m.ContractLayers)
+	if !isPortSublayerFor(m, "store") {
+		t.Error("explicit 'store' port layer lost after WithSublayers")
+	}
+}
+
+// Regression (review #4): ContractLayers ⊇ PortLayers invariant. A layer
+// listed in PortLayers but not ContractLayers must still be classified as
+// a contract layer (via the union in isContractSublayerFor).
+func TestIsContractSublayerFor_UnionsPortLayers(t *testing.T) {
+	m := Model{
+		Sublayers:      []string{"store", "svc", "model"},
+		PortLayers:     []string{"store"},
+		ContractLayers: []string{"svc"},
+	}
+	if !isPortSublayerFor(m, "store") {
+		t.Error("'store' must be a port sublayer")
+	}
+	if !isContractSublayerFor(m, "store") {
+		t.Error("contract union: 'store' (in PortLayers) must be a contract sublayer")
+	}
+	if !isContractSublayerFor(m, "svc") {
+		t.Error("'svc' (in ContractLayers) must be a contract sublayer")
+	}
+	if isContractSublayerFor(m, "model") {
+		t.Error("'model' (in neither list) must not be a contract sublayer")
 	}
 }


### PR DESCRIPTION
Closes part of #18. Defers Config god-object split.

## Summary

- **Item A**: `NewModel` now promotes each `Sublayers` entry into `InternalTopLevel` when `DomainDir == ""` (flat layout). Previously, custom flat models built with `WithSublayers(...)` lost their top-level entries and `CheckStructure` rejected them. Domain-layout behavior is unchanged.
- **Item B**: Add `PortLayers []string` and `ContractLayers []string` fields to `Model`. New model-aware helpers `isPortSublayerFor` and `isContractSublayerFor` consult these fields when non-empty, falling back to hardcoded legacy names (`repo`, `gateway`, `svc`) so existing external users are unaffected. DDD and CleanArch presets populate these fields; Hexagonal does not (its `port` layer does not follow the DDD repo-file-interface pattern). New `WithPortLayers` and `WithContractLayers` options added.

## Test plan

- [ ] New tests: `TestNewModel_FlatLayout_PromotesSublayers` — custom flat model survives `NewModel`
- [ ] New tests: `TestNewModel_DomainLayout_UnchangedBehavior` — domain layout still works
- [ ] New tests: `TestIsPortSublayer_ConsultsModel`, `TestIsContractSublayer_ConsultsModel`, `TestMatchPortSublayer_CustomLayer` — helpers respect model fields
- [ ] New tests: `TestDDD_HasPortAndContractLayers`, `TestCleanArch_HasPortLayers` — preset fields populated
- [ ] `go test ./... -count=1` — green
- [ ] `make lint` — 0 issues
- [ ] All existing preset tests pass without behavior regression