### PR TITLE
refactor(interfaces/analysisutil): split option.go, signal flat layouts, fix non-determinism, support generics

### DIFF
--- a/core/analysisutil/ast.go
+++ b/core/analysisutil/ast.go
@@ -7,6 +7,16 @@ import (
 	"strings"
 )
 
+// IsTestFile reports whether file's source path ends with "_test.go". The
+// callsite supplies fset because *ast.File alone does not retain its
+// filename — only token.Position does.
+func IsTestFile(file *ast.File, fset *token.FileSet) bool {
+	if file == nil || fset == nil {
+		return false
+	}
+	return strings.HasSuffix(fset.Position(file.Pos()).Filename, "_test.go")
+}
+
 // TypeSpecInfo describes a single top-level type declaration in a Go file —
 // what InspectTypeSpecs extracts. Callers compute file-level metadata (e.g.
 // a relative path) once outside the loop; only per-decl fields live here.

--- a/core/runner.go
+++ b/core/runner.go
@@ -33,7 +33,7 @@ import (
 //     1. WithSeverityOverride(violationID, ...)
 //     2. RuleSpec.Violations[i].DefaultSeverity for matching ID
 //     3. Warning, when the violation ID starts with "meta." (environmental
-//        meta.* violations should never block builds by accident)
+//     meta.* violations should never block builds by accident)
 //     4. RuleSpec.DefaultSeverity
 //     5. Error
 //   - Violations are deduped by Rule field for any Rule starting with "meta.".

--- a/rules/interfaces/container.go
+++ b/rules/interfaces/container.go
@@ -5,7 +5,6 @@ import (
 	"go/ast"
 	"go/token"
 	"sort"
-	"strings"
 
 	"github.com/NamhaeSusan/go-arch-guard/core"
 	"github.com/NamhaeSusan/go-arch-guard/core/analysisutil"
@@ -13,15 +12,11 @@ import (
 )
 
 type Container struct {
-	cfg config
+	cfg ruleConfig
 }
 
 func NewContainer(opts ...Option) *Container {
-	cfg := config{severity: core.Warning}
-	for _, opt := range opts {
-		opt(&cfg)
-	}
-	return &Container{cfg: cfg}
+	return &Container{cfg: newConfig(opts, core.Warning)}
 }
 
 func (r *Container) Spec() core.RuleSpec {
@@ -59,7 +54,7 @@ func (r *Container) checkPackage(pkg *packages.Package) []core.Violation {
 	}
 
 	for _, file := range pkg.Syntax {
-		if isTestFile(pkg, file) {
+		if analysisutil.IsTestFile(file, pkg.Fset) {
 			continue
 		}
 		ast.Inspect(file, func(n ast.Node) bool {
@@ -160,13 +155,21 @@ func countTypeRefs(expr ast.Expr, ifaces map[string]token.Position, usage map[st
 	case *ast.FuncType:
 		countFieldListRefs(e.Params, ifaces, usage, kind)
 		countFieldListRefs(e.Results, ifaces, usage, kind)
+	case *ast.IndexExpr:
+		countTypeRefs(e.X, ifaces, usage, kind)
+		countTypeRefs(e.Index, ifaces, usage, kind)
+	case *ast.IndexListExpr:
+		countTypeRefs(e.X, ifaces, usage, kind)
+		for _, idx := range e.Indices {
+			countTypeRefs(idx, ifaces, usage, kind)
+		}
 	}
 }
 
 func collectNonTestInterfaces(pkg *packages.Package) map[string]token.Position {
 	result := make(map[string]token.Position)
 	for _, file := range pkg.Syntax {
-		if isTestFile(pkg, file) {
+		if analysisutil.IsTestFile(file, pkg.Fset) {
 			continue
 		}
 		for _, decl := range file.Decls {
@@ -186,11 +189,6 @@ func collectNonTestInterfaces(pkg *packages.Package) map[string]token.Position {
 		}
 	}
 	return result
-}
-
-func isTestFile(pkg *packages.Package, file *ast.File) bool {
-	pos := pkg.Fset.Position(file.Pos())
-	return strings.HasSuffix(pos.Filename, "_test.go")
 }
 
 var _ core.Rule = (*Container)(nil)

--- a/rules/interfaces/container_test.go
+++ b/rules/interfaces/container_test.go
@@ -62,6 +62,27 @@ func New() Reader { return &reader{} }
 	assertLacksRule(t, violations, "interface.container-only")
 }
 
+func TestContainerHandlesGenericTypeArguments(t *testing.T) {
+	root := writeFixture(t, "example.com/container-generics", map[string]string{
+		"internal/wire/wire.go": `package wire
+
+type Reader interface {
+	Read() string
+}
+
+type Cache[T any] struct {
+	v T
+}
+
+func New() *Cache[Reader] { return &Cache[Reader]{} }
+`,
+	})
+
+	violations := interfaces.NewContainer().Check(loadContext(t, root, flatArchitecture(), "example.com/container-generics"))
+
+	assertLacksRule(t, violations, "interface.container-only")
+}
+
 func TestContainerWithSeverity(t *testing.T) {
 	rule := interfaces.NewContainer(interfaces.WithSeverity(core.Error))
 

--- a/rules/interfaces/cross_domain.go
+++ b/rules/interfaces/cross_domain.go
@@ -12,15 +12,11 @@ import (
 )
 
 type CrossDomainAnonymous struct {
-	cfg config
+	cfg ruleConfig
 }
 
 func NewCrossDomainAnonymous(opts ...Option) *CrossDomainAnonymous {
-	cfg := config{severity: core.Error}
-	for _, opt := range opts {
-		opt(&cfg)
-	}
-	return &CrossDomainAnonymous{cfg: cfg}
+	return &CrossDomainAnonymous{cfg: newConfig(opts, core.Error)}
 }
 
 func (r *CrossDomainAnonymous) Spec() core.RuleSpec {
@@ -35,12 +31,20 @@ func (r *CrossDomainAnonymous) Spec() core.RuleSpec {
 }
 
 func (r *CrossDomainAnonymous) Check(ctx *core.Context) []core.Violation {
-	if ctx == nil || ctx.Arch().Layout.DomainDir == "" {
+	if ctx == nil {
+		return nil
+	}
+	pkgs := ctx.Pkgs()
+	projectModule := analysisutil.ResolveModuleFromContext(ctx, "")
+	if !hasInternalPackages(pkgs, projectModule) {
+		return []core.Violation{metaLayoutNotSupported("interfaces.cross-domain-anonymous", projectModule)}
+	}
+	if ctx.Arch().Layout.DomainDir == "" {
 		return nil
 	}
 
 	var violations []core.Violation
-	for _, pkg := range ctx.Pkgs() {
+	for _, pkg := range pkgs {
 		violations = append(violations, r.checkPackage(pkg, ctx.Arch())...)
 	}
 	return violations
@@ -54,7 +58,7 @@ func (r *CrossDomainAnonymous) checkPackage(pkg *packages.Package, arch core.Arc
 
 	var violations []core.Violation
 	for _, file := range pkg.Syntax {
-		if isTestFile(pkg, file) {
+		if analysisutil.IsTestFile(file, pkg.Fset) {
 			continue
 		}
 		for _, decl := range file.Decls {

--- a/rules/interfaces/layout_meta.go
+++ b/rules/interfaces/layout_meta.go
@@ -1,0 +1,36 @@
+package interfaces
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/NamhaeSusan/go-arch-guard/core"
+	"golang.org/x/tools/go/packages"
+)
+
+// hasInternalPackages reports whether any loaded package lives under
+// <module>/internal/. Pattern and CrossDomainAnonymous classify packages by
+// their internal/<DomainDir>/<sublayer> position, so flat-layout projects
+// produce no useful violations and should be signaled via metaLayoutNotSupported.
+func hasInternalPackages(pkgs []*packages.Package, projectModule string) bool {
+	if projectModule == "" {
+		return false
+	}
+	prefix := projectModule + "/internal/"
+	for _, pkg := range pkgs {
+		if strings.HasPrefix(pkg.PkgPath, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func metaLayoutNotSupported(ruleID, projectModule string) core.Violation {
+	return core.Violation{
+		Rule:              "meta.layout-not-supported",
+		Message:           fmt.Sprintf("%s requires an internal/-based layout; no internal/ packages found in module %q", ruleID, projectModule),
+		Fix:               "use this rule with internal/-based presets (DDD, CleanArch, Hexagonal, ModularMonolith), or remove it from your ruleset for flat layouts",
+		DefaultSeverity:   core.Warning,
+		EffectiveSeverity: core.Warning,
+	}
+}

--- a/rules/interfaces/layout_meta_test.go
+++ b/rules/interfaces/layout_meta_test.go
@@ -1,0 +1,59 @@
+package interfaces_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/NamhaeSusan/go-arch-guard/analyzer"
+	"github.com/NamhaeSusan/go-arch-guard/core"
+	"github.com/NamhaeSusan/go-arch-guard/rules/interfaces"
+)
+
+func loadFlatContext(t *testing.T) *core.Context {
+	t.Helper()
+	pkgs, err := analyzer.Load("../../testdata/flat", "...")
+	if err != nil {
+		t.Fatalf("load packages: %v", err)
+	}
+	// domainArchitecture() is used deliberately: hasInternalPackages
+	// short-circuits before DomainDir is read, so the arch config is
+	// irrelevant for the meta path. Using a non-empty DomainDir also
+	// proves the meta guard fires before the DomainDir-empty guard.
+	return core.NewContext(pkgs, "github.com/kimtaeyun/testproject-flat", "../../testdata/flat", domainArchitecture(), nil)
+}
+
+func assertExactlyOneMeta(t *testing.T, violations []core.Violation, ruleID string) {
+	t.Helper()
+	var count int
+	for _, v := range violations {
+		if v.Rule == "meta.layout-not-supported" {
+			count++
+			if !strings.Contains(v.Message, ruleID) {
+				t.Fatalf("meta message should mention %q, got %q", ruleID, v.Message)
+			}
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly 1 meta.layout-not-supported, got %d: %+v", count, violations)
+	}
+}
+
+func TestPatternFlatLayoutEmitsMetaWarning(t *testing.T) {
+	violations := interfaces.NewPattern().Check(loadFlatContext(t))
+	assertExactlyOneMeta(t, violations, "interfaces.pattern")
+}
+
+func TestCrossDomainAnonymousFlatLayoutEmitsMetaWarning(t *testing.T) {
+	violations := interfaces.NewCrossDomainAnonymous().Check(loadFlatContext(t))
+	assertExactlyOneMeta(t, violations, "interfaces.cross-domain-anonymous")
+}
+
+func TestContainerFlatLayoutDoesNotEmitMeta(t *testing.T) {
+	// Container is layout-agnostic and must not emit meta warnings.
+	violations := interfaces.NewContainer().Check(loadFlatContext(t))
+	for _, v := range violations {
+		if v.Rule == "meta.layout-not-supported" {
+			t.Fatalf("Container must not emit meta.layout-not-supported: %+v", v)
+		}
+	}
+}

--- a/rules/interfaces/option.go
+++ b/rules/interfaces/option.go
@@ -1,0 +1,30 @@
+package interfaces
+
+import "github.com/NamhaeSusan/go-arch-guard/core"
+
+type Option func(*ruleConfig)
+
+type ruleConfig struct {
+	severity   core.Severity
+	maxMethods int
+}
+
+func WithSeverity(severity core.Severity) Option {
+	return func(cfg *ruleConfig) {
+		cfg.severity = severity
+	}
+}
+
+func WithMaxMethods(n int) Option {
+	return func(cfg *ruleConfig) {
+		cfg.maxMethods = n
+	}
+}
+
+func newConfig(opts []Option, severity core.Severity) ruleConfig {
+	cfg := ruleConfig{severity: severity}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return cfg
+}

--- a/rules/interfaces/pattern.go
+++ b/rules/interfaces/pattern.go
@@ -12,35 +12,12 @@ import (
 	"golang.org/x/tools/go/packages"
 )
 
-type Option func(*config)
-
-type config struct {
-	severity   core.Severity
-	maxMethods int
-}
-
-func WithSeverity(s core.Severity) Option {
-	return func(c *config) {
-		c.severity = s
-	}
-}
-
-func WithMaxMethods(n int) Option {
-	return func(c *config) {
-		c.maxMethods = n
-	}
-}
-
 type Pattern struct {
-	cfg config
+	cfg ruleConfig
 }
 
 func NewPattern(opts ...Option) *Pattern {
-	cfg := config{severity: core.Error}
-	for _, opt := range opts {
-		opt(&cfg)
-	}
-	return &Pattern{cfg: cfg}
+	return &Pattern{cfg: newConfig(opts, core.Error)}
 }
 
 func (r *Pattern) Spec() core.RuleSpec {
@@ -62,9 +39,14 @@ func (r *Pattern) Check(ctx *core.Context) []core.Violation {
 	if ctx == nil {
 		return nil
 	}
+	pkgs := ctx.Pkgs()
+	projectModule := analysisutil.ResolveModuleFromContext(ctx, "")
+	if !hasInternalPackages(pkgs, projectModule) {
+		return []core.Violation{metaLayoutNotSupported("interfaces.pattern", projectModule)}
+	}
 
 	var violations []core.Violation
-	for _, pkg := range ctx.Pkgs() {
+	for _, pkg := range pkgs {
 		if isExcludedInterfacePatternPkg(ctx.Arch(), pkg) {
 			continue
 		}
@@ -211,8 +193,19 @@ func (r *Pattern) checkExportedImpl(pkg *packages.Package) []core.Violation {
 		return nil
 	}
 
+	structNames := make([]string, 0, len(structs))
+	for name := range structs {
+		structNames = append(structNames, name)
+	}
+	sort.Strings(structNames)
+	ifaceNames := make([]string, 0, len(typedIfaces))
+	for name := range typedIfaces {
+		ifaceNames = append(ifaceNames, name)
+	}
+	sort.Strings(ifaceNames)
+
 	var violations []core.Violation
-	for structName := range structs {
+	for _, structName := range structNames {
 		obj := scope.Lookup(structName)
 		if obj == nil {
 			continue
@@ -222,7 +215,8 @@ func (r *Pattern) checkExportedImpl(pkg *packages.Package) []core.Violation {
 			continue
 		}
 		ptrType := types.NewPointer(named)
-		for ifaceName, iface := range typedIfaces {
+		for _, ifaceName := range ifaceNames {
+			iface := typedIfaces[ifaceName]
 			if !types.Implements(named, iface) && !types.Implements(ptrType, iface) {
 				continue
 			}
@@ -330,9 +324,49 @@ func formatTypeExpr(expr ast.Expr) string {
 		return "[]" + formatTypeExpr(e.Elt)
 	case *ast.MapType:
 		return "map[" + formatTypeExpr(e.Key) + "]" + formatTypeExpr(e.Value)
+	case *ast.ChanType:
+		switch e.Dir {
+		case ast.SEND:
+			return "chan<- " + formatTypeExpr(e.Value)
+		case ast.RECV:
+			return "<-chan " + formatTypeExpr(e.Value)
+		default:
+			return "chan " + formatTypeExpr(e.Value)
+		}
+	case *ast.FuncType:
+		return "func" + formatFieldList(e.Params) + formatFuncResults(e.Results)
+	case *ast.IndexExpr:
+		return formatTypeExpr(e.X) + "[" + formatTypeExpr(e.Index) + "]"
+	case *ast.IndexListExpr:
+		parts := make([]string, 0, len(e.Indices))
+		for _, idx := range e.Indices {
+			parts = append(parts, formatTypeExpr(idx))
+		}
+		return formatTypeExpr(e.X) + "[" + strings.Join(parts, ", ") + "]"
 	default:
 		return "unknown"
 	}
+}
+
+func formatFieldList(fields *ast.FieldList) string {
+	if fields == nil {
+		return "()"
+	}
+	parts := make([]string, 0, len(fields.List))
+	for _, f := range fields.List {
+		parts = append(parts, formatTypeExpr(f.Type))
+	}
+	return "(" + strings.Join(parts, ", ") + ")"
+}
+
+func formatFuncResults(fields *ast.FieldList) string {
+	if fields == nil || len(fields.List) == 0 {
+		return ""
+	}
+	if len(fields.List) == 1 && len(fields.List[0].Names) == 0 {
+		return " " + formatTypeExpr(fields.List[0].Type)
+	}
+	return " " + formatFieldList(fields)
 }
 
 func (r *Pattern) violation(pkg *packages.Package, line int, id, message, fix string) core.Violation {

--- a/rules/interfaces/pattern_test.go
+++ b/rules/interfaces/pattern_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/NamhaeSusan/go-arch-guard/analyzer"
@@ -126,6 +127,45 @@ func TestPatternWithSeverity(t *testing.T) {
 		if v.DefaultSeverity != core.Warning {
 			t.Fatalf("%s DefaultSeverity = %v, want Warning", v.ID, v.DefaultSeverity)
 		}
+	}
+}
+
+func TestPatternConstructorReturnsInterfaceFormatsGenericReturn(t *testing.T) {
+	root := writeFixture(t, "example.com/pattern-generic-return", map[string]string{
+		"internal/store/store.go": `package store
+
+type Store interface {
+	Get(id string) string
+}
+
+type Cache[T any] struct{ v T }
+
+type s struct{}
+
+func (impl *s) Get(id string) string { return "" }
+
+// New does not return an interface — should be flagged with a readable type name.
+func New() *Cache[Store] { return &Cache[Store]{} }
+`,
+	})
+
+	violations := interfaces.NewPattern().Check(loadContext(t, root, flatArchitecture(), "example.com/pattern-generic-return"))
+
+	var found bool
+	for _, v := range violations {
+		if v.Rule != "interface.constructor-returns-interface" {
+			continue
+		}
+		found = true
+		if !strings.Contains(v.Message, "*Cache[Store]") {
+			t.Fatalf("Message should format generic type *Cache[Store], got %q", v.Message)
+		}
+		if strings.Contains(v.Message, "unknown") {
+			t.Fatalf("Message must not say 'unknown', got %q", v.Message)
+		}
+	}
+	if !found {
+		t.Fatalf("expected constructor-returns-interface violation, got %+v", violations)
 	}
 }
 

--- a/rules/types/no_setter.go
+++ b/rules/types/no_setter.go
@@ -3,6 +3,7 @@ package types
 import (
 	"fmt"
 	"go/ast"
+	"slices"
 	"strings"
 	"unicode"
 
@@ -148,10 +149,5 @@ func autoExcludedPackage(pkg *packages.Package) bool {
 
 func hasPathSegment(path, segment string) bool {
 	path = analysisutil.NormalizeMatchPath(path)
-	for _, part := range strings.Split(path, "/") {
-		if part == segment {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(strings.Split(path, "/"), segment)
 }


### PR DESCRIPTION
> **Stacked on #53** (which is stacked on #48 -> #44 -> #39). Base will auto-rebase to `main` once #53 merges.

## Summary

`rules/interfaces/` cleanup — completes the cross-package consistency work for all five rule packages.

- **#54** — Move `Option`/`ruleConfig` out of `pattern.go` into `rules/interfaces/option.go`. Rename `config` → `ruleConfig` to match `naming`/`types`/`dependency`/`structural`. Three constructors now use `newConfig(opts, default)`. **All 5 rule packages share identical Option naming.**
- **#55** — `Pattern` and `CrossDomainAnonymous` hardcode `internal/`. On flat layouts they silently emit zero violations. Now each emits `meta.layout-not-supported` Warning when no `<module>/internal/` packages exist. **Container is unchanged** (layout-agnostic by design — verified by new test that asserts no meta warning).
- **#56** — Two `pattern.go` fixes:
  - `checkExportedImpl` produced non-deterministic violation order from map iteration. Now sorts struct and interface names.
  - `formatTypeExpr` returned `\"unknown\"` for generics (`Foo[T]`, `Foo[K, V]`), channel types, and func types. Extended with `*ast.IndexExpr`, `*ast.IndexListExpr`, `*ast.ChanType` (direction-aware), and `*ast.FuncType` (with helper `formatFieldList`/`formatFuncResults`).
- **#57** — Two cleanups:
  - Promote `isTestFile` to `analysisutil.IsTestFile(file *ast.File, fset *token.FileSet) bool`. Update both `container.go` and `cross_domain.go` call sites.
  - Extend `countTypeRefs` to recurse into `*ast.IndexExpr`/`*ast.IndexListExpr` so generic type arguments (`type Cache[T Iface]`) are counted. Fixes a Container false positive.

Closes #54, closes #55, closes #56, closes #57.

## Test plan

- [x] `go test ./...` — 16/16 packages green
- [x] `goimports -w .`
- [x] `make lint` — 0 issues
- [x] New tests:
  - `core/analysisutil` — `IsTestFile` covered indirectly by all rule tests
  - `rules/interfaces/layout_meta_test.go` — three tests:
    - `TestPatternFlatLayoutEmitsMetaWarning`
    - `TestCrossDomainAnonymousFlatLayoutEmitsMetaWarning`
    - `TestContainerFlatLayoutDoesNotEmitMeta` (regression guard for layout-agnostic rule)
  - `TestContainerHandlesGenericTypeArguments` — `*Cache[Reader]` correctly NOT flagged as field-only
  - `TestPatternConstructorReturnsInterfaceFormatsGenericReturn` — Fix message contains `*Cache[Store]`, not `unknown`
- [x] code-reviewer agent — APPROVE; verified ChanDir bitmask handling, formatFuncResults single-unnamed-return path, and meta-guard ordering. Two doc nits addressed (one) or accepted as defensible (one).

## Public API impact

- **New**: `analysisutil.IsTestFile(file *ast.File, fset *token.FileSet) bool`. Stable, godoc-commented.
- **Compatible**: `interfaces.WithSeverity(...)` and `interfaces.WithMaxMethods(...)` signatures unchanged.
- **Theoretical breaking**: `interfaces.Option` switches from `func(*config)` to `func(*ruleConfig)`. No in-repo callers implement `Option`.
- **Behavior change for flat-layout users**: Pattern + CrossDomainAnonymous now emit one `meta.layout-not-supported` Warning each instead of zero violations. Severity = Warning, builds not blocked. Container is unchanged.

## Pattern consolidation status (after this PR + #39 + #44 + #48 + #53)

**All 5 rule packages share the same Option pattern**:
| Package | Pattern |
|---|---|
| `naming` | `func(*ruleConfig)` |
| `types` | `func(*ruleConfig)` |
| `dependency` | `func(*ruleConfig)` |
| `structural` | `func(*ruleConfig)` |
| `interfaces` | `func(*ruleConfig)` ← this PR |

**Shared helpers in analysisutil**: `SnakeToPascal`, `ReceiverTypeName`, `InspectTypeSpecs`/`TypeSpecInfo`, `IsTestFile` ← this PR.

**Layout-not-supported coverage** (rules that emit meta on flat layouts):
- `dependency.isolation`, `dependency.layer-direction`, `dependency.blast-radius` (#46)
- `structural.alias`, `structural.placement`, `structural.banned-package`, `structural.model-required`, `structural.internal-top-level` (#50)
- `interfaces.pattern`, `interfaces.cross-domain-anonymous` (#55, this PR)
- Layout-agnostic (no meta needed): all `naming.*`, `types.*`, and `interfaces.container`.