### PR TITLE
test(core): add 4 regression guards from codex review

### DIFF
--- a/core/architecture_test.go
+++ b/core/architecture_test.go
@@ -45,3 +45,110 @@ func TestArchitectureCarriesAllSubModels(t *testing.T) {
 		t.Errorf("Structure.TypePatterns[0].TypeSuffix = %q", got)
 	}
 }
+
+// TestCloneArchitectureCoversAllMutableFields is a deliberate regression
+// guard: it builds an Architecture where every map and slice field has
+// content, clones it, mutates the clone in every field, and asserts that
+// the original is untouched. If a future contributor adds a new map/slice
+// field to Architecture without extending cloneArchitecture, this test
+// fails in the relevant assertion.
+func TestCloneArchitectureCoversAllMutableFields(t *testing.T) {
+	original := Architecture{
+		Layers: LayerModel{
+			Sublayers:        []string{"handler", "core"},
+			PortLayers:       []string{"core/repo"},
+			ContractLayers:   []string{"core/repo", "core/svc"},
+			Direction:        map[string][]string{"handler": {"app"}, "app": {"core/model"}},
+			LayerDirNames:    map[string]bool{"handler": true},
+			InternalTopLevel: map[string]bool{"domain": true},
+			PkgRestricted:    map[string]bool{"core/model": true},
+		},
+		Layout: LayoutModel{DomainDir: "domain"},
+		Naming: NamingPolicy{
+			BannedPkgNames: []string{"util"},
+			LegacyPkgNames: []string{"router"},
+			AliasFileName:  "alias.go",
+		},
+		Structure: StructurePolicy{
+			RequireAlias:            true,
+			RequireModel:            true,
+			ModelPath:               "core/model",
+			DTOAllowedLayers:        []string{"handler"},
+			TypePatterns:            []TypePattern{{Dir: "worker", FilePrefix: "worker", TypeSuffix: "Worker"}},
+			InterfacePatternExclude: map[string]bool{"handler": true},
+		},
+	}
+
+	clone := cloneArchitecture(original)
+
+	// Slice fields — append to the clone and verify the original is not extended.
+	clone.Layers.Sublayers = append(clone.Layers.Sublayers, "X")
+	clone.Layers.PortLayers = append(clone.Layers.PortLayers, "X")
+	clone.Layers.ContractLayers = append(clone.Layers.ContractLayers, "X")
+	clone.Naming.BannedPkgNames = append(clone.Naming.BannedPkgNames, "X")
+	clone.Naming.LegacyPkgNames = append(clone.Naming.LegacyPkgNames, "X")
+	clone.Structure.DTOAllowedLayers = append(clone.Structure.DTOAllowedLayers, "X")
+	clone.Structure.TypePatterns = append(clone.Structure.TypePatterns, TypePattern{Dir: "X"})
+
+	// Slice element overwrites — these would mutate shared backing arrays
+	// if cloneStringSlice forgot to allocate a new array.
+	clone.Layers.Sublayers[0] = "MUTATED"
+	clone.Layers.PortLayers[0] = "MUTATED"
+	clone.Layers.ContractLayers[0] = "MUTATED"
+	clone.Naming.BannedPkgNames[0] = "MUTATED"
+	clone.Naming.LegacyPkgNames[0] = "MUTATED"
+	clone.Structure.DTOAllowedLayers[0] = "MUTATED"
+	clone.Structure.TypePatterns[0].Dir = "MUTATED"
+
+	// Map fields — insert a key and verify the original does not see it.
+	clone.Layers.LayerDirNames["new"] = true
+	clone.Layers.InternalTopLevel["new"] = true
+	clone.Layers.PkgRestricted["new"] = true
+	clone.Structure.InterfacePatternExclude["new"] = true
+	clone.Layers.Direction["new"] = []string{"X"}
+
+	// Nested slice inside the Direction map — mutate an existing inner slice.
+	clone.Layers.Direction["handler"] = append(clone.Layers.Direction["handler"], "X")
+	clone.Layers.Direction["handler"][0] = "MUTATED"
+
+	// Now check the original is intact.
+	if got := original.Layers.Sublayers; len(got) != 2 || got[0] != "handler" {
+		t.Errorf("Layers.Sublayers leaked: %v", got)
+	}
+	if got := original.Layers.PortLayers; len(got) != 1 || got[0] != "core/repo" {
+		t.Errorf("Layers.PortLayers leaked: %v", got)
+	}
+	if got := original.Layers.ContractLayers; len(got) != 2 || got[0] != "core/repo" {
+		t.Errorf("Layers.ContractLayers leaked: %v", got)
+	}
+	if got := original.Naming.BannedPkgNames; len(got) != 1 || got[0] != "util" {
+		t.Errorf("Naming.BannedPkgNames leaked: %v", got)
+	}
+	if got := original.Naming.LegacyPkgNames; len(got) != 1 || got[0] != "router" {
+		t.Errorf("Naming.LegacyPkgNames leaked: %v", got)
+	}
+	if got := original.Structure.DTOAllowedLayers; len(got) != 1 || got[0] != "handler" {
+		t.Errorf("Structure.DTOAllowedLayers leaked: %v", got)
+	}
+	if got := original.Structure.TypePatterns; len(got) != 1 || got[0].Dir != "worker" {
+		t.Errorf("Structure.TypePatterns leaked: %v", got)
+	}
+	if _, ok := original.Layers.LayerDirNames["new"]; ok {
+		t.Errorf("Layers.LayerDirNames leaked: %v", original.Layers.LayerDirNames)
+	}
+	if _, ok := original.Layers.InternalTopLevel["new"]; ok {
+		t.Errorf("Layers.InternalTopLevel leaked: %v", original.Layers.InternalTopLevel)
+	}
+	if _, ok := original.Layers.PkgRestricted["new"]; ok {
+		t.Errorf("Layers.PkgRestricted leaked: %v", original.Layers.PkgRestricted)
+	}
+	if _, ok := original.Structure.InterfacePatternExclude["new"]; ok {
+		t.Errorf("Structure.InterfacePatternExclude leaked: %v", original.Structure.InterfacePatternExclude)
+	}
+	if _, ok := original.Layers.Direction["new"]; ok {
+		t.Errorf("Layers.Direction leaked (new key): %v", original.Layers.Direction)
+	}
+	if got := original.Layers.Direction["handler"]; len(got) != 1 || got[0] != "app" {
+		t.Errorf("Layers.Direction[handler] inner slice leaked: %v", got)
+	}
+}

