### PR TITLE
refactor(structural/analysisutil): unify Option, dedupe InspectTypeSpecs, signal flat layouts, fix non-determinism

### DIFF
--- a/core/analysisutil/ast.go
+++ b/core/analysisutil/ast.go
@@ -2,9 +2,58 @@ package analysisutil
 
 import (
 	"go/ast"
+	"go/token"
 	"go/types"
 	"strings"
 )
+
+// TypeSpecInfo describes a single top-level type declaration in a Go file —
+// what InspectTypeSpecs extracts. Callers compute file-level metadata (e.g.
+// a relative path) once outside the loop; only per-decl fields live here.
+type TypeSpecInfo struct {
+	Name        string
+	Line        int
+	IsInterface bool
+	AliasFrom   string // import path of `type X = pkg.Y`; empty if not an alias
+}
+
+// InspectTypeSpecs walks the top-level type decls in file and returns one
+// entry per interface declaration or per type alias whose RHS is
+// `<ident>.<Name>`. Other type decls are skipped. Callers usually want to
+// detect interfaces or detect re-exports of types from other packages.
+func InspectTypeSpecs(file *ast.File, fset *token.FileSet) []TypeSpecInfo {
+	var result []TypeSpecInfo
+	for _, decl := range file.Decls {
+		gd, ok := decl.(*ast.GenDecl)
+		if !ok {
+			continue
+		}
+		for _, spec := range gd.Specs {
+			ts, ok := spec.(*ast.TypeSpec)
+			if !ok {
+				continue
+			}
+			info := TypeSpecInfo{
+				Name: ts.Name.Name,
+				Line: fset.Position(ts.Name.Pos()).Line,
+			}
+			if _, ok := ts.Type.(*ast.InterfaceType); ok {
+				info.IsInterface = true
+			}
+			if ts.Assign != 0 {
+				if sel, ok := ts.Type.(*ast.SelectorExpr); ok {
+					if ident, ok := sel.X.(*ast.Ident); ok {
+						info.AliasFrom = ResolveIdentImportPath(file, ident.Name)
+					}
+				}
+			}
+			if info.IsInterface || info.AliasFrom != "" {
+				result = append(result, info)
+			}
+		}
+	}
+	return result
+}
 
 // ReceiverTypeName extracts the unqualified receiver type name from an
 // *ast.FuncDecl receiver expression. It unwraps a leading pointer and

