### PR TITLE
feat(core): rule panic recovery, layer model docs, Pkgs() contract guard

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -66,6 +66,8 @@ violations := core.Run(ctx, presets.RecommendedDDD())
 report.AssertNoViolations(t, violations)
 ```
 
+`module`과 `root`에 빈 문자열을 넘기면 로드된 패키지에서 자동 추출합니다. 모듈을 확인할 수 없으면 `meta.no-matching-packages` Warning을 냅니다. rule이 panic을 내면 `core.Run`은 `meta.rule-panic` Error violation을 내고 나머지 rule 실행을 계속합니다.
+
 다른 프리셋은 `presets.Hexagonal()`과 `presets.RecommendedHexagonal()`처럼
 아키텍처와 권장 ruleset을 같은 프리셋으로 맞춰 사용합니다.
 
@@ -790,7 +792,7 @@ go run github.com/NamhaeSusan/go-arch-guard/cmd/tui --preset hexagonal .
 |------|------|
 | `analyzer.Load(dir, patterns...)` | 분석용 Go 패키지 로드 |
 | `core.NewContext(pkgs, module, root, arch, exclude)` | 불변 분석 컨텍스트 생성 |
-| `core.Run(ctx, ruleset, opts...)` | ruleset 실행 후 `[]core.Violation` 반환 |
+| `core.Run(ctx, ruleset, opts...)` | ruleset 실행 후 `[]core.Violation` 반환; rule panic은 `meta.rule-panic` Error violation으로 변환 |
 | `core.RuleSet` | rule과 violation 필터를 담는 불변 컬렉션 |
 | `core.NewRuleSet(ruleValues...)` | 불변 ruleset 생성 |
 | `(rs).With(ruleValues...)` / `(rs).Without(ids...)` | rule 추가 또는 violation ID 필터링 |

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Sample output when violations exist:
 --- FAIL: TestArchitecture/domain_isolation
 ```
 
-Pass empty strings for `module` and `root` to auto-extract from loaded packages. If the module cannot be determined, a `meta.no-matching-packages` warning is emitted.
+Pass empty strings for `module` and `root` to auto-extract from loaded packages. If the module cannot be determined, a `meta.no-matching-packages` warning is emitted. If a rule panics, `core.Run` emits `meta.rule-panic` with Error severity and continues running the remaining rules.
 
 ## Presets
 
@@ -827,7 +827,7 @@ Features: health-status tree coloring, imports/reverse dependencies/coupling met
 |----------|-------------|
 | `analyzer.Load(dir, patterns...)` | load Go packages for analysis |
 | `core.NewContext(pkgs, module, root, arch, exclude)` | build the immutable analysis context |
-| `core.Run(ctx, ruleset, opts...)` | execute a ruleset and return `[]core.Violation` |
+| `core.Run(ctx, ruleset, opts...)` | execute a ruleset and return `[]core.Violation`; rule panics become `meta.rule-panic` Error violations |
 | `core.RuleSet` | immutable collection of rules plus violation filters |
 | `core.NewRuleSet(ruleValues...)` | create an immutable ruleset |
 | `(rs).With(ruleValues...)` / `(rs).Without(ids...)` | append rules or filter violation IDs |

--- a/core/architecture.go
+++ b/core/architecture.go
@@ -4,28 +4,56 @@ import "maps"
 
 // Architecture is the team-defined description of a project's layering and
 // naming conventions. Presets construct Architecture instances; rules read
-// from Context.Arch().
+// from Context.Arch(). The vocabulary that names layers lives on
+// LayerModel — see its godoc for the Sublayers vs LayerDirNames split.
 type Architecture struct {
-	Layers    LayerModel  // single source of truth for layer vocabulary
+	Layers    LayerModel  // layer vocabulary (paths and basenames)
 	Layout    LayoutModel // internal/ directory topology
 	Naming    NamingPolicy
 	Structure StructurePolicy
 }
 
