### PR TITLE
fix(core): close 4 data-model gaps found by codex review

### DIFF
--- a/core/context.go
+++ b/core/context.go
@@ -19,7 +19,11 @@ type Context struct {
 }
 
 // NewContext builds a Context. Excludes are normalized (leading "./"
-// stripped, OS path separators converted) at construction.
+// stripped, OS path separators converted) at construction. The Architecture
+// is deep-cloned so caller-side mutations to its maps and slices after this
+// call cannot leak into the Context's view; Arch() also returns a defensive
+// clone, but cloning here closes the construction-time window where a
+// caller could otherwise mutate shared state before the first Arch() read.
 func NewContext(pkgs []*packages.Package, module, root string, arch Architecture, exclude []string) *Context {
 	norm := make([]string, len(exclude))
 	for i, p := range exclude {
@@ -29,7 +33,7 @@ func NewContext(pkgs []*packages.Package, module, root string, arch Architecture
 		pkgs:    pkgs,
 		module:  module,
 		root:    root,
-		arch:    arch,
+		arch:    cloneArchitecture(arch),
 		exclude: norm,
 	}
 }
@@ -88,14 +92,27 @@ func matchExcludePattern(pattern, path string) bool {
 	return pattern == path
 }
 
+// normalizeMatchPath canonicalizes both exclude patterns and the file paths
+// rules emit so they match consistently. The supported equivalences are:
+//
+//   - Backslashes are converted to forward slashes (Windows-shell paste).
+//   - Leading "/" is trimmed (absolute-path fallback in analysisutil).
+//   - Leading "./" is trimmed (rule-emitted relative paths).
+//   - Trailing "/" is trimmed for non-recursive patterns; a recursive
+//     pattern keeps its "..." suffix intact since matchExcludePattern
+//     reads it.
+//
+// As a result "internal/foo", "/internal/foo", "./internal/foo",
+// "internal\\foo", and "internal/foo/" are all the same key.
 func normalizeMatchPath(path string) string {
-	// filepath.ToSlash is a no-op on Unix; mixed-style inputs (e.g. excludes
-	// copy-pasted from a Windows shell) need explicit backslash replacement
-	// to match downstream forward-slash paths emitted by rules.
 	path = strings.ReplaceAll(path, "\\", "/")
 	path = filepath.ToSlash(path)
+	path = strings.TrimPrefix(path, "/")
 	for strings.HasPrefix(path, "./") {
 		path = strings.TrimPrefix(path, "./")
+	}
+	if strings.HasSuffix(path, "/") && !strings.HasSuffix(path, "...") {
+		path = strings.TrimSuffix(path, "/")
 	}
 	return path
 }

--- a/core/context_test.go
+++ b/core/context_test.go
@@ -58,3 +58,63 @@ func TestContextIsExcludedNormalizesBackslashes(t *testing.T) {
 		t.Errorf("backslash exclude pattern must match forward-slash path")
 	}
 }