--- a/core/architecture_validate_test.go
+++ b/core/architecture_validate_test.go
@@ -33,6 +33,19 @@ func TestValidateAcceptsValid(t *testing.T) {
 	}
 }
 
+// TestValidateZeroValueArchitecture locks down the contract that an empty
+// Architecture is a legal "no-op" config: callers building one field at a
+// time must not see a panic from nil maps/slices, and Validate() must
+// succeed when no rules are configured. If a future change makes
+// validation stricter for zero values, that change must update this test
+// (and document the migration).
+func TestValidateZeroValueArchitecture(t *testing.T) {
+	var arch Architecture
+	if err := arch.Validate(); err != nil {
+		t.Fatalf("zero-value Architecture.Validate() = %v, want nil", err)
+	}
+}
+
 func TestValidateRejectsDirectionKeyMissing(t *testing.T) {
 	a := validArchitecture()
 	delete(a.Layers.Direction, "core/svc")

--- a/core/ruleset.go
+++ b/core/ruleset.go
@@ -16,10 +16,17 @@ func NewRuleSet(rules ...Rule) RuleSet {
 	return RuleSet{}.With(rules...)
 }
 
-// With returns a new RuleSet with the given rules appended.
+// With returns a new RuleSet with the given rules appended. nil rules are
+// silently dropped so callers can compose conditional rule lists like
+// rs.With(maybeRule()) without an explicit nil check at every site.
 func (rs RuleSet) With(rules ...Rule) RuleSet {
 	out := rs.copy()
-	out.rules = append(out.rules, rules...)
+	for _, r := range rules {
+		if r == nil {
+			continue
+		}
+		out.rules = append(out.rules, r)
+	}
 	return out
 }
 

--- a/core/ruleset_test.go
+++ b/core/ruleset_test.go
@@ -29,6 +29,26 @@ func TestRuleSetWithAppendsRules(t *testing.T) {
 	}
 }
 