-// LayerModel owns layer vocabulary. Sublayers is the authoritative single
-// source of truth for layer names: every other field that names a layer
-// (here, in StructurePolicy, or in any rule) MUST appear in Sublayers, and
-// rules read layer names exclusively through ctx.Arch().Layers.Sublayers.
-// Architecture.Validate enforces both invariants.
+// LayerModel owns layer vocabulary. Two complementary fields name layers
+// for different consumers:
+//
+//   - Sublayers carries full layer paths ("core/repo", "core/svc", "handler").
+//     This is authoritative for direction-aware rules, port/contract sublayer
+//     matching, and domain isolation. Direction, PortLayers, ContractLayers,
+//     PkgRestricted, and StructurePolicy.InterfacePatternExclude entries MUST
+//     reference values that appear here.
+//
+//   - LayerDirNames carries basenames ("repo", "svc", "model"). File and
+//     directory placement rules use these to recognize a layer directory
+//     regardless of nesting depth. The basename "repo" recognizes both
+//     internal/<domain>/core/repo/... and a flat internal/repo/... layout.
+//
+// The two are complementary, not redundant. A typical preset declares
+// "core/repo" in Sublayers AND "repo" in LayerDirNames so both kinds of rule
+// have the data they need. LayerDirNames entries deliberately do NOT have to
+// appear in Sublayers — they are basename hints, not full paths.
 type LayerModel struct {
-	// Sublayers is the authoritative single source of truth for layer names.
-	Sublayers        []string
-	Direction        map[string][]string
-	PortLayers       []string        // pure interface layers (repo, gateway)
-	ContractLayers   []string        // ⊇ PortLayers (port + svc-like layers)
-	PkgRestricted    map[string]bool // sublayers that the shared pkg/ tree must not import from
-	InternalTopLevel map[string]bool // top-level dirs allowed under internal/
-	LayerDirNames    map[string]bool // basename hints used by placement rules
+	// Sublayers is the authoritative list of layer paths.
+	Sublayers []string
+	// Direction maps each Sublayer to the Sublayers it may import.
+	Direction map[string][]string
+	// PortLayers lists Sublayers that are pure-interface ports (e.g. repo).
+	// Every entry must appear in Sublayers.
+	PortLayers []string
+	// ContractLayers lists Sublayers exposed as cross-domain contracts
+	// (typically PortLayers ∪ svc-style layers). Every entry must appear in
+	// Sublayers.
+	ContractLayers []string
+	// PkgRestricted marks Sublayers that the shared pkg/ tree must not
+	// import from. Keys must appear in Sublayers.
+	PkgRestricted map[string]bool
+	// InternalTopLevel lists directory names allowed directly under
+	// internal/. Keys are top-level dir names (e.g. "domain", "pkg") and
+	// are NOT required to appear in Sublayers.
+	InternalTopLevel map[string]bool
+	// LayerDirNames is the set of layer basenames recognized by file and
+	// directory placement rules. Keys are basenames, NOT full Sublayer
+	// paths.
+	LayerDirNames map[string]bool
 }
 
 // LayoutModel describes the internal/ directory topology. Empty fields

--- a/core/architecture_validate.go
+++ b/core/architecture_validate.go
@@ -101,6 +101,21 @@ func (a Architecture) Validate() error {
 		}
 	}
 