+
+func TestContextIsExcludedNormalizesLeadingSlash(t *testing.T) {
+	c := NewContext(nil, "", "", Architecture{}, []string{"internal/handler/foo.go"})
+	if !c.IsExcluded("/internal/handler/foo.go") {
+		t.Errorf("IsExcluded should normalize leading / on the input path")
+	}
+}
+
+func TestContextIsExcludedNormalizesTrailingSlash(t *testing.T) {
+	// Pattern without trailing slash should match input with trailing slash
+	// (placement rules emit dir paths as "internal/foo/").
+	c := NewContext(nil, "", "", Architecture{}, []string{"internal/handler"})
+	if !c.IsExcluded("internal/handler/") {
+		t.Errorf("IsExcluded should match trailing-slash input against bare pattern")
+	}
+
+	// And the reverse: trailing-slash pattern matching bare input.
+	c2 := NewContext(nil, "", "", Architecture{}, []string{"internal/handler/"})
+	if !c2.IsExcluded("internal/handler") {
+		t.Errorf("IsExcluded should match bare input against trailing-slash pattern")
+	}
+}
+
+func TestContextIsExcludedRecursivePatternUnchanged(t *testing.T) {
+	// Regression guard: trailing-slash trim must not break recursive "..." semantics.
+	c := NewContext(nil, "", "", Architecture{}, []string{"internal/handler/..."})
+	if !c.IsExcluded("internal/handler/foo.go") {
+		t.Errorf("recursive pattern broke after normalization changes")
+	}
+	if !c.IsExcluded("internal/handler") {
+		t.Errorf("recursive pattern should still match base path")
+	}
+	if c.IsExcluded("internal/app/foo.go") {
+		t.Errorf("recursive pattern should not match siblings")
+	}
+}
+
+func TestNewContextIsolatesCallerArchitectureMutation(t *testing.T) {
+	arch := validArchitecture()
+	arch.Layers.LayerDirNames = map[string]bool{"handler": true, "app": true}
+	c := NewContext(nil, "m", "/r", arch, nil)
+
+	// Mutate the original arch maps and slices after NewContext.
+	arch.Layers.Sublayers = append(arch.Layers.Sublayers, "rogue")
+	arch.Layers.LayerDirNames["rogue"] = true
+	arch.Layers.Direction["rogue"] = []string{"handler"}
+
+	got := c.Arch()
+	for _, sl := range got.Layers.Sublayers {
+		if sl == "rogue" {
+			t.Fatalf("caller mutation leaked into Context: Sublayers contains rogue")
+		}
+	}
+	if got.Layers.LayerDirNames["rogue"] {
+		t.Fatalf("caller mutation leaked into Context: LayerDirNames contains rogue")
+	}
+	if _, ok := got.Layers.Direction["rogue"]; ok {
+		t.Fatalf("caller mutation leaked into Context: Direction contains rogue")
+	}
+}

--- a/core/runner.go
+++ b/core/runner.go
@@ -198,15 +198,25 @@ func defaultsByID(spec RuleSpec) map[string]Severity {
 	return out
 }
 
