### PR TITLE
refactor(types/analysisutil): unify Option, extract shared helpers, support generics, drop internal/ hardcoding

### DIFF
--- a/core/analysisutil/ast.go
+++ b/core/analysisutil/ast.go
@@ -6,6 +6,48 @@ import (
 	"strings"
 )
 
+// ReceiverTypeName extracts the unqualified receiver type name from an
+// *ast.FuncDecl receiver expression. It unwraps a leading pointer and
+// handles generic receivers — *ast.IndexExpr (T[U]) and *ast.IndexListExpr
+// (T[U, V]) — so callers do not silently miss methods on parameterized
+// types. Returns "" if the expression does not match a recognized shape.
+func ReceiverTypeName(expr ast.Expr) string {
+	if star, ok := expr.(*ast.StarExpr); ok {
+		expr = star.X
+	}
+	switch t := expr.(type) {
+	case *ast.Ident:
+		return t.Name
+	case *ast.IndexExpr:
+		if id, ok := t.X.(*ast.Ident); ok {
+			return id.Name
+		}
+	case *ast.IndexListExpr:
+		if id, ok := t.X.(*ast.Ident); ok {
+			return id.Name
+		}
+	}
+	return ""
+}
+
+// SnakeToPascal converts a snake_case identifier (e.g. "user_repository")
+// to PascalCase (e.g. "UserRepository"). Empty segments are skipped, so
+// leading/trailing/double underscores do not produce empty letters. Input
+// is assumed to be ASCII; non-ASCII first bytes in a segment are not
+// case-converted but are preserved.
+func SnakeToPascal(s string) string {
+	parts := strings.Split(s, "_")
+	var b strings.Builder
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		b.WriteString(strings.ToUpper(part[:1]))
+		b.WriteString(part[1:])
+	}
+	return b.String()
+}
+
 func ResolveIdentImportPath(file *ast.File, identName string) string {
 	for _, imp := range file.Imports {
 		impPath := strings.Trim(imp.Path.Value, `"`)

--- a/core/analysisutil/ast_test.go
+++ b/core/analysisutil/ast_test.go
@@ -9,6 +9,61 @@ import (
 	"testing"
 )
 
+func TestReceiverTypeName(t *testing.T) {
+	src := `package sample
+type Foo struct{}
+func (f Foo) A() {}
+func (f *Foo) B() {}
+type Bar[T any] struct{}
+func (b Bar[T]) C() {}
+func (b *Bar[T]) D() {}
+type Baz[K comparable, V any] struct{}
+func (z *Baz[K, V]) E() {}
+`
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "sample.go", src, parser.AllErrors)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"Foo", "Foo", "Bar", "Bar", "Baz"}
+	var got []string
+	for _, decl := range file.Decls {
+		fd, ok := decl.(*ast.FuncDecl)
+		if !ok || fd.Recv == nil {
+			continue
+		}
+		got = append(got, ReceiverTypeName(fd.Recv.List[0].Type))
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d names, want %d: %v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestSnakeToPascal(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"user_repository", "UserRepository"},
+		{"order", "Order"},
+		{"a_b_c", "ABC"},
+		{"", ""},
+		{"_leading", "Leading"},
+		{"trailing_", "Trailing"},
+		{"double__underscore", "DoubleUnderscore"},
+	}
+	for _, tc := range cases {
+		if got := SnakeToPascal(tc.in); got != tc.want {
+			t.Fatalf("SnakeToPascal(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
 func TestResolveIdentImportPath(t *testing.T) {
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, "sample.go", `package sample

--- a/rules/naming/no_hand_mock.go
+++ b/rules/naming/no_hand_mock.go
@@ -72,7 +72,7 @@ func (r *NoHandMock) checkFile(path, relPath string) []core.Violation {
 		if !ok || fd.Recv == nil || len(fd.Recv.List) == 0 {
 			continue
 		}
-		recvName := receiverTypeName(fd.Recv.List[0].Type)
+		recvName := analysisutil.ReceiverTypeName(fd.Recv.List[0].Type)
 		line, ok := structs[recvName]
 		if !ok {
 			continue
@@ -113,16 +113,6 @@ func collectMockStructs(fset *token.FileSet, file *ast.File) map[string]int {
 		}
 	}
 	return result
-}
-
-func receiverTypeName(expr ast.Expr) string {
-	if star, ok := expr.(*ast.StarExpr); ok {
-		expr = star.X
-	}
-	if ident, ok := expr.(*ast.Ident); ok {
-		return ident.Name
-	}
-	return ""
 }
 
 var _ core.Rule = (*NoHandMock)(nil)

--- a/rules/naming/repo_file_interface.go
+++ b/rules/naming/repo_file_interface.go
@@ -62,7 +62,7 @@ func (r *RepoFileInterface) checkPortPackage(ctx *core.Context, pkg *packages.Pa
 		if ctx.IsExcluded(relPath) {
 			continue
 		}
-		expected := snakeToPascal(strings.TrimSuffix(base, ".go"))
+		expected := analysisutil.SnakeToPascal(strings.TrimSuffix(base, ".go"))
 		ifaces := collectInterfacesFromFile(file)
 		if _, ok := ifaces[expected]; !ok {
 			violations = append(violations, r.violation(
@@ -140,19 +140,6 @@ func (r *RepoFileInterface) violation(file string, line int, rule, message, fix 
 		DefaultSeverity:   r.severity,
 		EffectiveSeverity: r.severity,
 	}
-}
-
-func snakeToPascal(s string) string {
-	parts := strings.Split(s, "_")
-	var b strings.Builder
-	for _, part := range parts {
-		if part == "" {
-			continue
-		}
-		b.WriteString(strings.ToUpper(part[:1]))
-		b.WriteString(part[1:])
-	}
-	return b.String()
 }
 
 func collectInterfacesFromFile(file *ast.File) map[string]*ast.InterfaceType {

--- a/rules/types/no_setter.go
+++ b/rules/types/no_setter.go
@@ -34,11 +34,8 @@ type NoSetter struct {
 }
 
 func NewNoSetter(opts ...Option) *NoSetter {
-	r := &NoSetter{severity: core.Warning}
-	for _, opt := range opts {
-		opt.applyNoSetter(r)
-	}
-	return r
+	cfg := newConfig(opts, core.Warning)
+	return &NoSetter{severity: cfg.severity}
 }
 
 func (r *NoSetter) Spec() core.RuleSpec {
@@ -128,19 +125,14 @@ func receiverTypeString(fd *ast.FuncDecl) string {
 	if fd.Recv == nil || len(fd.Recv.List) == 0 {
 		return ""
 	}
-	return receiverTypeName(fd.Recv.List[0].Type)
+	return analysisutil.ReceiverTypeName(fd.Recv.List[0].Type)
 }
 
 func isFluentBuilder(fd *ast.FuncDecl) bool {
 	if fd.Type.Results == nil || len(fd.Type.Results.List) != 1 {
 		return false
 	}
-	result := fd.Type.Results.List[0].Type
-	if star, ok := result.(*ast.StarExpr); ok {
-		result = star.X
-	}
-	ident, ok := result.(*ast.Ident)
-	return ok && ident.Name == receiverTypeString(fd)
+	return analysisutil.ReceiverTypeName(fd.Type.Results.List[0].Type) == receiverTypeString(fd)
 }
 
 func autoExcludedFile(filename string) bool {

--- a/rules/types/no_setter_test.go
+++ b/rules/types/no_setter_test.go
@@ -1,6 +1,8 @@
 package types_test
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -64,6 +66,58 @@ func TestNoSetterFlagsClassicSetters(t *testing.T) {
 		if v.DefaultSeverity != core.Warning || v.EffectiveSeverity != core.Warning {
 			t.Fatalf("setter severity = default %v effective %v, want Warning/Warning", v.DefaultSeverity, v.EffectiveSeverity)
 		}
+	}
+}
+
+func TestNoSetterHandlesGenericReceivers(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte("module example.com/gen\n\ngo 1.25.0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "internal", "model"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	src := `package model
+
+type Stack[T any] struct{ items []T }
+func (s *Stack[T]) SetTop(v T) { s.items[len(s.items)-1] = v }
+
+type Builder[T any] struct{ v T }
+func (b *Builder[T]) SetValue(v T) *Builder[T] { b.v = v; return b }
+
+type Pair[K comparable, V any] struct{ k K; v V }
+func (p *Pair[K, V]) SetKey(k K) { p.k = k }
+`
+	if err := os.WriteFile(filepath.Join(root, "internal", "model", "gen.go"), []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	pkgs, err := analyzer.Load(root, "internal/...")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := core.NewContext(pkgs, "example.com/gen", root, core.Architecture{}, nil)
+	got := types.NewNoSetter().Check(ctx)
+
+	var setTop, setKey, setValue int
+	for _, v := range got {
+		switch {
+		case strings.Contains(v.Message, "SetTop"):
+			setTop++
+		case strings.Contains(v.Message, "SetKey"):
+			setKey++
+		case strings.Contains(v.Message, "SetValue"):
+			setValue++
+		}
+	}
+	if setTop != 1 {
+		t.Fatalf("Stack[T].SetTop: got %d violations, want 1: %+v", setTop, got)
+	}
+	if setKey != 1 {
+		t.Fatalf("Pair[K,V].SetKey: got %d violations, want 1: %+v", setKey, got)
+	}
+	if setValue != 0 {
+		t.Fatalf("Builder[T].SetValue is fluent: got %d violations, want 0: %+v", setValue, got)
 	}
 }
 

--- a/rules/types/option.go
+++ b/rules/types/option.go
@@ -1,0 +1,23 @@
+package types
+
+import "github.com/NamhaeSusan/go-arch-guard/core"
+
+type Option func(*ruleConfig)
+
+type ruleConfig struct {
+	severity core.Severity
+}
+
+func WithSeverity(severity core.Severity) Option {
+	return func(cfg *ruleConfig) {
+		cfg.severity = severity
+	}
+}
+
+func newConfig(opts []Option, severity core.Severity) ruleConfig {
+	cfg := ruleConfig{severity: severity}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return cfg
+}

--- a/rules/types/type_pattern.go
+++ b/rules/types/type_pattern.go
@@ -36,33 +36,9 @@ type TypePattern struct {
 	severity core.Severity
 }
 
-type Option interface {
-	applyNoSetter(*NoSetter)
-	applyTypePattern(*TypePattern)
-}
-
-type severityOption struct {
-	severity core.Severity
-}
-
-func WithSeverity(s core.Severity) Option {
-	return severityOption{severity: s}
-}
-
-func (o severityOption) applyNoSetter(r *NoSetter) {
-	r.severity = o.severity
-}
-
-func (o severityOption) applyTypePattern(r *TypePattern) {
-	r.severity = o.severity
-}
-
 func NewTypePattern(opts ...Option) *TypePattern {
-	r := &TypePattern{severity: core.Error}
-	for _, opt := range opts {
-		opt.applyTypePattern(r)
-	}
-	return r
+	cfg := newConfig(opts, core.Error)
+	return &TypePattern{severity: cfg.severity}
 }
 
 func (r *TypePattern) Spec() core.RuleSpec {
@@ -88,7 +64,7 @@ func (r *TypePattern) Check(ctx *core.Context) []core.Violation {
 }
 
 func (r *TypePattern) checkPackage(ctx *core.Context, pkg *packages.Package, pattern core.TypePattern) []core.Violation {
-	if pkg == nil || !strings.HasSuffix(pkg.PkgPath, "/internal/"+pattern.Dir) {
+	if pkg == nil || !strings.HasSuffix(pkg.PkgPath, "/"+pattern.Dir) {
 		return nil
 	}
 
@@ -110,7 +86,7 @@ func (r *TypePattern) checkPackage(ctx *core.Context, pkg *packages.Package, pat
 			continue
 		}
 
-		expectedType := snakeToPascal(suffix) + pattern.TypeSuffix
+		expectedType := analysisutil.SnakeToPascal(suffix) + pattern.TypeSuffix
 		if !hasExportedType(file, expectedType) {
 			violations = append(violations, core.Violation{
 				File:              relPath,
@@ -173,35 +149,11 @@ func collectMethods(pkg *packages.Package) map[string]bool {
 			if !ok || fd.Recv == nil || len(fd.Recv.List) == 0 {
 				continue
 			}
-			typeName := receiverTypeName(fd.Recv.List[0].Type)
+			typeName := analysisutil.ReceiverTypeName(fd.Recv.List[0].Type)
 			if typeName != "" {
 				result[typeName+"."+fd.Name.Name] = true
 			}
 		}
 	}
 	return result
-}
-
-func receiverTypeName(expr ast.Expr) string {
-	if star, ok := expr.(*ast.StarExpr); ok {
-		expr = star.X
-	}
-	ident, ok := expr.(*ast.Ident)
-	if !ok {
-		return ""
-	}
-	return ident.Name
-}
-
-func snakeToPascal(s string) string {
-	parts := strings.Split(s, "_")
-	var b strings.Builder
-	for _, part := range parts {
-		if part == "" {
-			continue
-		}
-		b.WriteString(strings.ToUpper(part[:1]))
-		b.WriteString(part[1:])
-	}
-	return b.String()
 }

--- a/rules/types/type_pattern_test.go
+++ b/rules/types/type_pattern_test.go
@@ -1,12 +1,25 @@
 package types_test
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/NamhaeSusan/go-arch-guard/analyzer"
 	"github.com/NamhaeSusan/go-arch-guard/core"
 	types "github.com/NamhaeSusan/go-arch-guard/rules/types"
 )
+
+func writeTempFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
 
 func typePatternArch() core.Architecture {
 	return core.Architecture{
@@ -68,6 +81,53 @@ func TestTypePatternFlagsMissingTypeAndMethod(t *testing.T) {
 
 	if mismatch != 1 || missingMethod != 1 {
 		t.Fatalf("mismatch=%d missingMethod=%d, want 1/1; all violations: %+v", mismatch, missingMethod, got)
+	}
+}
+
+func TestTypePatternMatchesFlatLayout(t *testing.T) {
+	root := t.TempDir()
+	writeTempFile(t, filepath.Join(root, "go.mod"), "module example.com/flat\n\ngo 1.25.0\n")
+	writeTempFile(t, filepath.Join(root, "worker", "worker_order.go"), "package worker\n\ntype OrderWorker struct{}\n\nfunc (w *OrderWorker) Process() {}\n")
+	writeTempFile(t, filepath.Join(root, "worker", "worker_payment.go"), "package worker\n\ntype Payment struct{}\n")
+
+	pkgs, err := analyzer.Load(root, "worker/...")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := core.NewContext(pkgs, "example.com/flat", root, typePatternArch(), nil)
+	got := types.NewTypePattern().Check(ctx)
+
+	var mismatch int
+	for _, v := range got {
+		if v.Rule == "naming.type-pattern-mismatch" && strings.Contains(v.File, "worker_payment.go") {
+			mismatch++
+		}
+		if strings.Contains(v.File, "worker_order.go") {
+			t.Fatalf("valid worker should not be flagged: %+v", v)
+		}
+	}
+	if mismatch != 1 {
+		t.Fatalf("expected 1 mismatch in flat layout, got %d: %+v", mismatch, got)
+	}
+}
+
+func TestTypePatternIgnoresPrefixSubstringDirs(t *testing.T) {
+	root := t.TempDir()
+	writeTempFile(t, filepath.Join(root, "go.mod"), "module example.com/edge\n\ngo 1.25.0\n")
+	writeTempFile(t, filepath.Join(root, "oldworker", "worker_thing.go"), "package oldworker\n\ntype Thing struct{}\n")
+	writeTempFile(t, filepath.Join(root, "worker", "sub", "worker_other.go"), "package sub\n\ntype Other struct{}\n")
+
+	pkgs, err := analyzer.Load(root, "...")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := core.NewContext(pkgs, "example.com/edge", root, typePatternArch(), nil)
+	got := types.NewTypePattern().Check(ctx)
+
+	for _, v := range got {
+		if strings.Contains(v.File, "oldworker") || strings.Contains(v.File, "worker/sub") {
+			t.Fatalf("non-matching dir incorrectly flagged: %+v", v)
+		}
 	}
 }
 


### PR DESCRIPTION
> **Stacked on #39.** Base will auto-rebase to `main` once #39 merges.

## Summary

Cross-cutting cleanup found during `rules/types/` review:

- **#40** — Promote `snakeToPascal` and `receiverTypeName` (duplicated across `rules/naming` and `rules/types`) into `core/analysisutil` as `SnakeToPascal` / `ReceiverTypeName`.
- **#41** — Replace the visitor-style `Option` interface in `rules/types` with the functional pattern used in `rules/naming`. Adds `rules/types/option.go`. **Breaking** for anyone implementing `types.Option` themselves (no in-repo callers); `types.WithSeverity(...)` callers unaffected.
- **#42** — `TypePattern` rule no longer requires an `internal/` prefix. Now fires on flat (`./worker/...`), DDD (`./internal/worker/...`), and monorepo (`./services/x/worker/...`) layouts. The leading `/` in the suffix match still rules out `oldworker` / `worker/sub` false matches.
- **#43** — `analysisutil.ReceiverTypeName` handles `*ast.IndexExpr` and `*ast.IndexListExpr`, fixing a false positive in `NoSetter` for fluent generic builders (`func (b *Builder[T]) SetX(v T) *Builder[T]`).

Closes #40, closes #41, closes #42, closes #43.

## Test plan

- [x] `go test ./...` — all packages green
- [x] `goimports -w .`
- [x] `make lint` — 0 issues
- [x] New tests:
  - `core/analysisutil/ast_test.go::TestReceiverTypeName` — 5 receiver shapes (Foo, *Foo, Foo[T], *Foo[T], *Foo[K,V])
  - `core/analysisutil/ast_test.go::TestSnakeToPascal` — 7 cases incl. empty, leading/trailing/double underscores
  - `rules/types/no_setter_test.go::TestNoSetterHandlesGenericReceivers` — Stack[T].SetTop flagged, Pair[K,V].SetKey flagged, Builder[T].SetValue exempt as fluent
  - `rules/types/type_pattern_test.go::TestTypePatternMatchesFlatLayout` — flat `<m>/worker/worker_*.go` fires
  - `rules/types/type_pattern_test.go::TestTypePatternIgnoresPrefixSubstringDirs` — `oldworker` and `worker/sub` correctly ignored
- [x] code-reviewer agent — APPROVE, no critical issues

## Public API impact

- **Compatible**: `types.WithSeverity(s core.Severity) Option` signature unchanged.
- **Breaking** (theoretical): the `types.Option` type is now `func(*ruleConfig)` instead of an interface. No in-repo or known external implementers exist; all callers pass `types.WithSeverity(...)` or nothing.
- README/SKILL.md mention `types.WithSeverity` in code examples — those still compile as-is.