### PR TITLE
feat(rules): DDD preset supports internal/app composition root and internal/server transport

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -280,6 +280,11 @@ import _ "myapp/internal/domain/order"  // 위반: pkg가 도메인에 의존
 
 트랜스포트 패키지는 오케스트레이션을 직접 import할 수 없습니다.
 
+### `isolation.transport-imports-unclassified`
+
+트랜스포트 패키지는 분류되지 않은 내부 패키지(예: `internal/config`, `internal/bootstrap`)를 import할 수 없습니다.
+트랜스포트가 의존하는 모든 것은 `internal/app/` (컴포지션 루트) 또는 `internal/pkg/`를 거쳐야 합니다.
+
 **Import 매트릭스 (DDD + app/server):**
 
 | from | 도메인 루트 | 도메인 하위 | 오케스트레이션 | 공유 패키지 | app | 트랜스포트 |

--- a/README.ko.md
+++ b/README.ko.md
@@ -180,6 +180,8 @@ m := rules.NewModel(
 | `WithDomainDir("domain")` | 도메인 최상위 디렉토리명 |
 | `WithOrchestrationDir("orchestration")` | 오케스트레이션 최상위 디렉토리명 |
 | `WithSharedDir("pkg")` | 공유 패키지 최상위 디렉토리명 |
+| `WithAppDir("app")` | 컴포지션 루트 최상위 디렉토리 (예: `internal/app/`). 이 패키지들은 무제한 import 가능. 비워두면 비활성화. |
+| `WithServerDir("server")` | 트랜스포트 레이어 최상위 디렉토리 (예: `internal/server/`). 하위 디렉토리는 모두 트랜스포트로 분류. app+pkg만 import 가능. 비워두면 비활성화. |
 | `WithRequireAlias(bool)` | 도메인 루트에 alias 파일 필수 여부 |
 | `WithAliasFileName("alias.go")` | alias 파일명 |
 | `WithRequireModel(bool)` | 도메인에 모델 디렉토리 필수 여부 |
@@ -267,17 +269,28 @@ import _ "myapp/internal/domain/order"  // 위반: pkg가 도메인에 의존
 
 ### `isolation.stray-imports-domain`
 
-도메인이 아닌 내부 패키지(orchestration/cmd/pkg 제외)는 도메인을 import할 수 없습니다.
+도메인이 아닌 내부 패키지(orchestration/cmd/pkg/app/transport 제외)는 도메인을 import할 수 없습니다.
 
-**Import 매트릭스:**
+### `isolation.transport-imports-domain`
 
-| from | 도메인 루트 | 도메인 하위 | 오케스트레이션 | 공유 패키지 |
-|------|:-:|:-:|:-:|:-:|
-| **같은 도메인** | O | O | X | O |
-| **다른 도메인** | X | X | X | O |
-| **오케스트레이션** | O | X | O | O |
-| **cmd** | O | X | O | O |
-| **공유 패키지** | X | X | X | O |
+트랜스포트 패키지(`internal/server/<proto>/`)는 도메인 하위 패키지를 직접 import할 수 없습니다.
+컴포지션 루트(`internal/app/`)를 통해야 합니다.
+
+### `isolation.transport-imports-orchestration`
+
+트랜스포트 패키지는 오케스트레이션을 직접 import할 수 없습니다.
+
+**Import 매트릭스 (DDD + app/server):**
+
+| from | 도메인 루트 | 도메인 하위 | 오케스트레이션 | 공유 패키지 | app | 트랜스포트 |
+|------|:-:|:-:|:-:|:-:|:-:|:-:|
+| **같은 도메인** | O | O | X | O | X | X |
+| **다른 도메인** | X | X | X | O | X | X |
+| **오케스트레이션** | O | X | O | O | X | X |
+| **cmd** | O | X | O | O | X | X |
+| **공유 패키지** | X | X | X | O | X | X |
+| **app (컴포지션 루트)** | O | O | O | O | O | X |
+| **트랜스포트** | X | X | X | O | O | O |
 
 > **Flat 레이아웃 프리셋** (ConsumerWorker, Batch, EventPipeline): 격리할 도메인이 없으므로
 > 격리 규칙이 완전히 스킵됩니다.

--- a/README.md
+++ b/README.md
@@ -301,6 +301,16 @@ import _ "myapp/internal/app"                       // correct: go through compo
 
 Transport packages must not import orchestration directly.
 
+### `isolation.transport-imports-unclassified`
+
+Transport packages must not import unclassified internal packages (e.g. `internal/config`, `internal/bootstrap`).
+Anything transport depends on must be routed through `internal/app/` (the composition root) or `internal/pkg/`.
+
+```go
+// internal/server/http/server.go
+import _ "myapp/internal/config"  // violation: transport imports unclassified package
+```
+
 **Import matrix (DDD with app/server):**
 
 | from | domain root | domain sub-pkg | orchestration | shared pkg | app | transport |

--- a/README.md
+++ b/README.md
@@ -195,6 +195,8 @@ All model options:
 | `WithDomainDir("domain")` | top-level directory name for domains |
 | `WithOrchestrationDir("orchestration")` | top-level directory name for orchestration |
 | `WithSharedDir("pkg")` | top-level directory name for shared packages |
+| `WithAppDir("app")` | top-level composition-root directory (e.g. `internal/app/`). Packages here may import anything. Empty to disable. |
+| `WithServerDir("server")` | top-level transport directory (e.g. `internal/server/`). Any subdirectory is a protocol transport. Restricted to app+pkg imports. Empty to disable. |
 | `WithRequireAlias(bool)` | whether domain roots must define alias.go |
 | `WithAliasFileName("alias.go")` | name of the alias file |
 | `WithRequireModel(bool)` | whether domains must have a model directory |
@@ -282,17 +284,34 @@ Only `cmd/` and orchestration itself may depend on orchestration.
 
 ### `isolation.stray-imports-domain`
 
-Non-domain internal packages (other than orchestration/cmd/pkg) must not import domains.
+Non-domain internal packages (other than orchestration/cmd/pkg/app/transport) must not import domains.
 
-**Import matrix:**
+### `isolation.transport-imports-domain`
 
-| from | domain root | domain sub-pkg | orchestration | shared pkg |
-|------|:-:|:-:|:-:|:-:|
-| **same domain** | Yes | Yes | No | Yes |
-| **other domain** | No | No | No | Yes |
-| **orchestration** | Yes | No | Yes | Yes |
-| **cmd** | Yes | No | Yes | Yes |
-| **shared pkg** | No | No | No | Yes |
+Transport packages (`internal/server/<proto>/`) must not import domain sub-packages directly.
+They should go through the composition root (`internal/app/`) instead.
+
+```go
+// internal/server/http/handler.go
+import _ "myapp/internal/domain/order/core/model"  // violation: transport imports domain directly
+import _ "myapp/internal/app"                       // correct: go through composition root
+```
+
+### `isolation.transport-imports-orchestration`
+
+Transport packages must not import orchestration directly.
+
+**Import matrix (DDD with app/server):**
+
+| from | domain root | domain sub-pkg | orchestration | shared pkg | app | transport |
+|------|:-:|:-:|:-:|:-:|:-:|:-:|
+| **same domain** | Yes | Yes | No | Yes | No | No |
+| **other domain** | No | No | No | Yes | No | No |
+| **orchestration** | Yes | No | Yes | Yes | No | No |
+| **cmd** | Yes | No | Yes | Yes | No | No |
+| **shared pkg** | No | No | No | Yes | No | No |
+| **app (composition root)** | Yes | Yes | Yes | Yes | Yes | No |
+| **transport** | No | No | No | Yes | Yes | Yes |
 
 > **Flat-layout presets** (ConsumerWorker, Batch, EventPipeline): isolation rules are
 > skipped entirely --- there are no domains to isolate.

--- a/docs/model-concepts.md
+++ b/docs/model-concepts.md
@@ -124,6 +124,46 @@ rules.WithSharedDir("pkg")  // internal/pkg/ (DDD default)
 
 ---
 
+### `AppDir`
+
+**What:** the name of the top-level directory under `internal/` that acts as the composition root (DI wiring, container setup).
+
+**Why:** packages under `AppDir` are classified as `kindApp`. The isolation rule grants them unrestricted import privileges — they are the composition root and must be able to wire together any combination of domain, orchestration, and shared packages.
+
+**Set to `""`** to disable. When non-empty, `NewModel` adds it to `InternalTopLevel` automatically.
+
+**Default in DDD:** `"app"` (`internal/app/`).
+
+**Example:**
+
+```go
+rules.WithAppDir("container")  // internal/container/
+rules.WithAppDir("")           // disable composition-root privilege
+```
+
+---
+
+### `ServerDir`
+
+**What:** the name of the top-level directory under `internal/` that groups transport layers. Any subdirectory under `ServerDir` is treated as a protocol-specific transport (e.g. `server/http`, `server/grpc`). No protocol whitelist — any subdirectory counts.
+
+**Why:** packages under `ServerDir/<proto>/` are classified as `kindTransport`. The isolation rule restricts them: they may only import `AppDir` (composition root) and `SharedDir` (shared utilities). Direct imports of domain packages or orchestration from transport layers trigger violations.
+
+Transport-to-domain restriction (`isolation.transport-imports-domain`) enforces the pattern where HTTP/gRPC handlers depend on the app container, not on domain internals directly.
+
+**Set to `""`** to disable. When non-empty, `NewModel` adds it to `InternalTopLevel` automatically.
+
+**Default in DDD:** `"server"` (`internal/server/`).
+
+**Example:**
+
+```go
+rules.WithServerDir("transport")  // internal/transport/http/, internal/transport/grpc/
+rules.WithServerDir("")           // disable transport isolation
+```
+
+---
+
 ### `InternalTopLevel`
 
 **What:** the set of directory names allowed directly under `internal/`.

--- a/docs/model-concepts.md
+++ b/docs/model-concepts.md
@@ -147,9 +147,14 @@ rules.WithAppDir("")           // disable composition-root privilege
 
 **What:** the name of the top-level directory under `internal/` that groups transport layers. Any subdirectory under `ServerDir` is treated as a protocol-specific transport (e.g. `server/http`, `server/grpc`). No protocol whitelist — any subdirectory counts.
 
-**Why:** packages under `ServerDir/<proto>/` are classified as `kindTransport`. The isolation rule restricts them: they may only import `AppDir` (composition root) and `SharedDir` (shared utilities). Direct imports of domain packages or orchestration from transport layers trigger violations.
+**Why:** packages under `ServerDir/<proto>/` are classified as `kindTransport`. The isolation rule restricts them: they may only import `AppDir` (composition root), `SharedDir` (shared utilities), or other transport packages. Imports of domain packages, orchestration, or unclassified internal packages from transport layers trigger violations.
 
-Transport-to-domain restriction (`isolation.transport-imports-domain`) enforces the pattern where HTTP/gRPC handlers depend on the app container, not on domain internals directly.
+Rule IDs emitted for transport source violations:
+- `isolation.transport-imports-domain` — transport imports domain (root or sub-package) directly
+- `isolation.transport-imports-orchestration` — transport imports orchestration directly
+- `isolation.transport-imports-unclassified` — transport imports an unclassified internal package (e.g. `internal/config`, `internal/bootstrap`)
+
+All three enforce the pattern where HTTP/gRPC handlers depend on the app container (or shared pkg), not on arbitrary internal code.
 
 **Set to `""`** to disable. When non-empty, `NewModel` adds it to `InternalTopLevel` automatically.
 

--- a/docs/presets.md
+++ b/docs/presets.md
@@ -44,7 +44,7 @@ DDD cross-layer isolation (composition root and transport):
 | source | allowed targets | forbidden targets |
 |--------|----------------|-------------------|
 | `internal/app/` (composition root) | anything | — |
-| `internal/server/<proto>/` (transport) | `internal/app/`, `internal/pkg/` | `internal/domain/` (direct), `internal/orchestration/` |
+| `internal/server/<proto>/` (transport) | `internal/app/`, `internal/pkg/`, sibling transport | `internal/domain/` (direct), `internal/orchestration/`, unclassified internal packages |
 
 ## Clean Architecture Layout
 

--- a/docs/presets.md
+++ b/docs/presets.md
@@ -19,11 +19,14 @@ internal/
 │       │   └── svc/              # domain service interface
 │       ├── event/                # domain events
 │       └── infra/persistence/    # outbound adapters
+├── app/                          # composition root (DI wiring)
+├── server/
+│   └── http/                     # transport layer (http, grpc, …)
 ├── orchestration/                # cross-domain coordination
 └── pkg/                          # shared utilities
 ```
 
-DDD layer direction:
+DDD layer direction (intra-domain sublayers):
 
 | from | allowed to import |
 |------|-------------------|
@@ -35,6 +38,13 @@ DDD layer direction:
 | `core/svc` | `core/model` |
 | `event` | `core/model` |
 | `infra` | `core/repo`, `core/model`, `event` |
+
+DDD cross-layer isolation (composition root and transport):
+
+| source | allowed targets | forbidden targets |
+|--------|----------------|-------------------|
+| `internal/app/` (composition root) | anything | — |
+| `internal/server/<proto>/` (transport) | `internal/app/`, `internal/pkg/` | `internal/domain/` (direct), `internal/orchestration/` |
 
 ## Clean Architecture Layout
 

--- a/plugins/go-arch-guard/skills/go-arch-guard/SKILL.md
+++ b/plugins/go-arch-guard/skills/go-arch-guard/SKILL.md
@@ -110,21 +110,29 @@ go test -run TestArchitecture -v
 ### DDD (기본값)
 
 ```text
-internal/domain/{domain}/
-├── alias.go           # public surface (필수)
-├── handler/           # 인바운드 어댑터
-├── app/               # 애플리케이션 서비스
-├── core/model/        # 도메인 모델 (필수)
-├── core/repo/         # 레포지토리 인터페이스
-├── core/svc/          # 도메인 서비스 인터페이스
-├── event/             # 도메인 이벤트
-└── infra/             # 아웃바운드 어댑터
+internal/
+├── domain/{domain}/
+│   ├── alias.go           # public surface (필수)
+│   ├── handler/           # 인바운드 어댑터
+│   ├── app/               # 애플리케이션 서비스
+│   ├── core/model/        # 도메인 모델 (필수)
+│   ├── core/repo/         # 레포지토리 인터페이스
+│   ├── core/svc/          # 도메인 서비스 인터페이스
+│   ├── event/             # 도메인 이벤트
+│   └── infra/             # 아웃바운드 어댑터
+├── app/                   # 컴포지션 루트 (DI 와이어링)
+├── server/
+│   └── http/              # 트랜스포트 레이어 (http, grpc, …)
+├── orchestration/         # 크로스 도메인 조정
+└── pkg/                   # 공유 유틸리티
 ```
 
 - `alias.go` 필수, domain root에 다른 .go 금지
 - `core/model/`에 최소 1개 .go 필수
 - `core/*`, `event`는 `internal/pkg` import 금지
 - interface는 `core/repo/`에만 정의
+- `internal/app/` (컴포지션 루트): 무제한 import 가능
+- `internal/server/<proto>/` (트랜스포트): `internal/app/`과 `internal/pkg/`만 import 가능. 도메인 직접 import 금지 (`isolation.transport-imports-domain`)
 
 ### Clean Architecture
 

--- a/plugins/go-arch-guard/skills/go-arch-guard/SKILL.md
+++ b/plugins/go-arch-guard/skills/go-arch-guard/SKILL.md
@@ -132,7 +132,7 @@ internal/
 - `core/*`, `event`는 `internal/pkg` import 금지
 - interface는 `core/repo/`에만 정의
 - `internal/app/` (컴포지션 루트): 무제한 import 가능
-- `internal/server/<proto>/` (트랜스포트): `internal/app/`과 `internal/pkg/`만 import 가능. 도메인 직접 import 금지 (`isolation.transport-imports-domain`)
+- `internal/server/<proto>/` (트랜스포트): `internal/app/`, `internal/pkg/`, 형제 트랜스포트만 import 가능. 위반 규칙: `isolation.transport-imports-domain`, `isolation.transport-imports-orchestration`, `isolation.transport-imports-unclassified`
 
 ### Clean Architecture
 

--- a/rules/classify.go
+++ b/rules/classify.go
@@ -14,6 +14,8 @@ const (
 	kindDomainRoot
 	kindCmd
 	kindUnclassified
+	kindApp       // internal/<AppDir>/...
+	kindTransport // internal/<ServerDir>/<proto>/...
 )
 
 type classified struct {
@@ -34,6 +36,24 @@ func classifyInternalPackage(m Model, pkgPath, internalPrefix string) classified
 	// Shared/pkg check first
 	if m.SharedDir != "" && isUnderInternalDir(pkgPath, internalPrefix, m.SharedDir) {
 		return classified{Kind: kindShared}
+	}
+
+	// App (composition root) check
+	if m.AppDir != "" && isUnderInternalDir(pkgPath, internalPrefix, m.AppDir) {
+		return classified{Kind: kindApp}
+	}
+
+	// Transport (server/<proto>) check — must be under ServerDir/<any-proto>/
+	if m.ServerDir != "" {
+		rel := strings.TrimPrefix(pkgPath, internalPrefix)
+		serverPrefix := m.ServerDir + "/"
+		if strings.HasPrefix(rel, serverPrefix) {
+			// rel is now "server/<proto>[/...]" — must have at least one proto segment
+			after := strings.TrimPrefix(rel, serverPrefix)
+			if after != "" {
+				return classified{Kind: kindTransport}
+			}
+		}
 	}
 
 	// Orchestration check

--- a/rules/classify_test.go
+++ b/rules/classify_test.go
@@ -122,6 +122,84 @@ func TestClassifyInternalPackage_FlatLayout(t *testing.T) {
 	}
 }
 
+func TestClassifyInternalPackage_AppAndTransport(t *testing.T) {
+	m := DDD()
+	internalPrefix := "example.com/myapp/internal/"
+
+	tests := []struct {
+		name     string
+		pkgPath  string
+		wantKind internalKind
+	}{
+		{
+			name:     "app composition root",
+			pkgPath:  "example.com/myapp/internal/app",
+			wantKind: kindApp,
+		},
+		{
+			name:     "app sub-package",
+			pkgPath:  "example.com/myapp/internal/app/container",
+			wantKind: kindApp,
+		},
+		{
+			name:     "transport http server",
+			pkgPath:  "example.com/myapp/internal/server/http",
+			wantKind: kindTransport,
+		},
+		{
+			name:     "transport grpc server",
+			pkgPath:  "example.com/myapp/internal/server/grpc",
+			wantKind: kindTransport,
+		},
+		{
+			name:     "transport sub-package",
+			pkgPath:  "example.com/myapp/internal/server/http/middleware",
+			wantKind: kindTransport,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyInternalPackage(m, tc.pkgPath, internalPrefix)
+			if got.Kind != tc.wantKind {
+				t.Errorf("Kind = %v, want %v", got.Kind, tc.wantKind)
+			}
+		})
+	}
+}
+
+func TestClassifyInternalPackage_AppAndTransport_Disabled(t *testing.T) {
+	// When AppDir/ServerDir are empty, these should be kindUnclassified
+	m := CleanArch() // CleanArch doesn't have AppDir/ServerDir
+	internalPrefix := "example.com/myapp/internal/"
+
+	tests := []struct {
+		name     string
+		pkgPath  string
+		wantKind internalKind
+	}{
+		{
+			name:     "app is unclassified without AppDir",
+			pkgPath:  "example.com/myapp/internal/app",
+			wantKind: kindUnclassified,
+		},
+		{
+			name:     "server is unclassified without ServerDir",
+			pkgPath:  "example.com/myapp/internal/server/http",
+			wantKind: kindUnclassified,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyInternalPackage(m, tc.pkgPath, internalPrefix)
+			if got.Kind != tc.wantKind {
+				t.Errorf("Kind = %v, want %v", got.Kind, tc.wantKind)
+			}
+		})
+	}
+}
+
 func TestClassifyInternalPackage_EventPipeline(t *testing.T) {
 	m := EventPipeline()
 	internalPrefix := "example.com/myapp/internal/"

--- a/rules/isolation.go
+++ b/rules/isolation.go
@@ -69,6 +69,11 @@ func CheckDomainIsolation(pkgs []*packages.Package, projectModule string, projec
 		// any known bucket (domain/, orchestration/, shared/). They may still
 		// import domains/orchestration and must be checked as "stray" sources.
 
+		// kindApp is a composition root — it may import anything. Skip all checks.
+		if src.Kind == kindApp {
+			continue
+		}
+
 		for impPath := range pkg.Imports {
 			if !strings.HasPrefix(impPath, internalPrefix) {
 				continue
@@ -79,6 +84,37 @@ func CheckDomainIsolation(pkgs []*packages.Package, projectModule string, projec
 			// Rule 2: import pkg/ → always allowed for anyone except pkg/ itself
 			// (pkg/ → pkg/ is just intra-shared and still allowed).
 			if imp.Kind == kindShared && src.Kind != kindShared {
+				continue
+			}
+
+			// kindTransport: may only import app, pkg, or other transport.
+			// Must not import domain or orchestration directly.
+			if src.Kind == kindTransport {
+				if imp.Kind == kindDomain || imp.Kind == kindDomainRoot {
+					file, line := findImportPosition(pkg, impPath, projectRoot)
+					violations = append(violations, Violation{
+						File:     file,
+						Line:     line,
+						Rule:     "isolation.transport-imports-domain",
+						Message:  fmt.Sprintf("transport package %q must not import domain %q directly", pkg.PkgPath, imp.Domain),
+						Fix:      fmt.Sprintf("import %s/ (the app/composition root) instead of domain sub-packages directly", m.AppDir),
+						Severity: cfg.Sev,
+					})
+					continue
+				}
+				if imp.Kind == kindOrchestration {
+					file, line := findImportPosition(pkg, impPath, projectRoot)
+					violations = append(violations, Violation{
+						File:     file,
+						Line:     line,
+						Rule:     "isolation.transport-imports-orchestration",
+						Message:  fmt.Sprintf("transport package %q must not import %s directly", pkg.PkgPath, m.OrchestrationDir),
+						Fix:      fmt.Sprintf("transport layers should only import %s/ (composition root) and %s/ (shared utilities)", m.AppDir, m.SharedDir),
+						Severity: cfg.Sev,
+					})
+					continue
+				}
+				// app, pkg, transport → allowed
 				continue
 			}
 

--- a/rules/isolation.go
+++ b/rules/isolation.go
@@ -88,9 +88,13 @@ func CheckDomainIsolation(pkgs []*packages.Package, projectModule string, projec
 			}
 
 			// kindTransport: may only import app, pkg, or other transport.
-			// Must not import domain or orchestration directly.
+			// Everything else (domain, orchestration, unclassified) is forbidden.
 			if src.Kind == kindTransport {
-				if imp.Kind == kindDomain || imp.Kind == kindDomainRoot {
+				switch imp.Kind {
+				case kindApp, kindShared, kindTransport:
+					// allowed
+					continue
+				case kindDomain, kindDomainRoot:
 					file, line := findImportPosition(pkg, impPath, projectRoot)
 					violations = append(violations, Violation{
 						File:     file,
@@ -101,8 +105,7 @@ func CheckDomainIsolation(pkgs []*packages.Package, projectModule string, projec
 						Severity: cfg.Sev,
 					})
 					continue
-				}
-				if imp.Kind == kindOrchestration {
+				case kindOrchestration:
 					file, line := findImportPosition(pkg, impPath, projectRoot)
 					violations = append(violations, Violation{
 						File:     file,
@@ -113,8 +116,21 @@ func CheckDomainIsolation(pkgs []*packages.Package, projectModule string, projec
 						Severity: cfg.Sev,
 					})
 					continue
+				case kindUnclassified:
+					file, line := findImportPosition(pkg, impPath, projectRoot)
+					violations = append(violations, Violation{
+						File:     file,
+						Line:     line,
+						Rule:     "isolation.transport-imports-unclassified",
+						Message:  fmt.Sprintf("transport package %q must not import unclassified internal package %q", pkg.PkgPath, impPath),
+						Fix:      fmt.Sprintf("move the dependency into internal/%s (expose via Container), internal/%s, or another transport package", m.AppDir, m.SharedDir),
+						Severity: cfg.Sev,
+					})
+					continue
+				case kindCmd:
+					// cmd imports transport, not the other way; unreachable in practice.
+					continue
 				}
-				// app, pkg, transport → allowed
 				continue
 			}
 

--- a/rules/isolation_test.go
+++ b/rules/isolation_test.go
@@ -232,3 +232,104 @@ func TestCheckDomainIsolation(t *testing.T) {
 	})
 
 }
+
+func TestCheckDomainIsolation_TransportCannotImportDomain(t *testing.T) {
+	root := t.TempDir()
+	module := "example.com/dddapp"
+
+	writeTestFile(t, filepath.Join(root, "go.mod"), "module "+module+"\n\ngo 1.21\n")
+
+	// domain/order/core/model
+	writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "alias.go"), "package order\n")
+	writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "core", "model", "model.go"), "package model\ntype Order struct{}\n")
+
+	// internal/app/container.go — legal: imports domain (kindApp can import anything)
+	writeTestFile(t, filepath.Join(root, "internal", "app", "container.go"),
+		"package app\n\nimport _ \""+module+"/internal/domain/order/core/model\"\n")
+
+	// internal/server/http/server.go — legal: imports internal/app only
+	writeTestFile(t, filepath.Join(root, "internal", "server", "http", "server.go"),
+		"package http\n\nimport _ \""+module+"/internal/app\"\n")
+
+	// internal/server/http/bad.go — ILLEGAL: transport imports domain directly
+	writeTestFile(t, filepath.Join(root, "internal", "server", "http", "bad.go"),
+		"package http\n\nimport _ \""+module+"/internal/domain/order/core/model\"\n")
+
+	pkgs := loadTestPackages(t, root)
+	violations := rules.CheckDomainIsolation(pkgs, module, root, rules.WithModel(rules.DDD()))
+
+	found := false
+	for _, v := range violations {
+		if v.Rule == "isolation.transport-imports-domain" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		for _, v := range violations {
+			t.Logf("violation: %s", v.String())
+		}
+		t.Error("expected isolation.transport-imports-domain violation")
+	}
+}
+
+func TestCheckDomainIsolation_AppCanImportAnything(t *testing.T) {
+	root := t.TempDir()
+	module := "example.com/dddapp2"
+
+	writeTestFile(t, filepath.Join(root, "go.mod"), "module "+module+"\n\ngo 1.21\n")
+
+	// domain/order/core/model
+	writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "alias.go"), "package order\n")
+	writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "core", "model", "model.go"), "package model\ntype Order struct{}\n")
+
+	// domain/user/core/model
+	writeTestFile(t, filepath.Join(root, "internal", "domain", "user", "alias.go"), "package user\n")
+	writeTestFile(t, filepath.Join(root, "internal", "domain", "user", "core", "model", "model.go"), "package model\ntype User struct{}\n")
+
+	// internal/orchestration — cross-domain coordination
+	writeTestFile(t, filepath.Join(root, "internal", "orchestration", "orch.go"), "package orchestration\n")
+
+	// internal/app/container.go — imports multiple domains (legal)
+	writeTestFile(t, filepath.Join(root, "internal", "app", "container.go"),
+		"package app\n\nimport (\n\t_ \""+module+"/internal/domain/order/core/model\"\n\t_ \""+module+"/internal/domain/user/core/model\"\n\t_ \""+module+"/internal/orchestration\"\n)\n")
+
+	pkgs := loadTestPackages(t, root)
+	violations := rules.CheckDomainIsolation(pkgs, module, root, rules.WithModel(rules.DDD()))
+
+	for _, v := range violations {
+		t.Errorf("expected no violations for kindApp, got: %s", v.String())
+	}
+}
+
+func TestCheckDomainIsolation_TransportCannotImportOrchestration(t *testing.T) {
+	root := t.TempDir()
+	module := "example.com/dddapp3"
+
+	writeTestFile(t, filepath.Join(root, "go.mod"), "module "+module+"\n\ngo 1.21\n")
+
+	writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "alias.go"), "package order\n")
+	writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "core", "model", "model.go"), "package model\ntype Order struct{}\n")
+	writeTestFile(t, filepath.Join(root, "internal", "orchestration", "orch.go"), "package orchestration\n")
+
+	// transport imports orchestration — ILLEGAL
+	writeTestFile(t, filepath.Join(root, "internal", "server", "http", "bad.go"),
+		"package http\n\nimport _ \""+module+"/internal/orchestration\"\n")
+
+	pkgs := loadTestPackages(t, root)
+	violations := rules.CheckDomainIsolation(pkgs, module, root, rules.WithModel(rules.DDD()))
+
+	found := false
+	for _, v := range violations {
+		if v.Rule == "isolation.transport-imports-orchestration" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		for _, v := range violations {
+			t.Logf("violation: %s", v.String())
+		}
+		t.Error("expected isolation.transport-imports-orchestration violation")
+	}
+}

--- a/rules/isolation_test.go
+++ b/rules/isolation_test.go
@@ -2,6 +2,7 @@ package rules_test
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/NamhaeSusan/go-arch-guard/analyzer"
@@ -331,5 +332,64 @@ func TestCheckDomainIsolation_TransportCannotImportOrchestration(t *testing.T) {
 			t.Logf("violation: %s", v.String())
 		}
 		t.Error("expected isolation.transport-imports-orchestration violation")
+	}
+}
+
+func TestCheckDomainIsolation_TransportCannotImportUnclassified(t *testing.T) {
+	root := t.TempDir()
+	module := "example.com/dddapp4"
+
+	writeTestFile(t, filepath.Join(root, "go.mod"), "module "+module+"\n\ngo 1.21\n")
+
+	writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "alias.go"), "package order\n")
+	writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "core", "model", "model.go"), "package model\ntype Order struct{}\n")
+
+	// internal/bootstrap is unclassified (not domain/orchestration/shared/app/server).
+	writeTestFile(t, filepath.Join(root, "internal", "bootstrap", "xyz", "boot.go"), "package xyz\n")
+
+	// transport imports unclassified package — ILLEGAL under tightened policy.
+	writeTestFile(t, filepath.Join(root, "internal", "server", "http", "bad.go"),
+		"package http\n\nimport _ \""+module+"/internal/bootstrap/xyz\"\n")
+
+	pkgs := loadTestPackages(t, root)
+	violations := rules.CheckDomainIsolation(pkgs, module, root, rules.WithModel(rules.DDD()))
+
+	var transportUnclassified []rules.Violation
+	for _, v := range violations {
+		if v.Rule == "isolation.transport-imports-unclassified" {
+			transportUnclassified = append(transportUnclassified, v)
+		}
+	}
+	if len(transportUnclassified) != 1 {
+		for _, v := range violations {
+			t.Logf("violation: %s", v.String())
+		}
+		t.Fatalf("expected exactly 1 isolation.transport-imports-unclassified violation, got %d", len(transportUnclassified))
+	}
+}
+
+func TestCheckDomainIsolation_TransportCanImportSharedPkg(t *testing.T) {
+	root := t.TempDir()
+	module := "example.com/dddapp5"
+
+	writeTestFile(t, filepath.Join(root, "go.mod"), "module "+module+"\n\ngo 1.21\n")
+
+	writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "alias.go"), "package order\n")
+	writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "core", "model", "model.go"), "package model\ntype Order struct{}\n")
+
+	// internal/pkg/logger — shared utility
+	writeTestFile(t, filepath.Join(root, "internal", "pkg", "logger", "logger.go"), "package logger\n")
+
+	// transport imports internal/pkg/... — LEGAL.
+	writeTestFile(t, filepath.Join(root, "internal", "server", "http", "server.go"),
+		"package http\n\nimport _ \""+module+"/internal/pkg/logger\"\n")
+
+	pkgs := loadTestPackages(t, root)
+	violations := rules.CheckDomainIsolation(pkgs, module, root, rules.WithModel(rules.DDD()))
+
+	for _, v := range violations {
+		if strings.HasPrefix(v.Rule, "isolation.transport-") {
+			t.Errorf("expected no transport-* violations, got: %s", v.String())
+		}
 	}
 }

--- a/rules/layer.go
+++ b/rules/layer.go
@@ -33,8 +33,9 @@ func CheckLayerDirection(pkgs []*packages.Package, projectModule string, project
 
 		src := classifyInternalPackage(m, pkg.PkgPath, internalPrefix)
 		// The layer rule only reasons about domain-shaped sources. Domain
-		// root / orchestration / shared / unclassified are not subject to
-		// direction checks here; they are handled by isolation or skipped.
+		// root / orchestration / shared / unclassified / app / transport
+		// are not subject to direction checks here; they are handled by
+		// isolation or skipped.
 		if src.Kind != kindDomain {
 			continue
 		}

--- a/rules/model.go
+++ b/rules/model.go
@@ -3,13 +3,20 @@ package rules
 // Model defines the architecture model used by all rule checks.
 // Use DDD(), CleanArch(), Layered(), Hexagonal(), ModularMonolith(), ConsumerWorker(), Batch(), EventPipeline(), or NewModel() to create one.
 type Model struct {
-	Sublayers               []string
-	Direction               map[string][]string
-	PkgRestricted           map[string]bool
-	InternalTopLevel        map[string]bool
-	DomainDir               string
-	OrchestrationDir        string
-	SharedDir               string
+	Sublayers        []string
+	Direction        map[string][]string
+	PkgRestricted    map[string]bool
+	InternalTopLevel map[string]bool
+	DomainDir        string
+	OrchestrationDir string
+	SharedDir        string
+	// AppDir is the top-level composition-root directory under internal/.
+	// e.g. "app". Empty to disable kindApp classification.
+	AppDir string
+	// ServerDir is the top-level transport directory under internal/.
+	// Any subdirectory under ServerDir counts as a transport layer (e.g. server/http, server/grpc).
+	// e.g. "server". Empty to disable kindTransport classification.
+	ServerDir               string
 	RequireAlias            bool
 	AliasFileName           string
 	RequireModel            bool
@@ -74,10 +81,13 @@ func DDD() Model {
 		},
 		InternalTopLevel: map[string]bool{
 			"domain": true, "orchestration": true, "pkg": true,
+			"app": true, "server": true,
 		},
 		DomainDir:        "domain",
 		OrchestrationDir: "orchestration",
 		SharedDir:        "pkg",
+		AppDir:           "app",
+		ServerDir:        "server",
 		RequireAlias:     true,
 		AliasFileName:    "alias.go",
 		RequireModel:     true,
@@ -424,6 +434,12 @@ func NewModel(opts ...ModelOption) Model {
 	if m.SharedDir != "" {
 		tl[m.SharedDir] = true
 	}
+	if m.AppDir != "" {
+		tl[m.AppDir] = true
+	}
+	if m.ServerDir != "" {
+		tl[m.ServerDir] = true
+	}
 	m.InternalTopLevel = tl
 	return m
 }
@@ -497,4 +513,12 @@ func WithPortLayers(layers []string) ModelOption {
 
 func WithContractLayers(layers []string) ModelOption {
 	return func(m *Model) { m.ContractLayers = layers }
+}
+
+func WithAppDir(s string) ModelOption {
+	return func(m *Model) { m.AppDir = s }
+}
+
+func WithServerDir(s string) ModelOption {
+	return func(m *Model) { m.ServerDir = s }
 }

--- a/rules/model_test.go
+++ b/rules/model_test.go
@@ -5,6 +5,21 @@ import (
 	"testing"
 )
 
+func TestDDD_IncludesAppAndServer(t *testing.T) {
+	m := DDD()
+	for _, dir := range []string{"app", "server"} {
+		if !m.InternalTopLevel[dir] {
+			t.Errorf("DDD InternalTopLevel missing %q", dir)
+		}
+	}
+	if m.AppDir != "app" {
+		t.Errorf("AppDir = %q, want %q", m.AppDir, "app")
+	}
+	if m.ServerDir != "server" {
+		t.Errorf("ServerDir = %q, want %q", m.ServerDir, "server")
+	}
+}
+
 func TestDDD_ReturnsValidModel(t *testing.T) {
 	m := DDD()
 	if len(m.Sublayers) == 0 {

--- a/rules/structure.go
+++ b/rules/structure.go
@@ -419,8 +419,17 @@ func isDTOAllowedSublayerWith(m Model, relPath string) bool {
 func isMisplacedLayerDirWith(m Model, rel, name string) bool {
 	switch name {
 	case "app", "infra":
+		if name == "app" && m.AppDir != "" && rel == filepath.ToSlash(filepath.Join("internal", m.AppDir)) {
+			return false
+		}
 		return !matchesDomainLayerWith(m, rel, name)
 	case "handler":
+		if m.ServerDir != "" {
+			serverBase := filepath.ToSlash(filepath.Join("internal", m.ServerDir))
+			if strings.HasPrefix(rel, serverBase+"/") || rel == serverBase {
+				return false
+			}
+		}
 		return !matchesDomainLayerWith(m, rel, name) && rel != filepath.ToSlash(filepath.Join("internal", m.OrchestrationDir, "handler"))
 	default:
 		return false

--- a/rules/structure_test.go
+++ b/rules/structure_test.go
@@ -540,4 +540,32 @@ type Order = model.Order
 			t.Error("expected internal-top-level violation for randomstuff/ in flat layout")
 		}
 	})
+
+	t.Run("DDD preset allows internal/app as composition root", func(t *testing.T) {
+		root := t.TempDir()
+		writeTestFile(t, filepath.Join(root, "internal", "app", "container.go"), "package app\n")
+		writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "alias.go"), "package order\n")
+		writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "core", "model", "order.go"), "package model\n")
+
+		violations := rules.CheckStructure(root)
+		for _, v := range violations {
+			if v.Rule == "structure.misplaced-layer" && v.File == "internal/app/" {
+				t.Errorf("internal/app should not be a misplaced-layer violation in DDD preset, got: %s", v.String())
+			}
+		}
+	})
+
+	t.Run("DDD preset allows internal/server as transport root", func(t *testing.T) {
+		root := t.TempDir()
+		writeTestFile(t, filepath.Join(root, "internal", "server", "http", "server.go"), "package http\n")
+		writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "alias.go"), "package order\n")
+		writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "core", "model", "order.go"), "package model\n")
+
+		violations := rules.CheckStructure(root)
+		for _, v := range violations {
+			if v.Rule == "structure.misplaced-layer" && strings.HasPrefix(v.File, "internal/server/") {
+				t.Errorf("internal/server/ should not be a misplaced-layer violation in DDD preset, got: %s", v.String())
+			}
+		}
+	})
 }

--- a/testdata/ddd-appserver/go.mod
+++ b/testdata/ddd-appserver/go.mod
@@ -1,0 +1,3 @@
+module github.com/kimtaeyun/testproject-ddd-appserver
+
+go 1.23

--- a/testdata/ddd-appserver/internal/app/container.go
+++ b/testdata/ddd-appserver/internal/app/container.go
@@ -1,0 +1,4 @@
+package app
+
+// Importing multiple domains is legal for the composition root.
+import _ "github.com/kimtaeyun/testproject-ddd-appserver/internal/domain/order/core/model"

--- a/testdata/ddd-appserver/internal/domain/order/alias.go
+++ b/testdata/ddd-appserver/internal/domain/order/alias.go
@@ -1,0 +1,1 @@
+package order

--- a/testdata/ddd-appserver/internal/domain/order/core/model/model.go
+++ b/testdata/ddd-appserver/internal/domain/order/core/model/model.go
@@ -1,0 +1,6 @@
+package model
+
+// Order is a domain model.
+type Order struct {
+	ID string
+}

--- a/testdata/ddd-appserver/internal/orchestration/orch.go
+++ b/testdata/ddd-appserver/internal/orchestration/orch.go
@@ -1,0 +1,1 @@
+package orchestration

--- a/testdata/ddd-appserver/internal/server/http/bad.go
+++ b/testdata/ddd-appserver/internal/server/http/bad.go
@@ -1,0 +1,4 @@
+package http
+
+// BAD: transport must not import domain directly (should go through app).
+import _ "github.com/kimtaeyun/testproject-ddd-appserver/internal/domain/order/core/model"

--- a/testdata/ddd-appserver/internal/server/http/server.go
+++ b/testdata/ddd-appserver/internal/server/http/server.go
@@ -1,0 +1,4 @@
+package http
+
+// Importing app is legal for transport.
+import _ "github.com/kimtaeyun/testproject-ddd-appserver/internal/app"


### PR DESCRIPTION
## Summary

- Adds `AppDir` and `ServerDir` fields to `Model` struct with `WithAppDir`/`WithServerDir` options
- Updates `DDD()` preset to set `AppDir="app"`, `ServerDir="server"`, and include both in `InternalTopLevel`
- Extends `classifyInternalPackage` with two new kinds: `kindApp` (composition root) and `kindTransport` (transport layer)
- Adds isolation rules: `kindApp` may import anything; `kindTransport` may only import app+pkg (not domain or orchestration directly)
- New rule IDs: `isolation.transport-imports-domain`, `isolation.transport-imports-orchestration`
- `NewModel` now includes `AppDir`/`ServerDir` in the rebuilt `InternalTopLevel`
- `CheckLayerDirection` naturally skips `kindApp`/`kindTransport` (they are not `kindDomain`)

## Test plan

- [ ] `go test ./... -count=1` passes (all 7 packages green)
- [ ] `make lint` reports 0 issues
- [ ] `TestDDD_IncludesAppAndServer` — verifies AppDir/ServerDir fields and InternalTopLevel entries
- [ ] `TestClassifyInternalPackage_AppAndTransport` — verifies kindApp/kindTransport classification
- [ ] `TestClassifyInternalPackage_AppAndTransport_Disabled` — verifies ClassArch without AppDir/ServerDir is kindUnclassified
- [ ] `TestCheckDomainIsolation_TransportCannotImportDomain` — verifies isolation.transport-imports-domain fires
- [ ] `TestCheckDomainIsolation_AppCanImportAnything` — verifies no violations for kindApp importing multiple domains
- [ ] `TestCheckDomainIsolation_TransportCannotImportOrchestration` — verifies isolation.transport-imports-orchestration fires
- [ ] `testdata/ddd-appserver/` fixture added (container.go legal, server.go legal, bad.go triggers violation)
- [ ] Docs updated: README.md, README.ko.md, docs/presets.md, docs/model-concepts.md, SKILL.md

## Backward compatibility

Additive only: `InternalTopLevel` gains `app` and `server` in DDD preset. Existing DDD projects without those dirs are unaffected. New transport-to-domain isolation rule only fires on `internal/server/<proto>/` paths, which don't exist in projects that haven't migrated.