### PR TITLE
refactor(rules/naming): split option.go and fix snake_case helpers

### DIFF
--- a/rules/naming/no_stutter.go
+++ b/rules/naming/no_stutter.go
@@ -9,26 +9,6 @@ import (
 	"github.com/NamhaeSusan/go-arch-guard/core/analysisutil"
 )
 
-type Option func(*ruleConfig)
-
-type ruleConfig struct {
-	severity core.Severity
-}
-
-func WithSeverity(severity core.Severity) Option {
-	return func(cfg *ruleConfig) {
-		cfg.severity = severity
-	}
-}
-
-func newConfig(opts []Option, severity core.Severity) ruleConfig {
-	cfg := ruleConfig{severity: severity}
-	for _, opt := range opts {
-		opt(&cfg)
-	}
-	return cfg
-}
-
 type NoStutter struct {
 	severity core.Severity
 }

--- a/rules/naming/option.go
+++ b/rules/naming/option.go
@@ -1,0 +1,23 @@
+package naming
+
+import "github.com/NamhaeSusan/go-arch-guard/core"
+
+type Option func(*ruleConfig)
+
+type ruleConfig struct {
+	severity core.Severity
+}
+
+func WithSeverity(severity core.Severity) Option {
+	return func(cfg *ruleConfig) {
+		cfg.severity = severity
+	}
+}
+
+func newConfig(opts []Option, severity core.Severity) ruleConfig {
+	cfg := ruleConfig{severity: severity}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return cfg
+}

--- a/rules/naming/repo_file_interface.go
+++ b/rules/naming/repo_file_interface.go
@@ -88,7 +88,7 @@ func (r *RepoFileInterface) checkPortPackage(ctx *core.Context, pkg *packages.Pa
 			0,
 			"structure.repo-file-extra-interface",
 			`file "`+base+`" in repo/ must define only "`+expected+`", found extra: `+strings.Join(extra, ", "),
-			"move each extra interface to its own file (e.g. "+strings.ToLower(extra[0])+".go)",
+			"move each extra interface to its own file (e.g. "+pascalToSnake(extra[0])+".go)",
 		))
 	}
 	return violations

--- a/rules/naming/repo_file_interface_test.go
+++ b/rules/naming/repo_file_interface_test.go
@@ -51,6 +51,30 @@ func TestRepoFileInterfaceFlagsExtraInterfaces(t *testing.T) {
 	}
 }
 