+func TestRuleSetWithDropsNilRules(t *testing.T) {
+	r := &fakeRule{spec: RuleSpec{ID: "a"}}
+	rs := RuleSet{}.With(nil, r, nil)
+	if got := len(rs.Rules()); got != 1 {
+		t.Fatalf("len(Rules()) = %d, want 1 (nils must be dropped)", got)
+	}
+	if rs.Rules()[0].Spec().ID != "a" {
+		t.Errorf("Rules()[0].ID = %q", rs.Rules()[0].Spec().ID)
+	}
+}
+
+func TestRunDoesNotPanicOnNilOnlyRuleSet(t *testing.T) {
+	rs := RuleSet{}.With(nil)
+	ctx := NewContext(nil, "", "", validArchitecture(), nil)
+	got := Run(ctx, rs)
+	if len(got) != 0 {
+		t.Fatalf("got %d violations from nil-only RuleSet, want 0: %+v", len(got), got)
+	}
+}
+
 func TestRuleSetWithoutAccumulatesIDs(t *testing.T) {
 	rs := RuleSet{}.Without("isolation.cross-domain").Without("blast.high-coupling")
 	if !rs.IsViolationSkipped("isolation.cross-domain") {

--- a/core/runner_test.go
+++ b/core/runner_test.go
@@ -231,6 +231,32 @@ func TestRunDedupesMetaViolations(t *testing.T) {
 	}
 }
 
+// TestRunSeverityLevel5FallsBackToError covers the absolute fallback in
+// the severity precedence documented at runner.go:33-37. When a violation
+// has no override, no per-violation-ID spec, no meta.* prefix, and no
+// rule-level default severity, the Severity zero value (Error) is used.
+// Without this test, swapping the order of the Severity enum constants
+// (Warning=0, Error=1) would silently change the fallback behavior.
+func TestRunSeverityLevel5FallsBackToError(t *testing.T) {
+	r := &fakeRule{
+		spec: RuleSpec{ID: "fake.demo"}, // no DefaultSeverity, no Violations catalog
+		violations: []Violation{
+			{File: ".", Rule: "fake.demo", Message: "x"},
+		},
+	}
+	ctx := NewContext(nil, "", "", validArchitecture(), nil)
+	got := Run(ctx, RuleSet{}.With(r))
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+	if got[0].EffectiveSeverity != Error {
+		t.Fatalf("level-5 fallback EffectiveSeverity = %v, want Error", got[0].EffectiveSeverity)
+	}
+	if got[0].DefaultSeverity != Error {
+		t.Fatalf("level-5 fallback DefaultSeverity = %v, want Error", got[0].DefaultSeverity)
+	}
+}
+
 func TestRunPreservesMetaViolationsWithDifferentMessages(t *testing.T) {
 	r1 := &fakeRule{
 		spec: RuleSpec{ID: "fake.a"},


### PR DESCRIPTION
> **Stacked on #58 (refactor/interfaces-option-and-cleanup), which now also contains the PR-1 fixes from #63.** Base will auto-rebase to \`main\` once #58 merges.

## Summary

PR-2 of the codex review series. PR-1 (#63, already merged into the stacked base) fixed bugs; PR-2 here locks down behavior with regression-guard tests, plus one minor fix (\`RuleSet.With\` now drops nil).

- **#64** — \`cloneArchitecture\` had no test that mutating a clone leaves the original untouched. New \`TestCloneArchitectureCoversAllMutableFields\` exercises every map and slice field with both **append** (forces backing-array growth) and **overwrite** (detects shared backing array) mutations. A future contributor who adds a new \`Architecture\` field without extending \`cloneArchitecture\` will see this test fail.

- **#65** — \`Architecture{}.Validate()\` had undocumented behavior. Manual probe confirmed it returns nil (zero-value is a legal no-op config). \`TestValidateZeroValueArchitecture\` locks the contract.

- **#66** — \`RuleSet.With(nil)\` and \`Run\` with a nil rule both panicked opaquely deep inside \`Run\`. Fix: filter nil at \`With\`. Two new tests:
  - \`TestRuleSetWithDropsNilRules\` — nil entries in mixed input dropped.
  - \`TestRunDoesNotPanicOnNilOnlyRuleSet\` — nil-only ruleset runs cleanly.

- **#67** — Severity precedence level 5 (the absolute \`Error\` fallback) was implicit because \`Severity\`'s zero value happens to be \`Error\`. \`TestRunSeverityLevel5FallsBackToError\` locks the contract — if a future change swapped \`Warning\`/\`Error\` iota positions, this test would catch it.

Closes #64, closes #65, closes #66, closes #67.

## Test plan

- [x] \`go test ./...\` — 16/16 packages green
- [x] \`make lint\` — 0 issues
- [x] code-reviewer agent — APPROVE; verified clone test covers all 12 mutable fields, level-5 trace correct, nil-rule entry points fully closed.

## Public API impact

- \`RuleSet.With(nil)\` now silently drops the nil instead of panicking later inside \`Run\`. Strict improvement.
- All other changes are test-only.

## Origin

This PR series follows the parallel codex review of \`core/\` (3 agents, one per file group). PR-1 (#63) merged. PR-2 here adds regression guards. Planned follow-up: PR-3 design-level (LayoutModel.InternalRoot, Sublayers/LayerDirNames authority, rule panic recovery, public-API rule sandboxing).