### PR TITLE
refactor(dependency): unify Option, decompose Isolation.Check, signal flat layouts

### DIFF
--- a/rules/dependency/blast_radius.go
+++ b/rules/dependency/blast_radius.go
@@ -12,11 +12,8 @@ import (
 type BlastRadius struct{ severity core.Severity }
 
 func NewBlastRadius(opts ...Option) *BlastRadius {
-	r := &BlastRadius{severity: core.Warning}
-	for _, opt := range opts {
-		r.severity = opt.severity()
-	}
-	return r
+	cfg := newConfig(opts, core.Warning)
+	return &BlastRadius{severity: cfg.severity}
 }
 
 func (r *BlastRadius) Spec() core.RuleSpec {
@@ -30,13 +27,17 @@ func (r *BlastRadius) Spec() core.RuleSpec {
 
 func (r *BlastRadius) Check(ctx *core.Context) []core.Violation {
 	projectModule := analysisutil.ResolveModuleFromContext(ctx, "")
-	if warns := validateModule(ctx.Pkgs(), projectModule); len(warns) > 0 {
+	pkgs := ctx.Pkgs()
+	if warns := validateModule(pkgs, projectModule); len(warns) > 0 {
 		return warns
+	}
+	if !hasInternalPackages(pkgs, projectModule) {
+		return []core.Violation{metaLayoutNotSupported("dependency.blast-radius", projectModule)}
 	}
 
 	internalPrefix := projectModule + "/internal/"
 	internalPkgs := make(map[string]bool)
-	for _, pkg := range ctx.Pkgs() {
+	for _, pkg := range pkgs {
 		if strings.HasPrefix(pkg.PkgPath, internalPrefix) &&
 			!isExcludedPackage(ctx, pkg.PkgPath, projectModule) {
 			internalPkgs[pkg.PkgPath] = true

--- a/rules/dependency/blast_radius_test.go
+++ b/rules/dependency/blast_radius_test.go
@@ -68,6 +68,12 @@ func TestBlastRadiusDetectsOutlier(t *testing.T) {
 	}
 }
 
+func TestBlastRadiusFlatLayoutEmitsMetaWarning(t *testing.T) {
+	ctx := loadFlatLayoutContext(t)
+	violations := dependency.NewBlastRadius().Check(ctx)
+	assertExactlyOneMetaLayoutNotSupported(t, violations, "dependency.blast-radius")
+}
+
 func TestBlastRadiusExclude(t *testing.T) {
 	ctx := loadContextWithExclude(t,
 		"../../testdata/blast",

--- a/rules/dependency/isolation.go
+++ b/rules/dependency/isolation.go
@@ -12,25 +12,10 @@ import (
 
 type Isolation struct{ severity core.Severity }
 
-type Option interface {
-	severity() core.Severity
-}
-
-type severityOption core.Severity
-
 func NewIsolation(opts ...Option) *Isolation {
-	r := &Isolation{severity: core.Error}
-	for _, opt := range opts {
-		r.severity = opt.severity()
-	}
-	return r
+	cfg := newConfig(opts, core.Error)
+	return &Isolation{severity: cfg.severity}
 }
-
-func WithSeverity(s core.Severity) Option {
-	return severityOption(s)
-}
-
-func (o severityOption) severity() core.Severity { return core.Severity(o) }
 
 func (r *Isolation) Spec() core.RuleSpec {
 	return core.RuleSpec{
@@ -62,153 +47,181 @@ func (r *Isolation) Check(ctx *core.Context) []core.Violation {
 
 	projectModule := analysisutil.ResolveModuleFromContext(ctx, "")
 	projectRoot := analysisutil.ResolveRootFromContext(ctx, "")
-	if warns := validateModule(ctx.Pkgs(), projectModule); len(warns) > 0 {
+	pkgs := ctx.Pkgs()
+	if warns := validateModule(pkgs, projectModule); len(warns) > 0 {
 		return warns
+	}
+	if !hasInternalPackages(pkgs, projectModule) {
+		return []core.Violation{metaLayoutNotSupported("dependency.isolation", projectModule)}
 	}
 
 	internalPrefix := projectModule + "/internal/"
 	cmdPrefix := projectModule + "/cmd"
 	var violations []core.Violation
 
-	for _, pkg := range ctx.Pkgs() {
+	for _, pkg := range pkgs {
 		if isExcludedPackage(ctx, pkg.PkgPath, projectModule) {
 			continue
 		}
-
 		if pkg.PkgPath == cmdPrefix || strings.HasPrefix(pkg.PkgPath, cmdPrefix+"/") {
-			if !arch.Structure.RequireAlias {
-				continue
-			}
-			for impPath := range pkg.Imports {
-				if !strings.HasPrefix(impPath, internalPrefix) {
-					continue
-				}
-				imp := classifyInternalPackage(arch, impPath, internalPrefix)
-				if imp.Kind != kindDomain {
-					continue
-				}
-				file, line := analysisutil.FindImportPosition(pkg, impPath, projectRoot)
-				violations = append(violations, r.violation(file, line,
-					"isolation.cmd-deep-import",
-					fmt.Sprintf("cmd/ must only import domain alias, not sub-package %q", impPath),
-					fmt.Sprintf("import the domain alias package instead: %s%s/%s", internalPrefix, layout.DomainDir, imp.Domain),
-				))
-			}
+			violations = append(violations, r.checkCmdPackage(pkg, arch, projectRoot, internalPrefix)...)
 			continue
 		}
-
 		if !strings.HasPrefix(pkg.PkgPath, internalPrefix) {
 			continue
 		}
-
 		src := classifyInternalPackage(arch, pkg.PkgPath, internalPrefix)
 		if src.Kind == kindApp {
 			continue
 		}
-
 		for impPath := range pkg.Imports {
 			if !strings.HasPrefix(impPath, internalPrefix) {
 				continue
 			}
-
 			imp := classifyInternalPackage(arch, impPath, internalPrefix)
-			if imp.Kind == kindShared && src.Kind != kindShared {
-				continue
-			}
-
-			if src.Kind == kindTransport {
-				violations = append(violations, r.checkTransportImport(pkg, projectRoot, impPath, layout, imp)...)
-				continue
-			}
-
-			if (src.Kind == kindDomain || src.Kind == kindDomainRoot) &&
-				(imp.Kind == kindDomain || imp.Kind == kindDomainRoot) &&
-				src.Domain != "" && src.Domain == imp.Domain {
-				continue
-			}
-
-			if src.Kind == kindOrchestration {
-				if imp.Kind != kindDomain || !arch.Structure.RequireAlias {
-					continue
-				}
-				label := layout.OrchestrationDir
-				if isOrchestrationHandlerWith(arch, pkg.PkgPath, internalPrefix) {
-					label = layout.OrchestrationDir + " handler"
-				}
-				file, line := analysisutil.FindImportPosition(pkg, impPath, projectRoot)
-				violations = append(violations, r.violation(file, line,
-					"isolation.orchestration-deep-import",
-					fmt.Sprintf("%s must only import domain alias, not sub-package %q", label, impPath),
-					fmt.Sprintf("import the domain alias package instead: %s%s/%s", internalPrefix, layout.DomainDir, imp.Domain),
-				))
-				continue
-			}
-
-			if src.Kind == kindShared {
-				if imp.Kind == kindDomain || imp.Kind == kindDomainRoot {
-					file, line := analysisutil.FindImportPosition(pkg, impPath, projectRoot)
-					violations = append(violations, r.violation(file, line,
-						"isolation.pkg-imports-domain",
-						fmt.Sprintf("%s/ must not import domain %q", layout.SharedDir, imp.Domain),
-						fmt.Sprintf("%s/ should only contain shared utilities with no domain or orchestration dependencies", layout.SharedDir),
-					))
-					continue
-				}
-				if imp.Kind == kindOrchestration {
-					file, line := analysisutil.FindImportPosition(pkg, impPath, projectRoot)
-					violations = append(violations, r.violation(file, line,
-						"isolation.pkg-imports-orchestration",
-						fmt.Sprintf("%s/ must not import %s", layout.SharedDir, layout.OrchestrationDir),
-						fmt.Sprintf("move %s-aware code to internal/%s or cmd/", layout.OrchestrationDir, layout.OrchestrationDir),
-					))
-					continue
-				}
-			}
-
-			if imp.Kind == kindOrchestration {
-				file, line := analysisutil.FindImportPosition(pkg, impPath, projectRoot)
-				if src.Kind == kindDomain || src.Kind == kindDomainRoot {
-					violations = append(violations, r.violation(file, line,
-						"isolation.domain-imports-orchestration",
-						fmt.Sprintf("domain %q must not import %s", src.Domain, layout.OrchestrationDir),
-						fmt.Sprintf("move cross-domain coordination to internal/%s callers instead of domain internals", layout.OrchestrationDir),
-					))
-					continue
-				}
-				violations = append(violations, r.violation(file, line,
-					"isolation.stray-imports-orchestration",
-					fmt.Sprintf("package %q must not import %s", pkg.PkgPath, layout.OrchestrationDir),
-					fmt.Sprintf("only cmd/ and internal/%s may depend on %s", layout.OrchestrationDir, layout.OrchestrationDir),
-				))
-				continue
-			}
-
-			if (src.Kind == kindDomain || src.Kind == kindDomainRoot) &&
-				(imp.Kind == kindDomain || imp.Kind == kindDomainRoot) &&
-				src.Domain != "" && imp.Domain != "" && src.Domain != imp.Domain {
-				file, line := analysisutil.FindImportPosition(pkg, impPath, projectRoot)
-				violations = append(violations, r.violation(file, line,
-					"isolation.cross-domain",
-					fmt.Sprintf("domain %q must not import domain %q", src.Domain, imp.Domain),
-					fmt.Sprintf("use %s/ for cross-domain orchestration or move shared types to %s/", layout.OrchestrationDir, layout.SharedDir),
-				))
-				continue
-			}
-
-			if src.Kind == kindUnclassified &&
-				(imp.Kind == kindDomain || imp.Kind == kindDomainRoot) {
-				file, line := analysisutil.FindImportPosition(pkg, impPath, projectRoot)
-				violations = append(violations, r.violation(file, line,
-					"isolation.stray-imports-domain",
-					fmt.Sprintf("package %q must not import domain %q", pkg.PkgPath, imp.Domain),
-					fmt.Sprintf("move domain orchestration to internal/%s or app wiring to cmd/", layout.OrchestrationDir),
-				))
-				continue
-			}
+			violations = append(violations, r.checkInternalImport(pkg, src, imp, impPath, arch, projectRoot, internalPrefix)...)
 		}
 	}
 
 	return violations
+}
+
+func (r *Isolation) checkCmdPackage(pkg *packages.Package, arch core.Architecture, projectRoot, internalPrefix string) []core.Violation {
+	if !arch.Structure.RequireAlias {
+		return nil
+	}
+	var violations []core.Violation
+	layout := arch.Layout
+	for impPath := range pkg.Imports {
+		if !strings.HasPrefix(impPath, internalPrefix) {
+			continue
+		}
+		imp := classifyInternalPackage(arch, impPath, internalPrefix)
+		if imp.Kind != kindDomain {
+			continue
+		}
+		file, line := analysisutil.FindImportPosition(pkg, impPath, projectRoot)
+		violations = append(violations, r.violation(file, line,
+			"isolation.cmd-deep-import",
+			fmt.Sprintf("cmd/ must only import domain alias, not sub-package %q", impPath),
+			fmt.Sprintf("import the domain alias package instead: %s%s/%s", internalPrefix, layout.DomainDir, imp.Domain),
+		))
+	}
+	return violations
+}
+
+func (r *Isolation) checkInternalImport(pkg *packages.Package, src, imp classified, impPath string, arch core.Architecture, projectRoot, internalPrefix string) []core.Violation {
+	if imp.Kind == kindShared && src.Kind != kindShared {
+		return nil
+	}
+	if src.Kind == kindTransport {
+		return r.checkTransportImport(pkg, projectRoot, impPath, arch.Layout, imp)
+	}
+	if isSameDomain(src, imp) {
+		return nil
+	}
+	switch src.Kind {
+	case kindOrchestration:
+		return r.checkOrchestrationDeepImport(pkg, imp, impPath, arch, projectRoot, internalPrefix)
+	case kindShared:
+		if v := r.checkSharedImport(pkg, imp, impPath, arch.Layout, projectRoot); v != nil {
+			return v
+		}
+	}
+	if imp.Kind == kindOrchestration {
+		return r.checkOrchestrationDependent(pkg, src, impPath, arch.Layout, projectRoot)
+	}
+	if isCrossDomain(src, imp) {
+		return r.crossDomainViolation(pkg, src, imp, impPath, arch.Layout, projectRoot)
+	}
+	if src.Kind == kindUnclassified && isDomainKind(imp.Kind) {
+		return r.strayDomainViolation(pkg, imp, impPath, arch.Layout, projectRoot)
+	}
+	return nil
+}
+
+func (r *Isolation) checkOrchestrationDeepImport(pkg *packages.Package, imp classified, impPath string, arch core.Architecture, projectRoot, internalPrefix string) []core.Violation {
+	if imp.Kind != kindDomain || !arch.Structure.RequireAlias {
+		return nil
+	}
+	layout := arch.Layout
+	label := layout.OrchestrationDir
+	if isOrchestrationHandlerWith(arch, pkg.PkgPath, internalPrefix) {
+		label = layout.OrchestrationDir + " handler"
+	}
+	file, line := analysisutil.FindImportPosition(pkg, impPath, projectRoot)
+	return []core.Violation{r.violation(file, line,
+		"isolation.orchestration-deep-import",
+		fmt.Sprintf("%s must only import domain alias, not sub-package %q", label, impPath),
+		fmt.Sprintf("import the domain alias package instead: %s%s/%s", internalPrefix, layout.DomainDir, imp.Domain),
+	)}
+}
+
+func (r *Isolation) checkSharedImport(pkg *packages.Package, imp classified, impPath string, layout core.LayoutModel, projectRoot string) []core.Violation {
+	switch {
+	case isDomainKind(imp.Kind):
+		file, line := analysisutil.FindImportPosition(pkg, impPath, projectRoot)
+		return []core.Violation{r.violation(file, line,
+			"isolation.pkg-imports-domain",
+			fmt.Sprintf("%s/ must not import domain %q", layout.SharedDir, imp.Domain),
+			fmt.Sprintf("%s/ should only contain shared utilities with no domain or orchestration dependencies", layout.SharedDir),
+		)}
+	case imp.Kind == kindOrchestration:
+		file, line := analysisutil.FindImportPosition(pkg, impPath, projectRoot)
+		return []core.Violation{r.violation(file, line,
+			"isolation.pkg-imports-orchestration",
+			fmt.Sprintf("%s/ must not import %s", layout.SharedDir, layout.OrchestrationDir),
+			fmt.Sprintf("move %s-aware code to internal/%s or cmd/", layout.OrchestrationDir, layout.OrchestrationDir),
+		)}
+	}
+	return nil
+}
+
+func (r *Isolation) checkOrchestrationDependent(pkg *packages.Package, src classified, impPath string, layout core.LayoutModel, projectRoot string) []core.Violation {
+	file, line := analysisutil.FindImportPosition(pkg, impPath, projectRoot)
+	if isDomainKind(src.Kind) {
+		return []core.Violation{r.violation(file, line,
+			"isolation.domain-imports-orchestration",
+			fmt.Sprintf("domain %q must not import %s", src.Domain, layout.OrchestrationDir),
+			fmt.Sprintf("move cross-domain coordination to internal/%s callers instead of domain internals", layout.OrchestrationDir),
+		)}
+	}
+	return []core.Violation{r.violation(file, line,
+		"isolation.stray-imports-orchestration",
+		fmt.Sprintf("package %q must not import %s", pkg.PkgPath, layout.OrchestrationDir),
+		fmt.Sprintf("only cmd/ and internal/%s may depend on %s", layout.OrchestrationDir, layout.OrchestrationDir),
+	)}
+}
+
+func (r *Isolation) crossDomainViolation(pkg *packages.Package, src, imp classified, impPath string, layout core.LayoutModel, projectRoot string) []core.Violation {
+	file, line := analysisutil.FindImportPosition(pkg, impPath, projectRoot)
+	return []core.Violation{r.violation(file, line,
+		"isolation.cross-domain",
+		fmt.Sprintf("domain %q must not import domain %q", src.Domain, imp.Domain),
+		fmt.Sprintf("use %s/ for cross-domain orchestration or move shared types to %s/", layout.OrchestrationDir, layout.SharedDir),
+	)}
+}
+
+func (r *Isolation) strayDomainViolation(pkg *packages.Package, imp classified, impPath string, layout core.LayoutModel, projectRoot string) []core.Violation {
+	file, line := analysisutil.FindImportPosition(pkg, impPath, projectRoot)
+	return []core.Violation{r.violation(file, line,
+		"isolation.stray-imports-domain",
+		fmt.Sprintf("package %q must not import domain %q", pkg.PkgPath, imp.Domain),
+		fmt.Sprintf("move domain orchestration to internal/%s or app wiring to cmd/", layout.OrchestrationDir),
+	)}
+}
+
+func isDomainKind(k internalKind) bool {
+	return k == kindDomain || k == kindDomainRoot
+}
+
+func isSameDomain(a, b classified) bool {
+	return isDomainKind(a.Kind) && isDomainKind(b.Kind) && a.Domain != "" && a.Domain == b.Domain
+}
+
+func isCrossDomain(a, b classified) bool {
+	return isDomainKind(a.Kind) && isDomainKind(b.Kind) &&
+		a.Domain != "" && b.Domain != "" && a.Domain != b.Domain
 }
 
 func (r *Isolation) checkTransportImport(pkg *packages.Package, projectRoot, impPath string, layout core.LayoutModel, imp classified) []core.Violation {
@@ -391,6 +404,30 @@ func metaNoMatchingPackages(message string) core.Violation {
 		Rule:              "meta.no-matching-packages",
 		Message:           message,
 		Fix:               "verify the module argument matches go.mod",
+		DefaultSeverity:   core.Warning,
+		EffectiveSeverity: core.Warning,
+	}
+}
+
+// hasInternalPackages reports whether any loaded package lives under
+// <module>/internal/. The dependency rules in this package operate only on
+// internal/-based layouts; flat-layout projects are signaled via
+// metaLayoutNotSupported instead of silently producing zero violations.
+func hasInternalPackages(pkgs []*packages.Package, projectModule string) bool {
+	prefix := projectModule + "/internal/"
+	for _, pkg := range pkgs {
+		if strings.HasPrefix(pkg.PkgPath, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func metaLayoutNotSupported(ruleID, projectModule string) core.Violation {
+	return core.Violation{
+		Rule:              "meta.layout-not-supported",
+		Message:           fmt.Sprintf("%s requires an internal/-based layout; no internal/ packages found in module %q", ruleID, projectModule),
+		Fix:               "use this rule with internal/-based presets (DDD, CleanArch, Hexagonal, ModularMonolith), or remove it from your ruleset for flat layouts",
 		DefaultSeverity:   core.Warning,
 		EffectiveSeverity: core.Warning,
 	}

--- a/rules/dependency/isolation_test.go
+++ b/rules/dependency/isolation_test.go
@@ -2,6 +2,7 @@ package dependency_test
 
 import (
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/NamhaeSusan/go-arch-guard/analyzer"
@@ -78,6 +79,21 @@ func TestIsolationDDDAppServerTransport(t *testing.T) {
 	assertHasRule(t, violations, "isolation.transport-imports-domain")
 }
 
+func TestIsolationFlatLayoutEmitsMetaWarning(t *testing.T) {
+	ctx := loadFlatLayoutContext(t)
+	violations := dependency.NewIsolation().Check(ctx)
+	assertExactlyOneMetaLayoutNotSupported(t, violations, "dependency.isolation")
+}
+
+func TestIsolationDDDProjectHasNoMetaLayoutWarning(t *testing.T) {
+	ctx := loadContext(t, "../../testdata/valid", "github.com/kimtaeyun/testproject-dc", dddArchitecture(), "internal/...")
+	for _, v := range dependency.NewIsolation().Check(ctx) {
+		if v.Rule == "meta.layout-not-supported" {
+			t.Fatalf("internal/-based project must not emit meta.layout-not-supported: %s", v.String())
+		}
+	}
+}
+
 func TestIsolationExclude(t *testing.T) {
 	ctx := loadContextWithExclude(t,
 		"../../testdata/invalid",
@@ -94,6 +110,27 @@ func TestIsolationExclude(t *testing.T) {
 			v.File == "internal/config/orchestration.go" {
 			t.Fatalf("expected config package to be excluded, got %s", v.String())
 		}
+	}
+}
+
+func loadFlatLayoutContext(t *testing.T) *core.Context {
+	t.Helper()
+	return loadContext(t, "../../testdata/flat", "github.com/kimtaeyun/testproject-flat", dddArchitecture(), "...")
+}
+
+func assertExactlyOneMetaLayoutNotSupported(t *testing.T, violations []core.Violation, ruleID string) {
+	t.Helper()
+	var count int
+	for _, v := range violations {
+		if v.Rule == "meta.layout-not-supported" {
+			count++
+			if !strings.Contains(v.Message, ruleID) {
+				t.Fatalf("meta message should mention %q, got %q", ruleID, v.Message)
+			}
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly 1 meta.layout-not-supported, got %d: %+v", count, violations)
 	}
 }
 

--- a/rules/dependency/layer_direction.go
+++ b/rules/dependency/layer_direction.go
@@ -13,11 +13,8 @@ import (
 type LayerDirection struct{ severity core.Severity }
 
 func NewLayerDirection(opts ...Option) *LayerDirection {
-	r := &LayerDirection{severity: core.Error}
-	for _, opt := range opts {
-		r.severity = opt.severity()
-	}
-	return r
+	cfg := newConfig(opts, core.Error)
+	return &LayerDirection{severity: cfg.severity}
 }
 
 func (r *LayerDirection) Spec() core.RuleSpec {
@@ -36,8 +33,12 @@ func (r *LayerDirection) Spec() core.RuleSpec {
 func (r *LayerDirection) Check(ctx *core.Context) []core.Violation {
 	projectModule := analysisutil.ResolveModuleFromContext(ctx, "")
 	projectRoot := analysisutil.ResolveRootFromContext(ctx, "")
-	if warns := validateModule(ctx.Pkgs(), projectModule); len(warns) > 0 {
+	pkgs := ctx.Pkgs()
+	if warns := validateModule(pkgs, projectModule); len(warns) > 0 {
 		return warns
+	}
+	if !hasInternalPackages(pkgs, projectModule) {
+		return []core.Violation{metaLayoutNotSupported("dependency.layer-direction", projectModule)}
 	}
 	internalPrefix := projectModule + "/internal/"
 

--- a/rules/dependency/layer_direction_test.go
+++ b/rules/dependency/layer_direction_test.go
@@ -61,6 +61,12 @@ func TestLayerDirectionInvalidProject(t *testing.T) {
 	}
 }
 
+func TestLayerDirectionFlatLayoutEmitsMetaWarning(t *testing.T) {
+	ctx := loadFlatLayoutContext(t)
+	violations := dependency.NewLayerDirection().Check(ctx)
+	assertExactlyOneMetaLayoutNotSupported(t, violations, "dependency.layer-direction")
+}
+
 func TestLayerDirectionExclude(t *testing.T) {
 	ctx := loadContextWithExclude(t,
 		"../../testdata/invalid",

--- a/rules/dependency/option.go
+++ b/rules/dependency/option.go
@@ -1,0 +1,23 @@
+package dependency
+
+import "github.com/NamhaeSusan/go-arch-guard/core"
+
+type Option func(*ruleConfig)
+
+type ruleConfig struct {
+	severity core.Severity
+}
+
+func WithSeverity(severity core.Severity) Option {
+	return func(cfg *ruleConfig) {
+		cfg.severity = severity
+	}
+}
+
+func newConfig(opts []Option, severity core.Severity) ruleConfig {
+	cfg := ruleConfig{severity: severity}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return cfg
+}

--- a/testdata/flat/go.mod
+++ b/testdata/flat/go.mod
@@ -1,0 +1,3 @@
+module github.com/kimtaeyun/testproject-flat
+
+go 1.23

--- a/testdata/flat/worker/worker.go
+++ b/testdata/flat/worker/worker.go
@@ -1,0 +1,5 @@
+package worker
+
+type Worker struct{}
+
+func (w *Worker) Process() {}


### PR DESCRIPTION
> **Stacked on #44** (which is stacked on #39). Base will auto-rebase to `main` once #44 merges.

## Summary

Cross-cutting cleanup found during `rules/dependency/` review:

- **#45** — Switch `rules/dependency` from a custom `Option` interface (with `.severity()` method, defined inside `isolation.go`) to the same functional pattern `rules/naming` and `rules/types` now use. Adds `rules/dependency/option.go`. **Also fixes a latent overwrite bug**: the old `for opt := range opts { r.severity = opt.severity() }` loop kept only the last option — functional options compose correctly.
- **#46** — All three rules (`Isolation`, `LayerDirection`, `BlastRadius`) hardcode the `<module>/internal/` prefix. On flat-layout projects (ConsumerWorker, Batch, EventPipeline presets) they ran successfully and produced **zero** violations, giving users no signal that the rule didn't apply. Now each rule emits `meta.layout-not-supported` Warning when no `internal/` packages are loaded. The runner already dedupes `meta.*` violations across rules.
- **#47** — Decompose `Isolation.Check` (was 156 lines, deeply nested, 11 violation IDs) into per-source-kind sub-checks: `checkCmdPackage`, `checkInternalImport`, `checkOrchestrationDeepImport`, `checkSharedImport`, `checkOrchestrationDependent`, `crossDomainViolation`, `strayDomainViolation`, plus predicate helpers (`isDomainKind`, `isSameDomain`, `isCrossDomain`). **Pure structural** — all 11 violation IDs emit under identical conditions.

Closes #45, closes #46, closes #47.

## Test plan

- [x] `go test ./...` — 16/16 packages green
- [x] `goimports -w .`
- [x] `make lint` — 0 issues
- [x] New `testdata/flat/` minimal fixture (single `worker/worker.go` package, no `internal/`)
- [x] New tests:
  - `TestIsolationFlatLayoutEmitsMetaWarning` / `TestLayerDirectionFlatLayoutEmitsMetaWarning` / `TestBlastRadiusFlatLayoutEmitsMetaWarning` — assert exactly one `meta.layout-not-supported` per rule
  - `TestIsolationDDDProjectHasNoMetaLayoutWarning` — regression guard: `internal/`-based projects do NOT emit the warning
- [x] code-reviewer agent — APPROVE; verified that the decomposition's `kindShared` fall-through is semantically equivalent to the original (the `pkg-imports-orchestration` case is fully consumed by `checkSharedImport` and never falls through to `checkOrchestrationDependent`)

## Public API impact

- **Compatible**: `dependency.WithSeverity(s core.Severity) Option` signature unchanged.
- **Theoretical breaking change**: `dependency.Option` switches from interface to function. No in-repo or known external implementers exist; all callers pass `dependency.WithSeverity(...)` or nothing.
- **Behavior change for flat-layout users**: instead of zero violations, they now get one `meta.layout-not-supported` Warning per rule. Severity is `Warning` so builds are not blocked.