--- a/rules/naming/repo_file_interface.go
+++ b/rules/naming/repo_file_interface.go
@@ -106,22 +106,22 @@ func (r *RepoFileInterface) checkInterfacePlacement(ctx *core.Context, pkg *pack
 		if ctx.IsExcluded(filePath) {
 			continue
 		}
-		for _, info := range inspectTypeSpecs(file, pkg) {
-			if info.isIface && isRepoPortName(info.name) {
+		for _, info := range analysisutil.InspectTypeSpecs(file, pkg.Fset) {
+			if info.IsInterface && isRepoPortName(info.Name) {
 				violations = append(violations, r.violation(
-					info.file,
-					info.line,
+					filePath,
+					info.Line,
 					"structure.interface-placement",
-					`interface "`+info.name+`" matches repository-port naming and must be defined in `+repoName+`/, not in `+path.Base(path.Dir(pkg.PkgPath))+`/`,
+					`interface "`+info.Name+`" matches repository-port naming and must be defined in `+repoName+`/, not in `+path.Base(path.Dir(pkg.PkgPath))+`/`,
 					"move to "+repoName+"/, or rename if it's a consumer-defined interface",
 				))
 			}
-			if info.aliasFrom != "" && analysisutil.MatchPortSublayer(arch.Layers, info.aliasFrom) != "" {
+			if info.AliasFrom != "" && analysisutil.MatchPortSublayer(arch.Layers, info.AliasFrom) != "" {
 				violations = append(violations, r.violation(
-					info.file,
-					info.line,
+					filePath,
+					info.Line,
 					"structure.interface-placement",
-					`type alias "`+info.name+`" re-exports interface from `+repoName+` - suspected cross-domain dependency; use `+arch.Layout.OrchestrationDir+`/ instead`,
+					`type alias "`+info.Name+`" re-exports interface from `+repoName+` - suspected cross-domain dependency; use `+arch.Layout.OrchestrationDir+`/ instead`,
 					"remove alias and move cross-domain coordination to "+arch.Layout.OrchestrationDir+"/",
 				))
 			}
@@ -168,50 +168,6 @@ func isDomainPackage(arch core.Architecture, pkgPath string) bool {
 
 func isRepoPortName(name string) bool {
 	return strings.HasSuffix(name, "Repository") || strings.HasSuffix(name, "Repo")
-}
-
-type typeSpecInfo struct {
-	name      string
-	file      string
-	line      int
-	isIface   bool
-	aliasFrom string
-}
-
-func inspectTypeSpecs(file *ast.File, pkg *packages.Package) []typeSpecInfo {
-	var result []typeSpecInfo
-	for _, decl := range file.Decls {
-		gd, ok := decl.(*ast.GenDecl)
-		if !ok {
-			continue
-		}
-		for _, spec := range gd.Specs {
-			ts, ok := spec.(*ast.TypeSpec)
-			if !ok {
-				continue
-			}
-			pos := pkg.Fset.Position(ts.Name.Pos())
-			info := typeSpecInfo{
-				name: ts.Name.Name,
-				file: analysisutil.RelativePathForPackage(pkg, pos.Filename),
-				line: pos.Line,
-			}
-			if _, ok := ts.Type.(*ast.InterfaceType); ok {
-				info.isIface = true
-			}
-			if ts.Assign != 0 {
-				if sel, ok := ts.Type.(*ast.SelectorExpr); ok {
-					if ident, ok := sel.X.(*ast.Ident); ok {
-						info.aliasFrom = analysisutil.ResolveIdentImportPath(file, ident.Name)
-					}
-				}
-			}
-			if info.isIface || info.aliasFrom != "" {
-				result = append(result, info)
-			}
-		}
-	}
-	return result
 }
 
 var _ core.Rule = (*RepoFileInterface)(nil)

--- a/rules/structural/alias.go
+++ b/rules/structural/alias.go
@@ -1,7 +1,6 @@
 package structural
 
 import (
-	"go/ast"
 	"go/parser"
 	"go/token"
 	"os"
@@ -21,33 +20,13 @@ const (
 	aliasContractExport = "structure.domain-alias-contract-reexport"
 )
 
-type Option func(any)
-
-func WithSeverity(s core.Severity) Option {
-	return func(rule any) {
-		switch r := rule.(type) {
-		case *Alias:
-			r.severity = s
-		case *Placement:
-			r.severity = s
-		case *BannedPackage:
-			r.severity = s
-		case *ModelRequired:
-			r.severity = s
-		case *InternalTopLevel:
-			r.severity = s
-		}
-	}
-}
-
 type Alias struct {
 	severity core.Severity
 }
 
 func NewAlias(opts ...Option) *Alias {
-	r := &Alias{severity: core.Error}
-	applyOptions(r, opts)
-	return r
+	cfg := newConfig(opts, core.Error)
+	return &Alias{severity: cfg.severity}
 }
 
 func (r *Alias) Spec() core.RuleSpec {
@@ -68,6 +47,9 @@ func (r *Alias) Spec() core.RuleSpec {
 func (r *Alias) Check(ctx *core.Context) []core.Violation {
 	if ctx == nil {
 		return nil
+	}
+	if !hasInternalDir(ctx.Root()) {
+		return []core.Violation{metaLayoutNotSupported(ruleAlias)}
 	}
 	arch := ctx.Arch()
 	if arch.Layout.DomainDir == "" || !arch.Structure.RequireAlias {
@@ -148,70 +130,23 @@ func (r *Alias) checkAliasTypes(aliasPath, aliasRel, aliasName string, arch core
 		return nil
 	}
 	var violations []core.Violation
-	for _, info := range inspectTypeSpecs(file, fset) {
-		if info.isInterface {
+	for _, info := range analysisutil.InspectTypeSpecs(file, fset) {
+		if info.IsInterface {
 			v := violation(r.severity, aliasNoInterface, aliasRel,
-				aliasName+` re-exports interface "`+info.name+`" - suspected cross-domain dependency; use `+arch.Layout.OrchestrationDir+`/ instead`,
+				aliasName+` re-exports interface "`+info.Name+`" - suspected cross-domain dependency; use `+arch.Layout.OrchestrationDir+`/ instead`,
 				"move cross-domain coordination to "+arch.Layout.OrchestrationDir+"/handler/ or "+arch.Layout.OrchestrationDir+"/")
-			v.Line = info.line
+			v.Line = info.Line
 			violations = append(violations, v)
 		}
-		if src := analysisutil.MatchContractSublayer(arch.Layers, info.aliasFrom); src != "" {
+		if src := analysisutil.MatchContractSublayer(arch.Layers, info.AliasFrom); src != "" {
 			v := violation(r.severity, aliasContractExport, aliasRel,
-				aliasName+` re-exports "`+info.name+`" from `+src+` - suspected cross-domain dependency; use `+arch.Layout.OrchestrationDir+`/ instead`,
+				aliasName+` re-exports "`+info.Name+`" from `+src+` - suspected cross-domain dependency; use `+arch.Layout.OrchestrationDir+`/ instead`,
 				"move cross-domain coordination to "+arch.Layout.OrchestrationDir+"/handler/ or "+arch.Layout.OrchestrationDir+"/")
-			v.Line = info.line
+			v.Line = info.Line
 			violations = append(violations, v)
 		}
 	}
 	return violations
-}
-
-type typeSpecInfo struct {
-	name        string
-	line        int
-	isInterface bool
-	aliasFrom   string
-}
-
-func inspectTypeSpecs(file *ast.File, fset *token.FileSet) []typeSpecInfo {
-	var result []typeSpecInfo
-	for _, decl := range file.Decls {
-		gen, ok := decl.(*ast.GenDecl)
-		if !ok {
-			continue
-		}
-		for _, spec := range gen.Specs {
-			typeSpec, ok := spec.(*ast.TypeSpec)
-			if !ok {
-				continue
-			}
-			info := typeSpecInfo{
-				name: typeSpec.Name.Name,
-				line: fset.Position(typeSpec.Name.Pos()).Line,
-			}
-			if _, ok := typeSpec.Type.(*ast.InterfaceType); ok {
-				info.isInterface = true
-			}
-			if typeSpec.Assign != 0 {
-				if sel, ok := typeSpec.Type.(*ast.SelectorExpr); ok {
-					if ident, ok := sel.X.(*ast.Ident); ok {
-						info.aliasFrom = analysisutil.ResolveIdentImportPath(file, ident.Name)
-					}
-				}
-			}
-			if info.isInterface || info.aliasFrom != "" {
-				result = append(result, info)
-			}
-		}
-	}
-	return result
-}
-
-func applyOptions(rule any, opts []Option) {
-	for _, opt := range opts {
-		opt(rule)
-	}
 }
 
 func withSeverity(spec core.RuleSpec, severity core.Severity) core.RuleSpec {

--- a/rules/structural/banned_package.go
+++ b/rules/structural/banned_package.go
@@ -19,9 +19,8 @@ type BannedPackage struct {
 }
 
 func NewBannedPackage(opts ...Option) *BannedPackage {
-	r := &BannedPackage{severity: core.Warning}
-	applyOptions(r, opts)
-	return r
+	cfg := newConfig(opts, core.Warning)
+	return &BannedPackage{severity: cfg.severity}
 }
 
 func (r *BannedPackage) Spec() core.RuleSpec {
@@ -39,6 +38,9 @@ func (r *BannedPackage) Spec() core.RuleSpec {
 func (r *BannedPackage) Check(ctx *core.Context) []core.Violation {
 	if ctx == nil {
 		return nil
+	}
+	if !hasInternalDir(ctx.Root()) {
+		return []core.Violation{metaLayoutNotSupported(ruleBannedPackage)}
 	}
 	internalDir := filepath.Join(ctx.Root(), "internal")
 	var violations []core.Violation

--- a/rules/structural/internal_top_level.go
+++ b/rules/structural/internal_top_level.go
@@ -1,9 +1,9 @@
 package structural
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/NamhaeSusan/go-arch-guard/core"
@@ -19,9 +19,8 @@ type InternalTopLevel struct {
 }
 
 func NewInternalTopLevel(opts ...Option) *InternalTopLevel {
-	r := &InternalTopLevel{severity: core.Error}
-	applyOptions(r, opts)
-	return r
+	cfg := newConfig(opts, core.Error)
+	return &InternalTopLevel{severity: cfg.severity}
 }
 
 func (r *InternalTopLevel) Spec() core.RuleSpec {
@@ -39,6 +38,9 @@ func (r *InternalTopLevel) Check(ctx *core.Context) []core.Violation {
 	if ctx == nil {
 		return nil
 	}
+	if !hasInternalDir(ctx.Root()) {
+		return []core.Violation{metaLayoutNotSupported(ruleInternalTopLevel)}
+	}
 	internalDir := filepath.Join(ctx.Root(), "internal")
 	entries, err := os.ReadDir(internalDir)
 	if err != nil {
@@ -50,6 +52,8 @@ func (r *InternalTopLevel) Check(ctx *core.Context) []core.Violation {
 	for name := range arch.Layers.InternalTopLevel {
 		allowedNames = append(allowedNames, "internal/"+name+"/")
 	}
+	sort.Strings(allowedNames)
+	allowedHint := strings.Join(allowedNames, ", ")
 
 	var violations []core.Violation
 	for _, entry := range entries {
@@ -60,7 +64,7 @@ func (r *InternalTopLevel) Check(ctx *core.Context) []core.Violation {
 			}
 			violations = append(violations, violation(r.severity, internalTopLevel, relPath+"/",
 				`internal/ top-level package "`+entry.Name()+`" is not allowed`,
-				fmt.Sprintf("use only %v at the internal/ top level", allowedNames)))
+				"use only "+allowedHint+" at the internal/ top level"))
 			continue
 		}
 
@@ -72,7 +76,7 @@ func (r *InternalTopLevel) Check(ctx *core.Context) []core.Violation {
 		}
 		violations = append(violations, violation(r.severity, internalTopLevel, relPath,
 			`internal/ top-level Go file "`+entry.Name()+`" is not allowed`,
-			fmt.Sprintf("move code under %v", allowedNames)))
+			"move code under "+allowedHint))
 	}
 	return violations
 }

--- a/rules/structural/internal_top_level_test.go
+++ b/rules/structural/internal_top_level_test.go
@@ -1,6 +1,7 @@
 package structural_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/NamhaeSusan/go-arch-guard/rules/structural"
@@ -15,5 +16,29 @@ func TestInternalTopLevel(t *testing.T) {
 	t.Run("detects invalid fixture unexpected internal top-level package", func(t *testing.T) {
 		violations := runRule(t, "../../testdata/invalid", structural.NewInternalTopLevel())
 		assertViolation(t, violations, "structure.internal-top-level", "internal/config/")
+	})
+
+	t.Run("allowedNames hint is deterministic and comma-joined", func(t *testing.T) {
+		var prev string
+		for i := range 5 {
+			violations := runRule(t, "../../testdata/invalid", structural.NewInternalTopLevel())
+			var msg string
+			for _, v := range violations {
+				if v.Rule == "structure.internal-top-level" {
+					msg = v.Fix
+					break
+				}
+			}
+			if msg == "" {
+				t.Fatalf("no internal-top-level violation found")
+			}
+			if strings.Contains(msg, "[") || strings.Contains(msg, "]") {
+				t.Fatalf("Fix should use comma-joined names, got %q", msg)
+			}
+			if i > 0 && msg != prev {
+				t.Fatalf("Fix non-deterministic: run %d %q != run 0 %q", i, msg, prev)
+			}
+			prev = msg
+		}
 	})
 }

--- a/rules/structural/layout_meta.go
+++ b/rules/structural/layout_meta.go
@@ -1,0 +1,30 @@
+package structural
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/NamhaeSusan/go-arch-guard/core"
+)
+
+// hasInternalDir reports whether <root>/internal exists as a directory. The
+// structural rules walk the filesystem rather than ctx.Pkgs(), so this is a
+// pre-flight check used to decide whether the rule applies at all.
+func hasInternalDir(root string) bool {
+	if root == "" {
+		return false
+	}
+	info, err := os.Stat(filepath.Join(root, "internal"))
+	return err == nil && info.IsDir()
+}
+
+func metaLayoutNotSupported(ruleID string) core.Violation {
+	return core.Violation{
+		Rule:              "meta.layout-not-supported",
+		Message:           fmt.Sprintf("%s requires an internal/-based layout; internal/ directory not found", ruleID),
+		Fix:               "use this rule with internal/-based presets (DDD, CleanArch, Hexagonal, ModularMonolith), or remove it from your ruleset for flat layouts",
+		DefaultSeverity:   core.Warning,
+		EffectiveSeverity: core.Warning,
+	}
+}

--- a/rules/structural/layout_meta_test.go
+++ b/rules/structural/layout_meta_test.go
@@ -1,0 +1,57 @@
+package structural_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/NamhaeSusan/go-arch-guard/core"
+	"github.com/NamhaeSusan/go-arch-guard/rules/structural"
+)
+
+func TestStructuralRulesEmitMetaOnFlatLayout(t *testing.T) {
+	cases := []struct {
+		ruleID string
+		rule   core.Rule
+	}{
+		{"structural.alias", structural.NewAlias()},
+		{"structural.placement", structural.NewPlacement()},
+		{"structural.banned-package", structural.NewBannedPackage()},
+		{"structural.model-required", structural.NewModelRequired()},
+		{"structural.internal-top-level", structural.NewInternalTopLevel()},
+	}
+	for _, tc := range cases {
+		t.Run(tc.ruleID, func(t *testing.T) {
+			violations := runRule(t, "../../testdata/flat", tc.rule)
+			var count int
+			for _, v := range violations {
+				if v.Rule == "meta.layout-not-supported" {
+					count++
+					if !strings.Contains(v.Message, tc.ruleID) {
+						t.Fatalf("meta message should mention %q, got %q", tc.ruleID, v.Message)
+					}
+				}
+			}
+			if count != 1 {
+				t.Fatalf("expected exactly 1 meta.layout-not-supported, got %d: %+v", count, violations)
+			}
+		})
+	}
+}
+
+func TestStructuralRulesNoMetaOnDDDLayout(t *testing.T) {
+	cases := []core.Rule{
+		structural.NewAlias(),
+		structural.NewPlacement(),
+		structural.NewBannedPackage(),
+		structural.NewModelRequired(),
+		structural.NewInternalTopLevel(),
+	}
+	for _, rule := range cases {
+		violations := runRule(t, "../../testdata/valid", rule)
+		for _, v := range violations {
+			if v.Rule == "meta.layout-not-supported" {
+				t.Fatalf("internal/-based project must not emit meta.layout-not-supported: %s", v.String())
+			}
+		}
+	}
+}

--- a/rules/structural/model_required.go
+++ b/rules/structural/model_required.go
@@ -17,9 +17,8 @@ type ModelRequired struct {
 }
 
 func NewModelRequired(opts ...Option) *ModelRequired {
-	r := &ModelRequired{severity: core.Error}
-	applyOptions(r, opts)
-	return r
+	cfg := newConfig(opts, core.Error)
+	return &ModelRequired{severity: cfg.severity}
 }
 
 func (r *ModelRequired) Spec() core.RuleSpec {
@@ -36,6 +35,9 @@ func (r *ModelRequired) Spec() core.RuleSpec {
 func (r *ModelRequired) Check(ctx *core.Context) []core.Violation {
 	if ctx == nil {
 		return nil
+	}
+	if !hasInternalDir(ctx.Root()) {
+		return []core.Violation{metaLayoutNotSupported(ruleModelRequired)}
 	}
 	arch := ctx.Arch()
 	if arch.Layout.DomainDir == "" || !arch.Structure.RequireModel {

--- a/rules/structural/option.go
+++ b/rules/structural/option.go
@@ -1,0 +1,23 @@
+package structural
+
+import "github.com/NamhaeSusan/go-arch-guard/core"
+
+type Option func(*ruleConfig)
+
+type ruleConfig struct {
+	severity core.Severity
+}
+
+func WithSeverity(severity core.Severity) Option {
+	return func(cfg *ruleConfig) {
+		cfg.severity = severity
+	}
+}
+
+func newConfig(opts []Option, severity core.Severity) ruleConfig {
+	cfg := ruleConfig{severity: severity}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return cfg
+}

--- a/rules/structural/placement.go
+++ b/rules/structural/placement.go
@@ -1,7 +1,6 @@
 package structural
 
 import (
-	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -23,9 +22,8 @@ type Placement struct {
 }
 
 func NewPlacement(opts ...Option) *Placement {
-	r := &Placement{severity: core.Error}
-	applyOptions(r, opts)
-	return r
+	cfg := newConfig(opts, core.Error)
+	return &Placement{severity: cfg.severity}
 }
 
 func (r *Placement) Spec() core.RuleSpec {
@@ -45,10 +43,10 @@ func (r *Placement) Check(ctx *core.Context) []core.Violation {
 	if ctx == nil {
 		return nil
 	}
-	internalDir := filepath.Join(ctx.Root(), "internal")
-	if _, err := os.Stat(internalDir); err != nil {
-		return nil
+	if !hasInternalDir(ctx.Root()) {
+		return []core.Violation{metaLayoutNotSupported(rulePlacement)}
 	}
+	internalDir := filepath.Join(ctx.Root(), "internal")
 	arch := ctx.Arch()
 	violations := r.checkLayerPlacement(ctx, internalDir, arch)
 	violations = append(violations, r.checkMiddlewarePlacement(ctx, internalDir, arch)...)
@@ -84,7 +82,7 @@ func (r *Placement) checkLayerPlacement(ctx *core.Context, internalDir string, a
 		}
 		violations = append(violations, violation(r.severity, misplacedLayer, rel+"/",
 			`layer package "`+name+`" is misplaced`,
-			fmt.Sprintf("place layer packages only in configured domain slices or %s handler", arch.Layout.OrchestrationDir)))
+			"place layer packages only in configured domain slices or "+arch.Layout.OrchestrationDir+" handler"))
 		return nil
 	})
 	return violations
@@ -143,7 +141,7 @@ func (r *Placement) checkDTOPlacement(ctx *core.Context, internalDir string, arc
 		}
 		violations = append(violations, violation(r.severity, dtoPlacement, rel,
 			`"`+name+`" found in forbidden layer`,
-			fmt.Sprintf("DTOs belong in %v", arch.Structure.DTOAllowedLayers)))
+			"DTOs belong in "+strings.Join(arch.Structure.DTOAllowedLayers, ", ")))
 		return nil
 	})
 	return violations


### PR DESCRIPTION
> **Stacked on #48** (which is stacked on #44 -> #39). Base will auto-rebase to `main` once #48 merges.

## Summary

`rules/structural/` cleanup — final Option-pattern unification + cross-package helper dedup + flat-layout signal + determinism fix.

- **#49** — Switch `rules/structural` from `Option func(any)` (with type-switch dispatch across 5 rules; `any` loses compile-time type safety, type-switch violates Open-Closed) to the same `func(*ruleConfig)` pattern that `naming`/`types`/`dependency` now use. Adds `rules/structural/option.go`. **All four rule packages now share the same Option shape.**
- **#50** — All 5 structural rules hardcode `<root>/internal`. On flat layouts they emitted zero violations silently. Now each emits `meta.layout-not-supported` Warning when `<root>/internal` is missing. The layout check runs **before** any policy guard (`RequireAlias`, `RequireModel`) so users get consistent feedback regardless of arch config.
- **#51** — Promote `inspectTypeSpecs` and `typeSpecInfo` (duplicated near-identically in `rules/naming/repo_file_interface.go` and `rules/structural/alias.go`) into `core/analysisutil` as `InspectTypeSpecs(file, fset) []TypeSpecInfo`. The `TypeSpecInfo.File` field is dropped — callers compute the relative path once outside the loop. Behavior preserved (all type specs in a single `*ast.File` share the same filename, so the per-spec computation was redundant).
- **#52** — `InternalTopLevel`'s violation message read `[internal/app/ internal/domain/ internal/pkg/]` with non-deterministic order (built from a `map`). Now sorted and joined with `", "`. Same `%v`-slice cleanup applied to `placement.go`'s `DTOAllowedLayers` and `misplacedLayer` messages. New regression test runs the rule 5x and asserts identical output.

Closes #49, closes #50, closes #51, closes #52.

## Test plan

- [x] `go test ./...` — 16/16 packages green
- [x] `goimports -w .`
- [x] `make lint` — 0 issues
- [x] New tests:
  - `core/analysisutil` — implicit (existing fixtures still pass)
  - `rules/structural/layout_meta_test.go::TestStructuralRulesEmitMetaOnFlatLayout` — table covers all 5 rules with `testdata/flat/`
  - `rules/structural/layout_meta_test.go::TestStructuralRulesNoMetaOnDDDLayout` — regression guard
  - `rules/structural/internal_top_level_test.go` — runs rule 5x, asserts identical output and no `[`/`]` brackets
- [x] code-reviewer agent — APPROVE; the originally-flagged WARNING (early-return precedence in Alias/ModelRequired) was addressed by swapping the guard order so all 5 rules now behave consistently on flat layouts. Nit (placement.go fmt.Sprintf cleanup) also addressed.

## Public API impact

- **New**: `analysisutil.InspectTypeSpecs(file *ast.File, fset *token.FileSet) []TypeSpecInfo` and `analysisutil.TypeSpecInfo`. Stable, documented.
- **Compatible**: `structural.WithSeverity(s core.Severity) Option` signature unchanged.
- **Theoretical breaking**: `structural.Option` switches from `func(any)` to `func(*ruleConfig)`. No in-repo callers implement `Option`; all use `WithSeverity` or nothing.
- **Behavior change for flat-layout users**: instead of zero violations from structural rules, they now get one `meta.layout-not-supported` Warning per rule. Severity = Warning, builds not blocked.

## Pattern consolidation status (after this PR + #39 + #44 + #48)

All 4 rule packages share the same Option pattern:
| Package | Pattern |
|---|---|
| `naming` | `func(*ruleConfig)` |
| `types` | `func(*ruleConfig)` |
| `dependency` | `func(*ruleConfig)` |
| `structural` | `func(*ruleConfig)` ← this PR |

All packages emit `meta.layout-not-supported` on flat layouts (`naming`/`types` operate per-package and don't need it).

Shared helpers in `analysisutil`: `SnakeToPascal`, `ReceiverTypeName`, `InspectTypeSpecs`/`TypeSpecInfo`.