+func TestRepoFileInterfaceExtraInterfaceFixUsesSnakeCase(t *testing.T) {
+	ctx := tempContext(t, map[string]string{
+		"internal/domain/order/core/repo/order.go": "package repo\n\ntype Order interface { Find() }\ntype UserRepository interface { Save() }\n",
+	}, dddArch())
+
+	got := naming.NewRepoFileInterface().Check(ctx)
+	var found bool
+	for _, v := range got {
+		if v.Rule != "structure.repo-file-extra-interface" {
+			continue
+		}
+		found = true
+		if !strings.Contains(v.Fix, "user_repository.go") {
+			t.Fatalf("Fix = %q, want it to suggest user_repository.go", v.Fix)
+		}
+		if strings.Contains(v.Fix, "userrepository.go") {
+			t.Fatalf("Fix = %q, must not suggest userrepository.go", v.Fix)
+		}
+	}
+	if !found {
+		t.Fatalf("expected extra-interface violation, got %+v", got)
+	}
+}
+
 func TestRepoFileInterfaceFlagsRepositoryPortOutsidePortLayer(t *testing.T) {
 	got := naming.NewRepoFileInterface().Check(invalidContext(t, nil))
 

--- a/rules/naming/snake_case_files.go
+++ b/rules/naming/snake_case_files.go
@@ -75,19 +75,29 @@ func isSnakeCase(filename string) bool {
 
 func toSnakeCase(filename string) string {
 	ext := filepath.Ext(filename)
-	name := strings.TrimSuffix(filename, ext)
+	return pascalToSnake(strings.TrimSuffix(filename, ext)) + ext
+}
+
+// pascalToSnake converts a PascalCase / camelCase / mixed identifier to
+// snake_case. Runs of uppercase are kept together as one word; an underscore
+// is inserted only at a real word boundary:
+//   - between a lowercase/digit and an uppercase ("createOrder" -> "create_order")
+//   - between an uppercase and an uppercase that is followed by a lowercase
+//     ("XMLParser" -> "xml_parser")
+func pascalToSnake(name string) string {
+	runes := []rune(name)
 	var result []rune
-	for i, r := range name {
-		if unicode.IsUpper(r) {
-			if i > 0 {
+	for i, r := range runes {
+		if i > 0 && unicode.IsUpper(r) {
+			prev := runes[i-1]
+			nextLower := i+1 < len(runes) && unicode.IsLower(runes[i+1])
+			if unicode.IsLower(prev) || unicode.IsDigit(prev) || (unicode.IsUpper(prev) && nextLower) {
 				result = append(result, '_')
 			}
-			result = append(result, unicode.ToLower(r))
-			continue
 		}
-		result = append(result, r)
+		result = append(result, unicode.ToLower(r))
 	}
-	return string(result) + ext
+	return string(result)
 }
 
 var _ core.Rule = (*SnakeCaseFiles)(nil)

--- a/rules/naming/snake_case_files_test.go
+++ b/rules/naming/snake_case_files_test.go
@@ -33,6 +33,30 @@ func TestSnakeCaseFilesFlagsNonSnakeCaseGoFile(t *testing.T) {
 	}
 }
 
+func TestSnakeCaseFilesFixHandlesUppercaseRuns(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"createOrder.go", "create_order.go"},
+		{"XMLParser.go", "xml_parser.go"},
+		{"HTTP.go", "http.go"},
+		{"HTTPServer.go", "http_server.go"},
+		{"parseHTTPRequest.go", "parse_http_request.go"},
+	}
+	for _, tc := range cases {
+		ctx := tempContext(t, map[string]string{
+			"internal/domain/order/app/" + tc.in: "package app\n",
+		}, dddArch())
+		got := naming.NewSnakeCaseFiles().Check(ctx)
+		if len(got) != 1 {
+			t.Fatalf("%s: len = %d, want 1: %+v", tc.in, len(got), got)
+		}
+		if !strings.Contains(got[0].Fix, tc.want) {
+			t.Fatalf("%s: Fix = %q, want it to contain %q", tc.in, got[0].Fix, tc.want)
+		}
+	}
+}
+
 func TestSnakeCaseFilesSkipsExcludedPath(t *testing.T) {
 	ctx := core.NewContext(loadInvalid(t), "github.com/kimtaeyun/testproject-dc-invalid", "../../testdata/invalid", dddArch(), []string{"internal/domain/order/handler/..."})
 


### PR DESCRIPTION
## Summary

Address three issues found during a step-by-step review of `rules/naming/`:

- **#36** — Move shared `Option` / `ruleConfig` / `WithSeverity` / `newConfig` out of `no_stutter.go` into a new `option.go`. Pure refactor; the file name now reflects ownership of the package-wide config surface.
- **#37** — Fix the `structure.repo-file-extra-interface` violation hint. It was using `strings.ToLower(extra[0])` to suggest a filename, producing `userrepository.go` for `UserRepository`. Now uses snake_case (`user_repository.go`), consistent with how this rule maps filenames → interface names elsewhere.
- **#38** — Rewrite `toSnakeCase` so runs of uppercase are a single word: `XMLParser.go` → `xml_parser.go` (was `x_m_l_parser.go`). Shared via `pascalToSnake`, also reused by `repo_file_interface.go` for #37.

No public API changes. README/SKILL.md untouched.

Closes #36, closes #37, closes #38.

## Test plan

- [x] `go test ./rules/naming/...`
- [x] `go test ./...`
- [x] `goimports -w .`
- [x] `make lint` — 0 issues
- [x] New test cases:
  - `TestSnakeCaseFilesFixHandlesUppercaseRuns` — table covers `createOrder`, `XMLParser`, `HTTP`, `HTTPServer`, `parseHTTPRequest`.
  - `TestRepoFileInterfaceExtraInterfaceFixUsesSnakeCase` — asserts the fix hint contains `user_repository.go` and not `userrepository.go`.
- [x] `code-reviewer` agent — approve, no critical issues.