+// dedupeMetaViolations collapses duplicate meta.* violations. The dedup key
+// is the (Rule, Message) pair, not just Rule alone — two rules can emit the
+// same meta ID with different messages (e.g. "module not determined" vs
+// "module does not match any loaded package") and both signals should reach
+// the user. Exact duplicates are still collapsed.
 func dedupeMetaViolations(in []Violation) []Violation {
-	seen := make(map[string]bool)
+	type metaKey struct {
+		Rule    string
+		Message string
+	}
+	seen := make(map[metaKey]bool)
 	out := in[:0]
 	for _, v := range in {
 		if strings.HasPrefix(v.Rule, "meta.") {
-			if seen[v.Rule] {
+			key := metaKey{Rule: v.Rule, Message: v.Message}
+			if seen[key] {
 				continue
 			}
-			seen[v.Rule] = true
+			seen[key] = true
 		}
 		out = append(out, v)
 	}

--- a/core/runner_test.go
+++ b/core/runner_test.go
@@ -231,6 +231,38 @@ func TestRunDedupesMetaViolations(t *testing.T) {
 	}
 }
 
+func TestRunPreservesMetaViolationsWithDifferentMessages(t *testing.T) {
+	r1 := &fakeRule{
+		spec: RuleSpec{ID: "fake.a"},
+		violations: []Violation{
+			{File: ".", Rule: "meta.no-matching-packages", Message: "module not determined"},
+		},
+	}
+	r2 := &fakeRule{
+		spec: RuleSpec{ID: "fake.b"},
+		violations: []Violation{
+			{File: ".", Rule: "meta.no-matching-packages", Message: "module does not match any loaded package"},
+		},
+	}
+	ctx := NewContext(nil, "", "", validArchitecture(), nil)
+	got := Run(ctx, RuleSet{}.With(r1).With(r2))
+
+	var count int
+	messages := make(map[string]bool)
+	for _, v := range got {
+		if v.Rule == "meta.no-matching-packages" {
+			count++
+			messages[v.Message] = true
+		}
+	}
+	if count != 2 {
+		t.Fatalf("len = %d, want 2 (different messages must NOT be deduped): %+v", count, got)
+	}
+	if !messages["module not determined"] || !messages["module does not match any loaded package"] {
+		t.Fatalf("expected both messages preserved, got %v", messages)
+	}
+}
+
 func TestRunRejectsUnknownWithoutID(t *testing.T) {
 	r := &fakeRule{
 		spec: RuleSpec{

--- a/rules/structural/placement.go
+++ b/rules/structural/placement.go
@@ -176,12 +176,23 @@ func matchesDomainLayer(arch core.Architecture, rel, name string) bool {
 	return len(parts) == 4 && parts[0] == "internal" && parts[1] == arch.Layout.DomainDir && parts[2] != "" && parts[3] == name
 }
 
+// isDTOAllowedSublayer reports whether the file at rel sits in one of the
+// DTOAllowedLayers. The check tries every nested depth from the sublayer
+// start position so DTOAllowedLayers entries like "core/repo" match nested
+// directories — "core" is tested first, then "core/repo", and so on. The
+// last segment of parts is the filename, so it is excluded from candidates.
 func isDTOAllowedSublayer(arch core.Architecture, rel string) bool {
 	domainDepth := len(strings.Split(arch.Layout.DomainDir, "/"))
 	parts := strings.Split(rel, "/")
-	sublayerIdx := 1 + domainDepth + 1
-	if len(parts) <= sublayerIdx {
+	sublayerStart := 1 + domainDepth + 1
+	if len(parts) <= sublayerStart {
 		return false
 	}
-	return slices.Contains(arch.Structure.DTOAllowedLayers, parts[sublayerIdx])
+	for depth := 1; sublayerStart+depth < len(parts); depth++ {
+		candidate := strings.Join(parts[sublayerStart:sublayerStart+depth], "/")
+		if slices.Contains(arch.Structure.DTOAllowedLayers, candidate) {
+			return true
+		}
+	}
+	return false
 }

--- a/rules/structural/placement_test.go
+++ b/rules/structural/placement_test.go
@@ -1,8 +1,10 @@
 package structural_test
 
 import (
+	"path/filepath"
 	"testing"
 
+	"github.com/NamhaeSusan/go-arch-guard/core"
 	"github.com/NamhaeSusan/go-arch-guard/rules/structural"
 )
 
@@ -19,4 +21,36 @@ func TestPlacement(t *testing.T) {
 		assertViolation(t, violations, "structure.middleware-placement", "internal/handler/middleware/")
 		assertViolation(t, violations, "structure.dto-placement", "internal/domain/user/core/model/user_dto.go")
 	})
+}
+
+func TestPlacementDTOAllowedLayersAcceptsNestedSublayer(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "alias.go"), "package order\n")
+	writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "core", "model", "order.go"), "package model\n")
+	writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "core", "repo", "order_dto.go"), "package repo\n")
+
+	arch := dddArch()
+	arch.Structure.DTOAllowedLayers = []string{"core/repo"}
+	ctx := core.NewContext(nil, "github.com/example/app", root, arch, nil)
+	violations := core.Run(ctx, core.NewRuleSet(structural.NewPlacement()))
+
+	for _, v := range violations {
+		if v.Rule == "structure.dto-placement" {
+			t.Fatalf("DTO under core/repo must be allowed when DTOAllowedLayers contains core/repo, got %s", v.String())
+		}
+	}
+}
+
+func TestPlacementDTOAllowedLayersStillRejectsUnlistedNestedSublayer(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "alias.go"), "package order\n")
+	writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "core", "model", "order.go"), "package model\n")
+	writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "core", "svc", "order_dto.go"), "package svc\n")
+
+	arch := dddArch()
+	arch.Structure.DTOAllowedLayers = []string{"core/repo"}
+	ctx := core.NewContext(nil, "github.com/example/app", root, arch, nil)
+	violations := core.Run(ctx, core.NewRuleSet(structural.NewPlacement()))
+
+	assertViolation(t, violations, "structure.dto-placement", "internal/domain/order/core/svc/order_dto.go")
 }