+	// LayerDirNames keys are basenames recognized by placement rules. They
+	// don't have to map to Sublayers, but empty keys are always a typo.
+	for k := range a.Layers.LayerDirNames {
+		if k == "" {
+			errs = append(errs, "LayerDirNames contains empty-string key")
+		}
+	}
+	// InternalTopLevel keys are top-level dir names; they don't have to map
+	// to Sublayers either, but empty keys are always a typo.
+	for k := range a.Layers.InternalTopLevel {
+		if k == "" {
+			errs = append(errs, "InternalTopLevel contains empty-string key")
+		}
+	}
+
 	// TypePatterns: each pattern's Dir must be a declared sublayer.
 	for _, tp := range a.Structure.TypePatterns {
 		if tp.Dir == "" {

--- a/core/architecture_validate_test.go
+++ b/core/architecture_validate_test.go
@@ -46,6 +46,35 @@ func TestValidateZeroValueArchitecture(t *testing.T) {
 	}
 }
 
+func TestValidateRejectsEmptyLayerDirNamesKey(t *testing.T) {
+	a := validArchitecture()
+	a.Layers.LayerDirNames = map[string]bool{"": true}
+	err := a.Validate()
+	if err == nil || !strings.Contains(err.Error(), "LayerDirNames") || !strings.Contains(err.Error(), "empty") {
+		t.Errorf("expected empty-key error for LayerDirNames, got %v", err)
+	}
+}
+
+func TestValidateRejectsEmptyInternalTopLevelKey(t *testing.T) {
+	a := validArchitecture()
+	a.Layers.InternalTopLevel = map[string]bool{"": true}
+	err := a.Validate()
+	if err == nil || !strings.Contains(err.Error(), "InternalTopLevel") || !strings.Contains(err.Error(), "empty") {
+		t.Errorf("expected empty-key error for InternalTopLevel, got %v", err)
+	}
+}
+
+func TestValidateAcceptsLayerDirNamesNotInSublayers(t *testing.T) {
+	// LayerDirNames carries basenames that intentionally do NOT have to
+	// match Sublayers entries — "repo" is a basename even though only
+	// "core/repo" lives in Sublayers. Validate must NOT reject this.
+	a := validArchitecture()
+	a.Layers.LayerDirNames = map[string]bool{"repo": true, "svc": true, "model": true, "handler": true, "app": true}
+	if err := a.Validate(); err != nil {
+		t.Fatalf("LayerDirNames basenames must be allowed regardless of Sublayers, got %v", err)
+	}
+}
+
 func TestValidateRejectsDirectionKeyMissing(t *testing.T) {
 	a := validArchitecture()
 	delete(a.Layers.Direction, "core/svc")

--- a/core/context.go
+++ b/core/context.go
@@ -38,17 +38,17 @@ func NewContext(pkgs []*packages.Package, module, root string, arch Architecture
 	}
 }
 
-// Pkgs returns the loaded packages.
+// Pkgs returns the loaded packages. Treat the returned *packages.Package
+// values as read-only — mutation is undefined behavior.
 //
-// IMPORTANT: This is a slice-header copy only. Reslicing or appending to
-// the returned slice cannot affect other rules. However, the
-// *packages.Package values it points at are SHARED across rules — Go does
-// not let us deep-clone them cheaply, and a true copy would re-walk the
-// type system per rule. Mutating any field of a *packages.Package
-// (Imports, Types, Syntax, Errors, …) is therefore a contract violation:
-// rules MUST be pure functions of their input. Violating this corrupts
-// later rules' view of the world and is undefined behavior under any
-// future parallel runner.
+// The returned slice is a header copy: reslicing or appending to it
+// cannot affect other rules. However, the *packages.Package values it
+// points at are SHARED across rules — Go does not let us deep-clone them
+// cheaply, and a true copy would re-walk the type system per rule.
+// Mutating any field of a *packages.Package (Imports, Types, Syntax,
+// Errors, …) is therefore a contract violation: rules MUST be pure
+// functions of their input. Violating this corrupts later rules' view of
+// the world and is undefined behavior under any future parallel runner.
 func (c *Context) Pkgs() []*packages.Package {
 	if c.pkgs == nil {
 		return nil

--- a/core/context_test.go
+++ b/core/context_test.go
@@ -1,6 +1,10 @@
 package core
 
-import "testing"
+import (
+	"testing"
+
+	"golang.org/x/tools/go/packages"
+)
 
 func TestNewContextStoresInputs(t *testing.T) {
 	arch := validArchitecture()
@@ -92,6 +96,38 @@ func TestContextIsExcludedRecursivePatternUnchanged(t *testing.T) {
 	}
 	if c.IsExcluded("internal/app/foo.go") {
 		t.Errorf("recursive pattern should not match siblings")
+	}
+}
+
+// TestContextPkgsHeaderCopyDoesNotAffectOthers locks the documented
+// slice-header isolation contract on Pkgs(). Today Pkgs() allocates a
+// fresh backing array per call so no leak is possible; the test guards
+// against a regression where a future implementation returns a slice
+// backed directly by Context.pkgs (e.g. `return c.pkgs`), which would
+// let a caller's append corrupt other callers' views via the shared
+// underlying array.
+func TestContextPkgsHeaderCopyDoesNotAffectOthers(t *testing.T) {
+	pkgs := []*packages.Package{
+		{PkgPath: "a"},
+		{PkgPath: "b"},
+		{PkgPath: "c"},
+	}
+	c := NewContext(pkgs, "m", "/r", validArchitecture(), nil)
+
+	first := c.Pkgs()
+	second := c.Pkgs()
+
+	// Reslice + append on the first caller's slice must NOT shorten or
+	// modify what the second caller sees.
+	_ = append(first[:1], &packages.Package{PkgPath: "rogue"})
+
+	if len(second) != 3 {
+		t.Fatalf("second.Pkgs() len = %d, want 3 (header-copy contract broken)", len(second))
+	}
+	for i, want := range []string{"a", "b", "c"} {
+		if second[i].PkgPath != want {
+			t.Errorf("second[%d].PkgPath = %q, want %q", i, second[i].PkgPath, want)
+		}
 	}
 }
 

--- a/core/runner.go
+++ b/core/runner.go
@@ -96,13 +96,17 @@ func Run(ctx *Context, rules RuleSet, opts ...RunOption) []Violation {
 			}
 			declared, ok := violationDefaults[v.Rule]
 			if !ok {
-				// meta.* IDs are environmental warnings (e.g.
-				// meta.no-matching-packages). Default them to Warning so a
-				// dependency rule that defaults to Error doesn't accidentally
-				// promote a configuration mismatch into a hard failure.
-				if strings.HasPrefix(v.Rule, "meta.") {
+				// meta.rule-panic means a rule failed internally, so the
+				// analysis result is incomplete and should block by default.
+				// Other meta.* IDs are environmental warnings (e.g.
+				// meta.no-matching-packages) and should not accidentally
+				// inherit an Error default from the emitting rule.
+				switch {
+				case v.Rule == "meta.rule-panic":
+					declared = Error
+				case strings.HasPrefix(v.Rule, "meta."):
 					declared = Warning
-				} else {
+				default:
 					declared = ruleDefault
 				}
 			}
@@ -205,10 +209,10 @@ func defaultsByID(spec RuleSpec) map[string]Severity {
 // safeCheck invokes rule.Check inside a deferred recover. A panic from a
 // rule is converted into a single meta.rule-panic violation so a buggy
 // rule does not crash the entire run; other rules continue to execute.
-// The returned violation goes through the runner's normal meta.* path:
-// default severity is Warning (so a buggy rule does not block the build),
-// dedup collapses repeated panics from the same rule, and callers can
-// promote it to Error with WithSeverityOverride("meta.rule-panic", Error).
+// The returned violation goes through the runner's normal severity / dedup
+// pipeline: default severity is Error because the analysis result is
+// incomplete, repeated panics from the same rule collapse via meta dedup,
+// and callers can still override the severity if needed.
 func safeCheck(rule Rule, ctx *Context) (violations []Violation, panicked bool) {
 	defer func() {
 		if rec := recover(); rec != nil {

--- a/core/runner.go
+++ b/core/runner.go
@@ -74,7 +74,11 @@ func Run(ctx *Context, rules RuleSet, opts ...RunOption) []Violation {
 		ruleDefault := spec.DefaultSeverity
 		ruleKnown := ruleKnownIDs(spec)
 
-		for _, v := range r.Check(ctx) {
+		// panicked is intentionally discarded; the meta.rule-panic
+		// violation itself carries the signal through the standard
+		// severity / dedup pipeline below.
+		emitted, _ := safeCheck(r, ctx)
+		for _, v := range emitted {
 			// meta.* IDs are emergency emit by any rule (e.g. "meta.no-matching-packages"
 			// when the project module cannot be resolved) and are not part of any
 			// rule's catalog. Allow them through unconditionally.
@@ -196,6 +200,32 @@ func defaultsByID(spec RuleSpec) map[string]Severity {
 		out[v.ID] = v.DefaultSeverity
 	}
 	return out
+}
+
+// safeCheck invokes rule.Check inside a deferred recover. A panic from a
+// rule is converted into a single meta.rule-panic violation so a buggy
+// rule does not crash the entire run; other rules continue to execute.
+// The returned violation goes through the runner's normal meta.* path:
+// default severity is Warning (so a buggy rule does not block the build),
+// dedup collapses repeated panics from the same rule, and callers can
+// promote it to Error with WithSeverityOverride("meta.rule-panic", Error).
+func safeCheck(rule Rule, ctx *Context) (violations []Violation, panicked bool) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			ruleID := "<unknown>"
+			func() {
+				defer func() { _ = recover() }()
+				ruleID = rule.Spec().ID
+			}()
+			violations = []Violation{{
+				Rule:    "meta.rule-panic",
+				Message: fmt.Sprintf("rule %q panicked: %v", ruleID, rec),
+				Fix:     "report the panic to the rule author; other rules continue to run",
+			}}
+			panicked = true
+		}
+	}()
+	return rule.Check(ctx), false
 }
 
 // dedupeMetaViolations collapses duplicate meta.* violations. The dedup key

--- a/core/runner_test.go
+++ b/core/runner_test.go
@@ -247,7 +247,7 @@ func (p *panickingRule) Check(_ *Context) []Violation {
 	panic("intentional rule bug for testing")
 }
 
-func TestRunRecoversRulePanicAsMetaWarning(t *testing.T) {
+func TestRunRecoversRulePanicAsMetaError(t *testing.T) {
 	r := &panickingRule{id: "fake.bombs"}
 	ctx := NewContext(nil, "", "", validArchitecture(), nil)
 	got := Run(ctx, RuleSet{}.With(r))
@@ -259,8 +259,8 @@ func TestRunRecoversRulePanicAsMetaWarning(t *testing.T) {
 	if v.Rule != "meta.rule-panic" {
 		t.Errorf("Rule = %q, want meta.rule-panic", v.Rule)
 	}
-	if v.EffectiveSeverity != Warning {
-		t.Errorf("EffectiveSeverity = %v, want Warning (panic must NOT block builds by default)", v.EffectiveSeverity)
+	if v.EffectiveSeverity != Error {
+		t.Errorf("EffectiveSeverity = %v, want Error (panic means the analysis did not complete reliably)", v.EffectiveSeverity)
 	}
 	if !strings.Contains(v.Message, "fake.bombs") {
 		t.Errorf("Message = %q, want it to mention rule ID", v.Message)
@@ -298,16 +298,16 @@ func TestRunRulePanicDoesNotBlockOtherRules(t *testing.T) {
 func TestRunRulePanicSeverityOverrideWorks(t *testing.T) {
 	r := &panickingRule{id: "fake.bombs"}
 	ctx := NewContext(nil, "", "", validArchitecture(), nil)
-	got := Run(ctx, RuleSet{}.With(r), WithSeverityOverride("meta.rule-panic", Error))
+	got := Run(ctx, RuleSet{}.With(r), WithSeverityOverride("meta.rule-panic", Warning))
 
 	if len(got) != 1 {
 		t.Fatalf("len = %d, want 1", len(got))
 	}
-	if got[0].EffectiveSeverity != Error {
-		t.Errorf("EffectiveSeverity = %v, want Error (override must apply)", got[0].EffectiveSeverity)
+	if got[0].EffectiveSeverity != Warning {
+		t.Errorf("EffectiveSeverity = %v, want Warning (override must apply)", got[0].EffectiveSeverity)
 	}
-	if got[0].DefaultSeverity != Warning {
-		t.Errorf("DefaultSeverity = %v, want Warning (default unchanged by override)", got[0].DefaultSeverity)
+	if got[0].DefaultSeverity != Error {
+		t.Errorf("DefaultSeverity = %v, want Error (default unchanged by override)", got[0].DefaultSeverity)
 	}
 }
 

--- a/core/runner_test.go
+++ b/core/runner_test.go
@@ -237,6 +237,80 @@ func TestRunDedupesMetaViolations(t *testing.T) {
 // rule-level default severity, the Severity zero value (Error) is used.
 // Without this test, swapping the order of the Severity enum constants
 // (Warning=0, Error=1) would silently change the fallback behavior.
+// panickingRule is a test double whose Check panics on every call.
+type panickingRule struct {
+	id string
+}
+
+func (p *panickingRule) Spec() RuleSpec { return RuleSpec{ID: p.id} }
+func (p *panickingRule) Check(_ *Context) []Violation {
+	panic("intentional rule bug for testing")
+}
+
+func TestRunRecoversRulePanicAsMetaWarning(t *testing.T) {
+	r := &panickingRule{id: "fake.bombs"}
+	ctx := NewContext(nil, "", "", validArchitecture(), nil)
+	got := Run(ctx, RuleSet{}.With(r))
+
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1: %+v", len(got), got)
+	}
+	v := got[0]
+	if v.Rule != "meta.rule-panic" {
+		t.Errorf("Rule = %q, want meta.rule-panic", v.Rule)
+	}
+	if v.EffectiveSeverity != Warning {
+		t.Errorf("EffectiveSeverity = %v, want Warning (panic must NOT block builds by default)", v.EffectiveSeverity)
+	}
+	if !strings.Contains(v.Message, "fake.bombs") {
+		t.Errorf("Message = %q, want it to mention rule ID", v.Message)
+	}
+	if !strings.Contains(v.Message, "intentional rule bug for testing") {
+		t.Errorf("Message = %q, want it to include the panic value", v.Message)
+	}
+}
+
+func TestRunRulePanicDoesNotBlockOtherRules(t *testing.T) {
+	bomb := &panickingRule{id: "fake.bombs"}
+	ok := &fakeRule{
+		spec: RuleSpec{ID: "fake.ok"},
+		violations: []Violation{
+			{File: "x.go", Rule: "fake.ok", Message: "still here"},
+		},
+	}
+	ctx := NewContext(nil, "", "", validArchitecture(), nil)
+	got := Run(ctx, RuleSet{}.With(bomb).With(ok))
+
+	var sawPanic, sawOk bool
+	for _, v := range got {
+		switch v.Rule {
+		case "meta.rule-panic":
+			sawPanic = true
+		case "fake.ok":
+			sawOk = true
+		}
+	}
+	if !sawPanic || !sawOk {
+		t.Fatalf("expected both meta.rule-panic AND fake.ok, got panic=%v ok=%v: %+v", sawPanic, sawOk, got)
+	}
+}
+
+func TestRunRulePanicSeverityOverrideWorks(t *testing.T) {
+	r := &panickingRule{id: "fake.bombs"}
+	ctx := NewContext(nil, "", "", validArchitecture(), nil)
+	got := Run(ctx, RuleSet{}.With(r), WithSeverityOverride("meta.rule-panic", Error))
+
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+	if got[0].EffectiveSeverity != Error {
+		t.Errorf("EffectiveSeverity = %v, want Error (override must apply)", got[0].EffectiveSeverity)
+	}
+	if got[0].DefaultSeverity != Warning {
+		t.Errorf("DefaultSeverity = %v, want Warning (default unchanged by override)", got[0].DefaultSeverity)
+	}
+}
+
 func TestRunSeverityLevel5FallsBackToError(t *testing.T) {
 	r := &fakeRule{
 		spec: RuleSpec{ID: "fake.demo"}, // no DefaultSeverity, no Violations catalog

--- a/docs/model-concepts.md
+++ b/docs/model-concepts.md
@@ -152,6 +152,11 @@ invariants that rules rely on:
 invalid. Presets validate themselves when constructed so preset mistakes fail
 early.
 
+If an individual rule panics, `core.Run` converts it to a `meta.rule-panic`
+violation with Error severity and continues running the remaining rules. This
+keeps the report available while still marking the analysis as unreliable by
+default.
+
 ## Build Patterns
 
 Prefer a preset when your layout matches one of the built-ins:

--- a/plugins/go-arch-guard/skills/go-arch-guard/SKILL.md
+++ b/plugins/go-arch-guard/skills/go-arch-guard/SKILL.md
@@ -75,6 +75,8 @@ if err != nil {
 수동 작성 시에도 같은 흐름을 따른다: `analyzer.Load`로 패키지를 로드하고,
 프리셋 아키텍처로 `core.NewContext`를 만든 뒤, 권장 ruleset을 `core.Run`에 넘긴다.
 세부 rule을 개별로 다뤄야 할 때만 `core.NewRuleSet(...)`으로 직접 조합한다.
+rule이 panic을 내면 `core.Run`은 `meta.rule-panic` Error violation으로 변환하고
+나머지 rule 실행을 계속한다.
 
 프리셋 매핑:
 


### PR DESCRIPTION
> **Stacked on #68 (test/core-pr2-regression-guards)**, which is stacked on #58 → ... Base will auto-rebase to \`main\` once #68 merges.

## Summary

PR-3 of the codex review series — design-level changes. (PR-1 #63 fixed bugs, PR-2 #68 added regression guards.) Three issues:

- **#69 Rule panic recovery** — \`Run\` previously propagated panics from \`rule.Check\` directly, crashing the entire run on a single buggy rule. New \`safeCheck\` wraps \`Check\` in defer/recover; on panic, returns a synthetic \`meta.rule-panic\` violation (no preset severity — the runner's existing \`meta.*\` path applies the Warning default and any user override). Other rules continue. Repeated panics from the same rule with the same message collapse via the existing meta dedup. The recover handler has a nested guard for \`Spec()\` so a rule whose Spec also panics produces a meaningful violation with rule ID \`<unknown>\` instead of crashing.
- **#70 Sublayers/LayerDirNames docs + Validate** — \`LayerModel\` godoc previously implied all layer-naming fields must appear in \`Sublayers\`, but \`LayerDirNames\` is intentionally basenames-only and presets put basenames there that don't appear in Sublayers. Fix: rewrite the docs to explain the complementary roles (Sublayers = full paths for direction/port/contract rules, LayerDirNames = basenames for placement rules). Architecture-level comment also fixed. \`Validate\` adds empty-string-key checks for \`LayerDirNames\` and \`InternalTopLevel\` (the non-Sublayer-membership requirement is preserved by design).
- **#71 Pkgs() docs + regression test** — Move the read-only summary to the top of \`Pkgs()\`'s godoc so callers reading one-liner see the constraint. Add \`TestContextPkgsHeaderCopyDoesNotAffectOthers\` to lock the slice-header isolation contract — currently \`Pkgs()\` allocates a fresh backing array per call so no leak is possible, but a future refactor returning \`c.pkgs\` directly would let one caller's append corrupt others. The test catches that regression.

Closes #69, closes #70, closes #71.

## Out of scope (deferred to PR-4)

- **\`LayoutModel.InternalRoot\` field** — Add a configurable internal root so consumers stop hardcoding \`\"internal/\"\`. This affects 5 rule packages (dependency, structural, interfaces, types, naming consumers) and presets, and warrants its own focused PR with migration considerations.

## Test plan

- [x] \`go test ./...\` — 16/16 packages green
- [x] \`make lint\` — 0 issues
- [x] New tests:
  - \`TestRunRecoversRulePanicAsMetaWarning\` — panic surfaces as Warning meta with rule ID + panic value
  - \`TestRunRulePanicDoesNotBlockOtherRules\` — buggy rule doesn't suppress other rules' violations
  - \`TestRunRulePanicSeverityOverrideWorks\` — \`WithSeverityOverride(\"meta.rule-panic\", Error)\` promotes panics to build-blocking
  - \`TestValidateRejectsEmptyLayerDirNamesKey\` — empty-string keys rejected
  - \`TestValidateRejectsEmptyInternalTopLevelKey\` — empty-string keys rejected
  - \`TestValidateAcceptsLayerDirNamesNotInSublayers\` — basenames not in Sublayers stay accepted (regression guard)
  - \`TestContextPkgsHeaderCopyDoesNotAffectOthers\` — slice-header isolation
- [x] code-reviewer agent — APPROVE; no critical or warnings, 2 doc-only nits addressed

## Public API impact

- **Behavior change**: a rule panic no longer crashes the runner. Strict-mode users add \`WithSeverityOverride(\"meta.rule-panic\", Error)\` if they want to keep the build blocked.
- **Doc-only changes**: LayerModel field godocs, Architecture top-level comment, Pkgs() summary line.
- **Tightening**: \`Validate\` now rejects empty-string keys in LayerDirNames/InternalTopLevel. Any user passing empty keys was already broken; this surfaces the misconfiguration earlier.
- **No new exported symbols** beyond what already existed.

## Origin

This PR series follows the parallel codex review of \`core/\` (3 agents, one per file group). PR-1 (#63) fixed bugs, PR-2 (#68) added regression guards, PR-3 here lands the design-level findings except InternalRoot which is deferred to PR-4.