### PR DESCRIPTION
> **Stacked on #58** (which is stacked on #53 -> #48 -> #44 -> #39). Base will auto-rebase to \`main\` once #58 merges.

## Summary

PR-1 of a series addressing core/ findings from a parallel codex review. Four issues:

- **#59 (CRITICAL)** — \`rules/structural/placement.go::isDTOAllowedSublayer\` only compared the first sublayer segment, so a config like \`DTOAllowedLayers: [\"core/repo\"]\` passed architecture validation but every DTO under \`core/repo\` was still flagged. Silent broken contract. Fix: iterate every nested depth from \`sublayerStart\` upward (excluding the filename) so both single-segment and nested-segment entries match.

- **#60** — \`core/runner.go::dedupeMetaViolations\` keyed dedup on \`v.Rule\` only. When two rules emitted the same meta ID with **different messages** (e.g. \"module not determined\" vs \"module does not match any loaded package\"), only the first survived. Fix: \`(Rule, Message)\` composite key — exact duplicates still collapse, distinct diagnostics survive.

- **#61** — \`core/context.go::NewContext\` stored Architecture by value, so caller-side mutations to its maps/slices after construction leaked into later \`ctx.Arch()\` calls. Fix: deep-clone at construction. \`Arch()\`'s per-call clone stays as defense-in-depth.

- **#62** — \`normalizeMatchPath\` only handled \`\\\\\` and leading \`./\`. Now also strips leading \`/\` (absolute-path fallback) and trailing \`/\` for non-recursive patterns (placement queries with \`rel + \"/\"\`). Recursive \`...\` semantics preserved.

Closes #59, closes #60, closes #61, closes #62.

## Test plan

- [x] \`go test ./...\` — 16/16 packages green
- [x] \`make lint\` — 0 issues
- [x] New tests:
  - \`TestPlacementDTOAllowedLayersAcceptsNestedSublayer\` — nested entries match
  - \`TestPlacementDTOAllowedLayersStillRejectsUnlistedNestedSublayer\` — regression guard
  - \`TestRunPreservesMetaViolationsWithDifferentMessages\` — different messages preserved
  - \`TestNewContextIsolatesCallerArchitectureMutation\` — caller mutations don't bleed in
  - \`TestContextIsExcludedNormalizesLeadingSlash\` — \`/internal/foo\` matches \`internal/foo\`
  - \`TestContextIsExcludedNormalizesTrailingSlash\` — both directions equivalent
  - \`TestContextIsExcludedRecursivePatternUnchanged\` — \`...\` semantics intact
- [x] code-reviewer agent — APPROVE; algorithm bounds traced, dedup key safety verified, edge cases including \`/\` and \`...\` handled correctly

## Public API impact

- All changes are bug fixes that EXPAND or CORRECT matching behavior.
- No exported signatures changed.
- Users relying on the broken \`DTOAllowedLayers\` behavior would have seen 100% violation noise on every DTO file in nested layers — there can be no such users in practice.
- \`NewContext\` callers see a tighter immutability guarantee than before (positive change).

## Origin

This PR series follows the parallel codex review of \`core/\` (3 agents, one per file group). PR-1 here addresses the must-fix items. Planned follow-ups:

- **PR-2**: regression-guard tests (cloneArchitecture coverage, zero-value Validate, nil rule, severity level 5)
- **PR-3**: design-level (LayoutModel.InternalRoot, Sublayers/LayerDirNames authority, rule panic recovery, public-API rule sandboxing)