### PR TITLE
feat(core/rules): full codex review series — Option unification, analysisutil helpers, flat-layout meta, regression guards, panic recovery, InternalRoot

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -66,6 +66,8 @@ violations := core.Run(ctx, presets.RecommendedDDD())
 report.AssertNoViolations(t, violations)
 ```
 
+`module`과 `root`에 빈 문자열을 넘기면 로드된 패키지에서 자동 추출합니다. 모듈을 확인할 수 없으면 `meta.no-matching-packages` Warning을 냅니다. rule이 panic을 내면 `core.Run`은 `meta.rule-panic` Error violation을 내고 나머지 rule 실행을 계속합니다.
+
 다른 프리셋은 `presets.Hexagonal()`과 `presets.RecommendedHexagonal()`처럼
 아키텍처와 권장 ruleset을 같은 프리셋으로 맞춰 사용합니다.
 
@@ -790,7 +792,7 @@ go run github.com/NamhaeSusan/go-arch-guard/cmd/tui --preset hexagonal .
 |------|------|
 | `analyzer.Load(dir, patterns...)` | 분석용 Go 패키지 로드 |
 | `core.NewContext(pkgs, module, root, arch, exclude)` | 불변 분석 컨텍스트 생성 |
-| `core.Run(ctx, ruleset, opts...)` | ruleset 실행 후 `[]core.Violation` 반환 |
+| `core.Run(ctx, ruleset, opts...)` | ruleset 실행 후 `[]core.Violation` 반환; rule panic은 `meta.rule-panic` Error violation으로 변환 |
 | `core.RuleSet` | rule과 violation 필터를 담는 불변 컬렉션 |
 | `core.NewRuleSet(ruleValues...)` | 불변 ruleset 생성 |
 | `(rs).With(ruleValues...)` / `(rs).Without(ids...)` | rule 추가 또는 violation ID 필터링 |

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Sample output when violations exist:
 --- FAIL: TestArchitecture/domain_isolation
 ```
 
-Pass empty strings for `module` and `root` to auto-extract from loaded packages. If the module cannot be determined, a `meta.no-matching-packages` warning is emitted.
+Pass empty strings for `module` and `root` to auto-extract from loaded packages. If the module cannot be determined, a `meta.no-matching-packages` warning is emitted. If a rule panics, `core.Run` emits `meta.rule-panic` with Error severity and continues running the remaining rules.
 
 ## Presets
 
@@ -827,7 +827,7 @@ Features: health-status tree coloring, imports/reverse dependencies/coupling met
 |----------|-------------|
 | `analyzer.Load(dir, patterns...)` | load Go packages for analysis |
 | `core.NewContext(pkgs, module, root, arch, exclude)` | build the immutable analysis context |
-| `core.Run(ctx, ruleset, opts...)` | execute a ruleset and return `[]core.Violation` |
+| `core.Run(ctx, ruleset, opts...)` | execute a ruleset and return `[]core.Violation`; rule panics become `meta.rule-panic` Error violations |
 | `core.RuleSet` | immutable collection of rules plus violation filters |
 | `core.NewRuleSet(ruleValues...)` | create an immutable ruleset |
 | `(rs).With(ruleValues...)` / `(rs).Without(ids...)` | append rules or filter violation IDs |

--- a/core/analysisutil/ast.go
+++ b/core/analysisutil/ast.go
@@ -2,9 +2,58 @@ package analysisutil
 
 import (
 	"go/ast"
+	"go/token"
 	"go/types"
 	"strings"
 )
+
+// TypeSpecInfo describes a single top-level type declaration in a Go file —
+// what InspectTypeSpecs extracts. Callers compute file-level metadata (e.g.
+// a relative path) once outside the loop; only per-decl fields live here.
+type TypeSpecInfo struct {
+	Name        string
+	Line        int
+	IsInterface bool
+	AliasFrom   string // import path of `type X = pkg.Y`; empty if not an alias
+}
+
+// InspectTypeSpecs walks the top-level type decls in file and returns one
+// entry per interface declaration or per type alias whose RHS is
+// `<ident>.<Name>`. Other type decls are skipped. Callers usually want to
+// detect interfaces or detect re-exports of types from other packages.
+func InspectTypeSpecs(file *ast.File, fset *token.FileSet) []TypeSpecInfo {
+	var result []TypeSpecInfo
+	for _, decl := range file.Decls {
+		gd, ok := decl.(*ast.GenDecl)
+		if !ok {
+			continue
+		}
+		for _, spec := range gd.Specs {
+			ts, ok := spec.(*ast.TypeSpec)
+			if !ok {
+				continue
+			}
+			info := TypeSpecInfo{
+				Name: ts.Name.Name,
+				Line: fset.Position(ts.Name.Pos()).Line,
+			}
+			if _, ok := ts.Type.(*ast.InterfaceType); ok {
+				info.IsInterface = true
+			}
+			if ts.Assign != 0 {
+				if sel, ok := ts.Type.(*ast.SelectorExpr); ok {
+					if ident, ok := sel.X.(*ast.Ident); ok {
+						info.AliasFrom = ResolveIdentImportPath(file, ident.Name)
+					}
+				}
+			}
+			if info.IsInterface || info.AliasFrom != "" {
+				result = append(result, info)
+			}
+		}
+	}
+	return result
+}
 
 // ReceiverTypeName extracts the unqualified receiver type name from an
 // *ast.FuncDecl receiver expression. It unwraps a leading pointer and

--- a/core/analysisutil/ast.go
+++ b/core/analysisutil/ast.go
@@ -6,6 +6,48 @@ import (
 	"strings"
 )
 
+// ReceiverTypeName extracts the unqualified receiver type name from an
+// *ast.FuncDecl receiver expression. It unwraps a leading pointer and
+// handles generic receivers — *ast.IndexExpr (T[U]) and *ast.IndexListExpr
+// (T[U, V]) — so callers do not silently miss methods on parameterized
+// types. Returns "" if the expression does not match a recognized shape.
+func ReceiverTypeName(expr ast.Expr) string {
+	if star, ok := expr.(*ast.StarExpr); ok {
+		expr = star.X
+	}
+	switch t := expr.(type) {
+	case *ast.Ident:
+		return t.Name
+	case *ast.IndexExpr:
+		if id, ok := t.X.(*ast.Ident); ok {
+			return id.Name
+		}
+	case *ast.IndexListExpr:
+		if id, ok := t.X.(*ast.Ident); ok {
+			return id.Name
+		}
+	}
+	return ""
+}
+
+// SnakeToPascal converts a snake_case identifier (e.g. "user_repository")
+// to PascalCase (e.g. "UserRepository"). Empty segments are skipped, so
+// leading/trailing/double underscores do not produce empty letters. Input
+// is assumed to be ASCII; non-ASCII first bytes in a segment are not
+// case-converted but are preserved.
+func SnakeToPascal(s string) string {
+	parts := strings.Split(s, "_")
+	var b strings.Builder
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		b.WriteString(strings.ToUpper(part[:1]))
+		b.WriteString(part[1:])
+	}
+	return b.String()
+}
+
 func ResolveIdentImportPath(file *ast.File, identName string) string {
 	for _, imp := range file.Imports {
 		impPath := strings.Trim(imp.Path.Value, `"`)

--- a/core/analysisutil/ast.go
+++ b/core/analysisutil/ast.go
@@ -7,6 +7,16 @@ import (
 	"strings"
 )
 
+// IsTestFile reports whether file's source path ends with "_test.go". The
+// callsite supplies fset because *ast.File alone does not retain its
+// filename — only token.Position does.
+func IsTestFile(file *ast.File, fset *token.FileSet) bool {
+	if file == nil || fset == nil {
+		return false
+	}
+	return strings.HasSuffix(fset.Position(file.Pos()).Filename, "_test.go")
+}
+
 // TypeSpecInfo describes a single top-level type declaration in a Go file —
 // what InspectTypeSpecs extracts. Callers compute file-level metadata (e.g.
 // a relative path) once outside the loop; only per-decl fields live here.

--- a/core/analysisutil/ast_test.go
+++ b/core/analysisutil/ast_test.go
@@ -9,6 +9,61 @@ import (
 	"testing"
 )
 
+func TestReceiverTypeName(t *testing.T) {
+	src := `package sample
+type Foo struct{}
+func (f Foo) A() {}
+func (f *Foo) B() {}
+type Bar[T any] struct{}
+func (b Bar[T]) C() {}
+func (b *Bar[T]) D() {}
+type Baz[K comparable, V any] struct{}
+func (z *Baz[K, V]) E() {}
+`
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "sample.go", src, parser.AllErrors)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"Foo", "Foo", "Bar", "Bar", "Baz"}
+	var got []string
+	for _, decl := range file.Decls {
+		fd, ok := decl.(*ast.FuncDecl)
+		if !ok || fd.Recv == nil {
+			continue
+		}
+		got = append(got, ReceiverTypeName(fd.Recv.List[0].Type))
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d names, want %d: %v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestSnakeToPascal(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"user_repository", "UserRepository"},
+		{"order", "Order"},
+		{"a_b_c", "ABC"},
+		{"", ""},
+		{"_leading", "Leading"},
+		{"trailing_", "Trailing"},
+		{"double__underscore", "DoubleUnderscore"},
+	}
+	for _, tc := range cases {
+		if got := SnakeToPascal(tc.in); got != tc.want {
+			t.Fatalf("SnakeToPascal(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
 func TestResolveIdentImportPath(t *testing.T) {
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, "sample.go", `package sample

--- a/core/architecture.go
+++ b/core/architecture.go
@@ -4,28 +4,56 @@ import "maps"
 
 // Architecture is the team-defined description of a project's layering and
 // naming conventions. Presets construct Architecture instances; rules read
-// from Context.Arch().
+// from Context.Arch(). The vocabulary that names layers lives on
+// LayerModel — see its godoc for the Sublayers vs LayerDirNames split.
 type Architecture struct {
-	Layers    LayerModel  // single source of truth for layer vocabulary
+	Layers    LayerModel  // layer vocabulary (paths and basenames)
 	Layout    LayoutModel // internal/ directory topology
 	Naming    NamingPolicy
 	Structure StructurePolicy
 }
 
-// LayerModel owns layer vocabulary. Sublayers is the authoritative single
-// source of truth for layer names: every other field that names a layer
-// (here, in StructurePolicy, or in any rule) MUST appear in Sublayers, and
-// rules read layer names exclusively through ctx.Arch().Layers.Sublayers.
-// Architecture.Validate enforces both invariants.
+// LayerModel owns layer vocabulary. Two complementary fields name layers
+// for different consumers:
+//
+//   - Sublayers carries full layer paths ("core/repo", "core/svc", "handler").
+//     This is authoritative for direction-aware rules, port/contract sublayer
+//     matching, and domain isolation. Direction, PortLayers, ContractLayers,
+//     PkgRestricted, and StructurePolicy.InterfacePatternExclude entries MUST
+//     reference values that appear here.
+//
+//   - LayerDirNames carries basenames ("repo", "svc", "model"). File and
+//     directory placement rules use these to recognize a layer directory
+//     regardless of nesting depth. The basename "repo" recognizes both
+//     internal/<domain>/core/repo/... and a flat internal/repo/... layout.
+//
+// The two are complementary, not redundant. A typical preset declares
+// "core/repo" in Sublayers AND "repo" in LayerDirNames so both kinds of rule
+// have the data they need. LayerDirNames entries deliberately do NOT have to
+// appear in Sublayers — they are basename hints, not full paths.
 type LayerModel struct {
-	// Sublayers is the authoritative single source of truth for layer names.
-	Sublayers        []string
-	Direction        map[string][]string
-	PortLayers       []string        // pure interface layers (repo, gateway)
-	ContractLayers   []string        // ⊇ PortLayers (port + svc-like layers)
-	PkgRestricted    map[string]bool // sublayers that the shared pkg/ tree must not import from
-	InternalTopLevel map[string]bool // top-level dirs allowed under internal/
-	LayerDirNames    map[string]bool // basename hints used by placement rules
+	// Sublayers is the authoritative list of layer paths.
+	Sublayers []string
+	// Direction maps each Sublayer to the Sublayers it may import.
+	Direction map[string][]string
+	// PortLayers lists Sublayers that are pure-interface ports (e.g. repo).
+	// Every entry must appear in Sublayers.
+	PortLayers []string
+	// ContractLayers lists Sublayers exposed as cross-domain contracts
+	// (typically PortLayers ∪ svc-style layers). Every entry must appear in
+	// Sublayers.
+	ContractLayers []string
+	// PkgRestricted marks Sublayers that the shared pkg/ tree must not
+	// import from. Keys must appear in Sublayers.
+	PkgRestricted map[string]bool
+	// InternalTopLevel lists directory names allowed directly under
+	// internal/. Keys are top-level dir names (e.g. "domain", "pkg") and
+	// are NOT required to appear in Sublayers.
+	InternalTopLevel map[string]bool
+	// LayerDirNames is the set of layer basenames recognized by file and
+	// directory placement rules. Keys are basenames, NOT full Sublayer
+	// paths.
+	LayerDirNames map[string]bool
 }
 
 // LayoutModel describes the internal/ directory topology. Empty fields

--- a/core/architecture.go
+++ b/core/architecture.go
@@ -56,10 +56,15 @@ type LayerModel struct {
 	LayerDirNames map[string]bool
 }
 
-// LayoutModel describes the internal/ directory topology. Empty fields
+// LayoutModel describes the package-root directory topology. Empty fields
 // disable the corresponding classification (e.g. flat layouts leave
 // DomainDir == "").
 type LayoutModel struct {
+	// InternalRoot is the project-relative directory under which all
+	// rule-managed packages live. Defaults to "internal" when empty;
+	// cloneArchitecture normalizes the empty value at construction so
+	// rules read this field directly without a per-call default check.
+	InternalRoot     string
 	DomainDir        string
 	OrchestrationDir string
 	SharedDir        string
@@ -94,8 +99,14 @@ type TypePattern struct {
 }
 
 // cloneArchitecture deep-copies every slice and map in an Architecture so
-// callers handling the result cannot influence the original.
+// callers handling the result cannot influence the original. It also
+// normalizes Layout.InternalRoot to "internal" when empty, which is the
+// single source of truth for that default — every consumer reads the
+// normalized value, so no per-call conditional is needed.
 func cloneArchitecture(a Architecture) Architecture {
+	if a.Layout.InternalRoot == "" {
+		a.Layout.InternalRoot = "internal"
+	}
 	return Architecture{
 		Layers: LayerModel{
 			Sublayers:        cloneStringSlice(a.Layers.Sublayers),

--- a/core/architecture_test.go
+++ b/core/architecture_test.go
@@ -45,3 +45,110 @@ func TestArchitectureCarriesAllSubModels(t *testing.T) {
 		t.Errorf("Structure.TypePatterns[0].TypeSuffix = %q", got)
 	}
 }
+
+// TestCloneArchitectureCoversAllMutableFields is a deliberate regression
+// guard: it builds an Architecture where every map and slice field has
+// content, clones it, mutates the clone in every field, and asserts that
+// the original is untouched. If a future contributor adds a new map/slice
+// field to Architecture without extending cloneArchitecture, this test
+// fails in the relevant assertion.
+func TestCloneArchitectureCoversAllMutableFields(t *testing.T) {
+	original := Architecture{
+		Layers: LayerModel{
+			Sublayers:        []string{"handler", "core"},
+			PortLayers:       []string{"core/repo"},
+			ContractLayers:   []string{"core/repo", "core/svc"},
+			Direction:        map[string][]string{"handler": {"app"}, "app": {"core/model"}},
+			LayerDirNames:    map[string]bool{"handler": true},
+			InternalTopLevel: map[string]bool{"domain": true},
+			PkgRestricted:    map[string]bool{"core/model": true},
+		},
+		Layout: LayoutModel{DomainDir: "domain"},
+		Naming: NamingPolicy{
+			BannedPkgNames: []string{"util"},
+			LegacyPkgNames: []string{"router"},
+			AliasFileName:  "alias.go",
+		},
+		Structure: StructurePolicy{
+			RequireAlias:            true,
+			RequireModel:            true,
+			ModelPath:               "core/model",
+			DTOAllowedLayers:        []string{"handler"},
+			TypePatterns:            []TypePattern{{Dir: "worker", FilePrefix: "worker", TypeSuffix: "Worker"}},
+			InterfacePatternExclude: map[string]bool{"handler": true},
+		},
+	}
+
+	clone := cloneArchitecture(original)
+
+	// Slice fields — append to the clone and verify the original is not extended.
+	clone.Layers.Sublayers = append(clone.Layers.Sublayers, "X")
+	clone.Layers.PortLayers = append(clone.Layers.PortLayers, "X")
+	clone.Layers.ContractLayers = append(clone.Layers.ContractLayers, "X")
+	clone.Naming.BannedPkgNames = append(clone.Naming.BannedPkgNames, "X")
+	clone.Naming.LegacyPkgNames = append(clone.Naming.LegacyPkgNames, "X")
+	clone.Structure.DTOAllowedLayers = append(clone.Structure.DTOAllowedLayers, "X")
+	clone.Structure.TypePatterns = append(clone.Structure.TypePatterns, TypePattern{Dir: "X"})
+
+	// Slice element overwrites — these would mutate shared backing arrays
+	// if cloneStringSlice forgot to allocate a new array.
+	clone.Layers.Sublayers[0] = "MUTATED"
+	clone.Layers.PortLayers[0] = "MUTATED"
+	clone.Layers.ContractLayers[0] = "MUTATED"
+	clone.Naming.BannedPkgNames[0] = "MUTATED"
+	clone.Naming.LegacyPkgNames[0] = "MUTATED"
+	clone.Structure.DTOAllowedLayers[0] = "MUTATED"
+	clone.Structure.TypePatterns[0].Dir = "MUTATED"
+
+	// Map fields — insert a key and verify the original does not see it.
+	clone.Layers.LayerDirNames["new"] = true
+	clone.Layers.InternalTopLevel["new"] = true
+	clone.Layers.PkgRestricted["new"] = true
+	clone.Structure.InterfacePatternExclude["new"] = true
+	clone.Layers.Direction["new"] = []string{"X"}
+
+	// Nested slice inside the Direction map — mutate an existing inner slice.
+	clone.Layers.Direction["handler"] = append(clone.Layers.Direction["handler"], "X")
+	clone.Layers.Direction["handler"][0] = "MUTATED"
+
+	// Now check the original is intact.
+	if got := original.Layers.Sublayers; len(got) != 2 || got[0] != "handler" {
+		t.Errorf("Layers.Sublayers leaked: %v", got)
+	}
+	if got := original.Layers.PortLayers; len(got) != 1 || got[0] != "core/repo" {
+		t.Errorf("Layers.PortLayers leaked: %v", got)
+	}
+	if got := original.Layers.ContractLayers; len(got) != 2 || got[0] != "core/repo" {
+		t.Errorf("Layers.ContractLayers leaked: %v", got)
+	}
+	if got := original.Naming.BannedPkgNames; len(got) != 1 || got[0] != "util" {
+		t.Errorf("Naming.BannedPkgNames leaked: %v", got)
+	}
+	if got := original.Naming.LegacyPkgNames; len(got) != 1 || got[0] != "router" {
+		t.Errorf("Naming.LegacyPkgNames leaked: %v", got)
+	}
+	if got := original.Structure.DTOAllowedLayers; len(got) != 1 || got[0] != "handler" {
+		t.Errorf("Structure.DTOAllowedLayers leaked: %v", got)
+	}
+	if got := original.Structure.TypePatterns; len(got) != 1 || got[0].Dir != "worker" {
+		t.Errorf("Structure.TypePatterns leaked: %v", got)
+	}
+	if _, ok := original.Layers.LayerDirNames["new"]; ok {
+		t.Errorf("Layers.LayerDirNames leaked: %v", original.Layers.LayerDirNames)
+	}
+	if _, ok := original.Layers.InternalTopLevel["new"]; ok {
+		t.Errorf("Layers.InternalTopLevel leaked: %v", original.Layers.InternalTopLevel)
+	}
+	if _, ok := original.Layers.PkgRestricted["new"]; ok {
+		t.Errorf("Layers.PkgRestricted leaked: %v", original.Layers.PkgRestricted)
+	}
+	if _, ok := original.Structure.InterfacePatternExclude["new"]; ok {
+		t.Errorf("Structure.InterfacePatternExclude leaked: %v", original.Structure.InterfacePatternExclude)
+	}
+	if _, ok := original.Layers.Direction["new"]; ok {
+		t.Errorf("Layers.Direction leaked (new key): %v", original.Layers.Direction)
+	}
+	if got := original.Layers.Direction["handler"]; len(got) != 1 || got[0] != "app" {
+		t.Errorf("Layers.Direction[handler] inner slice leaked: %v", got)
+	}
+}

--- a/core/architecture_test.go
+++ b/core/architecture_test.go
@@ -46,6 +46,22 @@ func TestArchitectureCarriesAllSubModels(t *testing.T) {
 	}
 }
 
+func TestCloneArchitectureNormalizesEmptyInternalRoot(t *testing.T) {
+	var arch Architecture
+	got := cloneArchitecture(arch)
+	if got.Layout.InternalRoot != "internal" {
+		t.Fatalf("empty InternalRoot must normalize to %q, got %q", "internal", got.Layout.InternalRoot)
+	}
+}
+
+func TestCloneArchitectureRespectsExplicitInternalRoot(t *testing.T) {
+	arch := Architecture{Layout: LayoutModel{InternalRoot: "packages"}}
+	got := cloneArchitecture(arch)
+	if got.Layout.InternalRoot != "packages" {
+		t.Fatalf("explicit InternalRoot must be preserved, got %q", got.Layout.InternalRoot)
+	}
+}
+
 // TestCloneArchitectureCoversAllMutableFields is a deliberate regression
 // guard: it builds an Architecture where every map and slice field has
 // content, clones it, mutates the clone in every field, and asserts that

--- a/core/architecture_validate.go
+++ b/core/architecture_validate.go
@@ -101,6 +101,21 @@ func (a Architecture) Validate() error {
 		}
 	}
 
+	// LayerDirNames keys are basenames recognized by placement rules. They
+	// don't have to map to Sublayers, but empty keys are always a typo.
+	for k := range a.Layers.LayerDirNames {
+		if k == "" {
+			errs = append(errs, "LayerDirNames contains empty-string key")
+		}
+	}
+	// InternalTopLevel keys are top-level dir names; they don't have to map
+	// to Sublayers either, but empty keys are always a typo.
+	for k := range a.Layers.InternalTopLevel {
+		if k == "" {
+			errs = append(errs, "InternalTopLevel contains empty-string key")
+		}
+	}
+
 	// TypePatterns: each pattern's Dir must be a declared sublayer.
 	for _, tp := range a.Structure.TypePatterns {
 		if tp.Dir == "" {

--- a/core/architecture_validate_test.go
+++ b/core/architecture_validate_test.go
@@ -33,6 +33,19 @@ func TestValidateAcceptsValid(t *testing.T) {
 	}
 }
 
+// TestValidateZeroValueArchitecture locks down the contract that an empty
+// Architecture is a legal "no-op" config: callers building one field at a
+// time must not see a panic from nil maps/slices, and Validate() must
+// succeed when no rules are configured. If a future change makes
+// validation stricter for zero values, that change must update this test
+// (and document the migration).
+func TestValidateZeroValueArchitecture(t *testing.T) {
+	var arch Architecture
+	if err := arch.Validate(); err != nil {
+		t.Fatalf("zero-value Architecture.Validate() = %v, want nil", err)
+	}
+}
+
 func TestValidateRejectsDirectionKeyMissing(t *testing.T) {
 	a := validArchitecture()
 	delete(a.Layers.Direction, "core/svc")

--- a/core/architecture_validate_test.go
+++ b/core/architecture_validate_test.go
@@ -46,6 +46,35 @@ func TestValidateZeroValueArchitecture(t *testing.T) {
 	}
 }
 
+func TestValidateRejectsEmptyLayerDirNamesKey(t *testing.T) {
+	a := validArchitecture()
+	a.Layers.LayerDirNames = map[string]bool{"": true}
+	err := a.Validate()
+	if err == nil || !strings.Contains(err.Error(), "LayerDirNames") || !strings.Contains(err.Error(), "empty") {
+		t.Errorf("expected empty-key error for LayerDirNames, got %v", err)
+	}
+}
+
+func TestValidateRejectsEmptyInternalTopLevelKey(t *testing.T) {
+	a := validArchitecture()
+	a.Layers.InternalTopLevel = map[string]bool{"": true}
+	err := a.Validate()
+	if err == nil || !strings.Contains(err.Error(), "InternalTopLevel") || !strings.Contains(err.Error(), "empty") {
+		t.Errorf("expected empty-key error for InternalTopLevel, got %v", err)
+	}
+}
+
+func TestValidateAcceptsLayerDirNamesNotInSublayers(t *testing.T) {
+	// LayerDirNames carries basenames that intentionally do NOT have to
+	// match Sublayers entries — "repo" is a basename even though only
+	// "core/repo" lives in Sublayers. Validate must NOT reject this.
+	a := validArchitecture()
+	a.Layers.LayerDirNames = map[string]bool{"repo": true, "svc": true, "model": true, "handler": true, "app": true}
+	if err := a.Validate(); err != nil {
+		t.Fatalf("LayerDirNames basenames must be allowed regardless of Sublayers, got %v", err)
+	}
+}
+
 func TestValidateRejectsDirectionKeyMissing(t *testing.T) {
 	a := validArchitecture()
 	delete(a.Layers.Direction, "core/svc")

--- a/core/context.go
+++ b/core/context.go
@@ -19,7 +19,11 @@ type Context struct {
 }
 
 // NewContext builds a Context. Excludes are normalized (leading "./"
-// stripped, OS path separators converted) at construction.
+// stripped, OS path separators converted) at construction. The Architecture
+// is deep-cloned so caller-side mutations to its maps and slices after this
+// call cannot leak into the Context's view; Arch() also returns a defensive
+// clone, but cloning here closes the construction-time window where a
+// caller could otherwise mutate shared state before the first Arch() read.
 func NewContext(pkgs []*packages.Package, module, root string, arch Architecture, exclude []string) *Context {
 	norm := make([]string, len(exclude))
 	for i, p := range exclude {
@@ -29,7 +33,7 @@ func NewContext(pkgs []*packages.Package, module, root string, arch Architecture
 		pkgs:    pkgs,
 		module:  module,
 		root:    root,
-		arch:    arch,
+		arch:    cloneArchitecture(arch),
 		exclude: norm,
 	}
 }
@@ -88,14 +92,27 @@ func matchExcludePattern(pattern, path string) bool {
 	return pattern == path
 }
 
+// normalizeMatchPath canonicalizes both exclude patterns and the file paths
+// rules emit so they match consistently. The supported equivalences are:
+//
+//   - Backslashes are converted to forward slashes (Windows-shell paste).
+//   - Leading "/" is trimmed (absolute-path fallback in analysisutil).
+//   - Leading "./" is trimmed (rule-emitted relative paths).
+//   - Trailing "/" is trimmed for non-recursive patterns; a recursive
+//     pattern keeps its "..." suffix intact since matchExcludePattern
+//     reads it.
+//
+// As a result "internal/foo", "/internal/foo", "./internal/foo",
+// "internal\\foo", and "internal/foo/" are all the same key.
 func normalizeMatchPath(path string) string {
-	// filepath.ToSlash is a no-op on Unix; mixed-style inputs (e.g. excludes
-	// copy-pasted from a Windows shell) need explicit backslash replacement
-	// to match downstream forward-slash paths emitted by rules.
 	path = strings.ReplaceAll(path, "\\", "/")
 	path = filepath.ToSlash(path)
+	path = strings.TrimPrefix(path, "/")
 	for strings.HasPrefix(path, "./") {
 		path = strings.TrimPrefix(path, "./")
+	}
+	if strings.HasSuffix(path, "/") && !strings.HasSuffix(path, "...") {
+		path = strings.TrimSuffix(path, "/")
 	}
 	return path
 }

--- a/core/context.go
+++ b/core/context.go
@@ -38,17 +38,17 @@ func NewContext(pkgs []*packages.Package, module, root string, arch Architecture
 	}
 }
 
-// Pkgs returns the loaded packages.
+// Pkgs returns the loaded packages. Treat the returned *packages.Package
+// values as read-only — mutation is undefined behavior.
 //
-// IMPORTANT: This is a slice-header copy only. Reslicing or appending to
-// the returned slice cannot affect other rules. However, the
-// *packages.Package values it points at are SHARED across rules — Go does
-// not let us deep-clone them cheaply, and a true copy would re-walk the
-// type system per rule. Mutating any field of a *packages.Package
-// (Imports, Types, Syntax, Errors, …) is therefore a contract violation:
-// rules MUST be pure functions of their input. Violating this corrupts
-// later rules' view of the world and is undefined behavior under any
-// future parallel runner.
+// The returned slice is a header copy: reslicing or appending to it
+// cannot affect other rules. However, the *packages.Package values it
+// points at are SHARED across rules — Go does not let us deep-clone them
+// cheaply, and a true copy would re-walk the type system per rule.
+// Mutating any field of a *packages.Package (Imports, Types, Syntax,
+// Errors, …) is therefore a contract violation: rules MUST be pure
+// functions of their input. Violating this corrupts later rules' view of
+// the world and is undefined behavior under any future parallel runner.
 func (c *Context) Pkgs() []*packages.Package {
 	if c.pkgs == nil {
 		return nil

--- a/core/context_test.go
+++ b/core/context_test.go
@@ -1,6 +1,10 @@
 package core
 
-import "testing"
+import (
+	"testing"
+
+	"golang.org/x/tools/go/packages"
+)
 
 func TestNewContextStoresInputs(t *testing.T) {
 	arch := validArchitecture()
@@ -92,6 +96,38 @@ func TestContextIsExcludedRecursivePatternUnchanged(t *testing.T) {
 	}
 	if c.IsExcluded("internal/app/foo.go") {
 		t.Errorf("recursive pattern should not match siblings")
+	}
+}
+
+// TestContextPkgsHeaderCopyDoesNotAffectOthers locks the documented
+// slice-header isolation contract on Pkgs(). Today Pkgs() allocates a
+// fresh backing array per call so no leak is possible; the test guards
+// against a regression where a future implementation returns a slice
+// backed directly by Context.pkgs (e.g. `return c.pkgs`), which would
+// let a caller's append corrupt other callers' views via the shared
+// underlying array.
+func TestContextPkgsHeaderCopyDoesNotAffectOthers(t *testing.T) {
+	pkgs := []*packages.Package{
+		{PkgPath: "a"},
+		{PkgPath: "b"},
+		{PkgPath: "c"},
+	}
+	c := NewContext(pkgs, "m", "/r", validArchitecture(), nil)
+
+	first := c.Pkgs()
+	second := c.Pkgs()
+
+	// Reslice + append on the first caller's slice must NOT shorten or
+	// modify what the second caller sees.
+	_ = append(first[:1], &packages.Package{PkgPath: "rogue"})
+
+	if len(second) != 3 {
+		t.Fatalf("second.Pkgs() len = %d, want 3 (header-copy contract broken)", len(second))
+	}
+	for i, want := range []string{"a", "b", "c"} {
+		if second[i].PkgPath != want {
+			t.Errorf("second[%d].PkgPath = %q, want %q", i, second[i].PkgPath, want)
+		}
 	}
 }
 

--- a/core/context_test.go
+++ b/core/context_test.go
@@ -58,3 +58,63 @@ func TestContextIsExcludedNormalizesBackslashes(t *testing.T) {
 		t.Errorf("backslash exclude pattern must match forward-slash path")
 	}
 }
+
+func TestContextIsExcludedNormalizesLeadingSlash(t *testing.T) {
+	c := NewContext(nil, "", "", Architecture{}, []string{"internal/handler/foo.go"})
+	if !c.IsExcluded("/internal/handler/foo.go") {
+		t.Errorf("IsExcluded should normalize leading / on the input path")
+	}
+}
+
+func TestContextIsExcludedNormalizesTrailingSlash(t *testing.T) {
+	// Pattern without trailing slash should match input with trailing slash
+	// (placement rules emit dir paths as "internal/foo/").
+	c := NewContext(nil, "", "", Architecture{}, []string{"internal/handler"})
+	if !c.IsExcluded("internal/handler/") {
+		t.Errorf("IsExcluded should match trailing-slash input against bare pattern")
+	}
+
+	// And the reverse: trailing-slash pattern matching bare input.
+	c2 := NewContext(nil, "", "", Architecture{}, []string{"internal/handler/"})
+	if !c2.IsExcluded("internal/handler") {
+		t.Errorf("IsExcluded should match bare input against trailing-slash pattern")
+	}
+}
+
+func TestContextIsExcludedRecursivePatternUnchanged(t *testing.T) {
+	// Regression guard: trailing-slash trim must not break recursive "..." semantics.
+	c := NewContext(nil, "", "", Architecture{}, []string{"internal/handler/..."})
+	if !c.IsExcluded("internal/handler/foo.go") {
+		t.Errorf("recursive pattern broke after normalization changes")
+	}
+	if !c.IsExcluded("internal/handler") {
+		t.Errorf("recursive pattern should still match base path")
+	}
+	if c.IsExcluded("internal/app/foo.go") {
+		t.Errorf("recursive pattern should not match siblings")
+	}
+}
+
+func TestNewContextIsolatesCallerArchitectureMutation(t *testing.T) {
+	arch := validArchitecture()
+	arch.Layers.LayerDirNames = map[string]bool{"handler": true, "app": true}
+	c := NewContext(nil, "m", "/r", arch, nil)
+
+	// Mutate the original arch maps and slices after NewContext.
+	arch.Layers.Sublayers = append(arch.Layers.Sublayers, "rogue")
+	arch.Layers.LayerDirNames["rogue"] = true
+	arch.Layers.Direction["rogue"] = []string{"handler"}
+
+	got := c.Arch()
+	for _, sl := range got.Layers.Sublayers {
+		if sl == "rogue" {
+			t.Fatalf("caller mutation leaked into Context: Sublayers contains rogue")
+		}
+	}
+	if got.Layers.LayerDirNames["rogue"] {
+		t.Fatalf("caller mutation leaked into Context: LayerDirNames contains rogue")
+	}
+	if _, ok := got.Layers.Direction["rogue"]; ok {
+		t.Fatalf("caller mutation leaked into Context: Direction contains rogue")
+	}
+}

--- a/core/ruleset.go
+++ b/core/ruleset.go
@@ -16,10 +16,17 @@ func NewRuleSet(rules ...Rule) RuleSet {
 	return RuleSet{}.With(rules...)
 }
 
-// With returns a new RuleSet with the given rules appended.
+// With returns a new RuleSet with the given rules appended. nil rules are
+// silently dropped so callers can compose conditional rule lists like
+// rs.With(maybeRule()) without an explicit nil check at every site.
 func (rs RuleSet) With(rules ...Rule) RuleSet {
 	out := rs.copy()
-	out.rules = append(out.rules, rules...)
+	for _, r := range rules {
+		if r == nil {
+			continue
+		}
+		out.rules = append(out.rules, r)
+	}
 	return out
 }
 

--- a/core/ruleset_test.go
+++ b/core/ruleset_test.go
@@ -29,6 +29,26 @@ func TestRuleSetWithAppendsRules(t *testing.T) {
 	}
 }
 
+func TestRuleSetWithDropsNilRules(t *testing.T) {
+	r := &fakeRule{spec: RuleSpec{ID: "a"}}
+	rs := RuleSet{}.With(nil, r, nil)
+	if got := len(rs.Rules()); got != 1 {
+		t.Fatalf("len(Rules()) = %d, want 1 (nils must be dropped)", got)
+	}
+	if rs.Rules()[0].Spec().ID != "a" {
+		t.Errorf("Rules()[0].ID = %q", rs.Rules()[0].Spec().ID)
+	}
+}
+
+func TestRunDoesNotPanicOnNilOnlyRuleSet(t *testing.T) {
+	rs := RuleSet{}.With(nil)
+	ctx := NewContext(nil, "", "", validArchitecture(), nil)
+	got := Run(ctx, rs)
+	if len(got) != 0 {
+		t.Fatalf("got %d violations from nil-only RuleSet, want 0: %+v", len(got), got)
+	}
+}
+
 func TestRuleSetWithoutAccumulatesIDs(t *testing.T) {
 	rs := RuleSet{}.Without("isolation.cross-domain").Without("blast.high-coupling")
 	if !rs.IsViolationSkipped("isolation.cross-domain") {

--- a/core/runner.go
+++ b/core/runner.go
@@ -198,15 +198,25 @@ func defaultsByID(spec RuleSpec) map[string]Severity {
 	return out
 }
 
+// dedupeMetaViolations collapses duplicate meta.* violations. The dedup key
+// is the (Rule, Message) pair, not just Rule alone — two rules can emit the
+// same meta ID with different messages (e.g. "module not determined" vs
+// "module does not match any loaded package") and both signals should reach
+// the user. Exact duplicates are still collapsed.
 func dedupeMetaViolations(in []Violation) []Violation {
-	seen := make(map[string]bool)
+	type metaKey struct {
+		Rule    string
+		Message string
+	}
+	seen := make(map[metaKey]bool)
 	out := in[:0]
 	for _, v := range in {
 		if strings.HasPrefix(v.Rule, "meta.") {
-			if seen[v.Rule] {
+			key := metaKey{Rule: v.Rule, Message: v.Message}
+			if seen[key] {
 				continue
 			}
-			seen[v.Rule] = true
+			seen[key] = true
 		}
 		out = append(out, v)
 	}

--- a/core/runner.go
+++ b/core/runner.go
@@ -33,7 +33,7 @@ import (
 //     1. WithSeverityOverride(violationID, ...)
 //     2. RuleSpec.Violations[i].DefaultSeverity for matching ID
 //     3. Warning, when the violation ID starts with "meta." (environmental
-//        meta.* violations should never block builds by accident)
+//     meta.* violations should never block builds by accident)
 //     4. RuleSpec.DefaultSeverity
 //     5. Error
 //   - Violations are deduped by Rule field for any Rule starting with "meta.".

--- a/core/runner.go
+++ b/core/runner.go
@@ -96,13 +96,17 @@ func Run(ctx *Context, rules RuleSet, opts ...RunOption) []Violation {
 			}
 			declared, ok := violationDefaults[v.Rule]
 			if !ok {
-				// meta.* IDs are environmental warnings (e.g.
-				// meta.no-matching-packages). Default them to Warning so a
-				// dependency rule that defaults to Error doesn't accidentally
-				// promote a configuration mismatch into a hard failure.
-				if strings.HasPrefix(v.Rule, "meta.") {
+				// meta.rule-panic means a rule failed internally, so the
+				// analysis result is incomplete and should block by default.
+				// Other meta.* IDs are environmental warnings (e.g.
+				// meta.no-matching-packages) and should not accidentally
+				// inherit an Error default from the emitting rule.
+				switch {
+				case v.Rule == "meta.rule-panic":
+					declared = Error
+				case strings.HasPrefix(v.Rule, "meta."):
 					declared = Warning
-				} else {
+				default:
 					declared = ruleDefault
 				}
 			}
@@ -205,10 +209,10 @@ func defaultsByID(spec RuleSpec) map[string]Severity {
 // safeCheck invokes rule.Check inside a deferred recover. A panic from a
 // rule is converted into a single meta.rule-panic violation so a buggy
 // rule does not crash the entire run; other rules continue to execute.
-// The returned violation goes through the runner's normal meta.* path:
-// default severity is Warning (so a buggy rule does not block the build),
-// dedup collapses repeated panics from the same rule, and callers can
-// promote it to Error with WithSeverityOverride("meta.rule-panic", Error).
+// The returned violation goes through the runner's normal severity / dedup
+// pipeline: default severity is Error because the analysis result is
+// incomplete, repeated panics from the same rule collapse via meta dedup,
+// and callers can still override the severity if needed.
 func safeCheck(rule Rule, ctx *Context) (violations []Violation, panicked bool) {
 	defer func() {
 		if rec := recover(); rec != nil {

--- a/core/runner.go
+++ b/core/runner.go
@@ -74,7 +74,11 @@ func Run(ctx *Context, rules RuleSet, opts ...RunOption) []Violation {
 		ruleDefault := spec.DefaultSeverity
 		ruleKnown := ruleKnownIDs(spec)
 
-		for _, v := range r.Check(ctx) {
+		// panicked is intentionally discarded; the meta.rule-panic
+		// violation itself carries the signal through the standard
+		// severity / dedup pipeline below.
+		emitted, _ := safeCheck(r, ctx)
+		for _, v := range emitted {
 			// meta.* IDs are emergency emit by any rule (e.g. "meta.no-matching-packages"
 			// when the project module cannot be resolved) and are not part of any
 			// rule's catalog. Allow them through unconditionally.
@@ -196,6 +200,32 @@ func defaultsByID(spec RuleSpec) map[string]Severity {
 		out[v.ID] = v.DefaultSeverity
 	}
 	return out
+}
+
+// safeCheck invokes rule.Check inside a deferred recover. A panic from a
+// rule is converted into a single meta.rule-panic violation so a buggy
+// rule does not crash the entire run; other rules continue to execute.
+// The returned violation goes through the runner's normal meta.* path:
+// default severity is Warning (so a buggy rule does not block the build),
+// dedup collapses repeated panics from the same rule, and callers can
+// promote it to Error with WithSeverityOverride("meta.rule-panic", Error).
+func safeCheck(rule Rule, ctx *Context) (violations []Violation, panicked bool) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			ruleID := "<unknown>"
+			func() {
+				defer func() { _ = recover() }()
+				ruleID = rule.Spec().ID
+			}()
+			violations = []Violation{{
+				Rule:    "meta.rule-panic",
+				Message: fmt.Sprintf("rule %q panicked: %v", ruleID, rec),
+				Fix:     "report the panic to the rule author; other rules continue to run",
+			}}
+			panicked = true
+		}
+	}()
+	return rule.Check(ctx), false
 }
 
 // dedupeMetaViolations collapses duplicate meta.* violations. The dedup key

--- a/core/runner_test.go
+++ b/core/runner_test.go
@@ -231,6 +231,32 @@ func TestRunDedupesMetaViolations(t *testing.T) {
 	}
 }
 
+// TestRunSeverityLevel5FallsBackToError covers the absolute fallback in
+// the severity precedence documented at runner.go:33-37. When a violation
+// has no override, no per-violation-ID spec, no meta.* prefix, and no
+// rule-level default severity, the Severity zero value (Error) is used.
+// Without this test, swapping the order of the Severity enum constants
+// (Warning=0, Error=1) would silently change the fallback behavior.
+func TestRunSeverityLevel5FallsBackToError(t *testing.T) {
+	r := &fakeRule{
+		spec: RuleSpec{ID: "fake.demo"}, // no DefaultSeverity, no Violations catalog
+		violations: []Violation{
+			{File: ".", Rule: "fake.demo", Message: "x"},
+		},
+	}
+	ctx := NewContext(nil, "", "", validArchitecture(), nil)
+	got := Run(ctx, RuleSet{}.With(r))
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+	if got[0].EffectiveSeverity != Error {
+		t.Fatalf("level-5 fallback EffectiveSeverity = %v, want Error", got[0].EffectiveSeverity)
+	}
+	if got[0].DefaultSeverity != Error {
+		t.Fatalf("level-5 fallback DefaultSeverity = %v, want Error", got[0].DefaultSeverity)
+	}
+}
+
 func TestRunPreservesMetaViolationsWithDifferentMessages(t *testing.T) {
 	r1 := &fakeRule{
 		spec: RuleSpec{ID: "fake.a"},

--- a/core/runner_test.go
+++ b/core/runner_test.go
@@ -231,6 +231,38 @@ func TestRunDedupesMetaViolations(t *testing.T) {
 	}
 }
 
+func TestRunPreservesMetaViolationsWithDifferentMessages(t *testing.T) {
+	r1 := &fakeRule{
+		spec: RuleSpec{ID: "fake.a"},
+		violations: []Violation{
+			{File: ".", Rule: "meta.no-matching-packages", Message: "module not determined"},
+		},
+	}
+	r2 := &fakeRule{
+		spec: RuleSpec{ID: "fake.b"},
+		violations: []Violation{
+			{File: ".", Rule: "meta.no-matching-packages", Message: "module does not match any loaded package"},
+		},
+	}
+	ctx := NewContext(nil, "", "", validArchitecture(), nil)
+	got := Run(ctx, RuleSet{}.With(r1).With(r2))
+
+	var count int
+	messages := make(map[string]bool)
+	for _, v := range got {
+		if v.Rule == "meta.no-matching-packages" {
+			count++
+			messages[v.Message] = true
+		}
+	}
+	if count != 2 {
+		t.Fatalf("len = %d, want 2 (different messages must NOT be deduped): %+v", count, got)
+	}
+	if !messages["module not determined"] || !messages["module does not match any loaded package"] {
+		t.Fatalf("expected both messages preserved, got %v", messages)
+	}
+}
+
 func TestRunRejectsUnknownWithoutID(t *testing.T) {
 	r := &fakeRule{
 		spec: RuleSpec{

--- a/core/runner_test.go
+++ b/core/runner_test.go
@@ -247,7 +247,7 @@ func (p *panickingRule) Check(_ *Context) []Violation {
 	panic("intentional rule bug for testing")
 }
 
-func TestRunRecoversRulePanicAsMetaWarning(t *testing.T) {
+func TestRunRecoversRulePanicAsMetaError(t *testing.T) {
 	r := &panickingRule{id: "fake.bombs"}
 	ctx := NewContext(nil, "", "", validArchitecture(), nil)
 	got := Run(ctx, RuleSet{}.With(r))
@@ -259,8 +259,8 @@ func TestRunRecoversRulePanicAsMetaWarning(t *testing.T) {
 	if v.Rule != "meta.rule-panic" {
 		t.Errorf("Rule = %q, want meta.rule-panic", v.Rule)
 	}
-	if v.EffectiveSeverity != Warning {
-		t.Errorf("EffectiveSeverity = %v, want Warning (panic must NOT block builds by default)", v.EffectiveSeverity)
+	if v.EffectiveSeverity != Error {
+		t.Errorf("EffectiveSeverity = %v, want Error (panic means the analysis did not complete reliably)", v.EffectiveSeverity)
 	}
 	if !strings.Contains(v.Message, "fake.bombs") {
 		t.Errorf("Message = %q, want it to mention rule ID", v.Message)
@@ -298,16 +298,16 @@ func TestRunRulePanicDoesNotBlockOtherRules(t *testing.T) {
 func TestRunRulePanicSeverityOverrideWorks(t *testing.T) {
 	r := &panickingRule{id: "fake.bombs"}
 	ctx := NewContext(nil, "", "", validArchitecture(), nil)
-	got := Run(ctx, RuleSet{}.With(r), WithSeverityOverride("meta.rule-panic", Error))
+	got := Run(ctx, RuleSet{}.With(r), WithSeverityOverride("meta.rule-panic", Warning))
 
 	if len(got) != 1 {
 		t.Fatalf("len = %d, want 1", len(got))
 	}
-	if got[0].EffectiveSeverity != Error {
-		t.Errorf("EffectiveSeverity = %v, want Error (override must apply)", got[0].EffectiveSeverity)
+	if got[0].EffectiveSeverity != Warning {
+		t.Errorf("EffectiveSeverity = %v, want Warning (override must apply)", got[0].EffectiveSeverity)
 	}
-	if got[0].DefaultSeverity != Warning {
-		t.Errorf("DefaultSeverity = %v, want Warning (default unchanged by override)", got[0].DefaultSeverity)
+	if got[0].DefaultSeverity != Error {
+		t.Errorf("DefaultSeverity = %v, want Error (default unchanged by override)", got[0].DefaultSeverity)
 	}
 }
 

--- a/core/runner_test.go
+++ b/core/runner_test.go
@@ -237,6 +237,80 @@ func TestRunDedupesMetaViolations(t *testing.T) {
 // rule-level default severity, the Severity zero value (Error) is used.
 // Without this test, swapping the order of the Severity enum constants
 // (Warning=0, Error=1) would silently change the fallback behavior.
+// panickingRule is a test double whose Check panics on every call.
+type panickingRule struct {
+	id string
+}
+
+func (p *panickingRule) Spec() RuleSpec { return RuleSpec{ID: p.id} }
+func (p *panickingRule) Check(_ *Context) []Violation {
+	panic("intentional rule bug for testing")
+}
+
+func TestRunRecoversRulePanicAsMetaWarning(t *testing.T) {
+	r := &panickingRule{id: "fake.bombs"}
+	ctx := NewContext(nil, "", "", validArchitecture(), nil)
+	got := Run(ctx, RuleSet{}.With(r))
+
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1: %+v", len(got), got)
+	}
+	v := got[0]
+	if v.Rule != "meta.rule-panic" {
+		t.Errorf("Rule = %q, want meta.rule-panic", v.Rule)
+	}
+	if v.EffectiveSeverity != Warning {
+		t.Errorf("EffectiveSeverity = %v, want Warning (panic must NOT block builds by default)", v.EffectiveSeverity)
+	}
+	if !strings.Contains(v.Message, "fake.bombs") {
+		t.Errorf("Message = %q, want it to mention rule ID", v.Message)
+	}
+	if !strings.Contains(v.Message, "intentional rule bug for testing") {
+		t.Errorf("Message = %q, want it to include the panic value", v.Message)
+	}
+}
+
+func TestRunRulePanicDoesNotBlockOtherRules(t *testing.T) {
+	bomb := &panickingRule{id: "fake.bombs"}
+	ok := &fakeRule{
+		spec: RuleSpec{ID: "fake.ok"},
+		violations: []Violation{
+			{File: "x.go", Rule: "fake.ok", Message: "still here"},
+		},
+	}
+	ctx := NewContext(nil, "", "", validArchitecture(), nil)
+	got := Run(ctx, RuleSet{}.With(bomb).With(ok))
+
+	var sawPanic, sawOk bool
+	for _, v := range got {
+		switch v.Rule {
+		case "meta.rule-panic":
+			sawPanic = true
+		case "fake.ok":
+			sawOk = true
+		}
+	}
+	if !sawPanic || !sawOk {
+		t.Fatalf("expected both meta.rule-panic AND fake.ok, got panic=%v ok=%v: %+v", sawPanic, sawOk, got)
+	}
+}
+
+func TestRunRulePanicSeverityOverrideWorks(t *testing.T) {
+	r := &panickingRule{id: "fake.bombs"}
+	ctx := NewContext(nil, "", "", validArchitecture(), nil)
+	got := Run(ctx, RuleSet{}.With(r), WithSeverityOverride("meta.rule-panic", Error))
+
+	if len(got) != 1 {
+		t.Fatalf("len = %d, want 1", len(got))
+	}
+	if got[0].EffectiveSeverity != Error {
+		t.Errorf("EffectiveSeverity = %v, want Error (override must apply)", got[0].EffectiveSeverity)
+	}
+	if got[0].DefaultSeverity != Warning {
+		t.Errorf("DefaultSeverity = %v, want Warning (default unchanged by override)", got[0].DefaultSeverity)
+	}
+}
+
 func TestRunSeverityLevel5FallsBackToError(t *testing.T) {
 	r := &fakeRule{
 		spec: RuleSpec{ID: "fake.demo"}, // no DefaultSeverity, no Violations catalog

--- a/docs/model-concepts.md
+++ b/docs/model-concepts.md
@@ -152,6 +152,11 @@ invariants that rules rely on:
 invalid. Presets validate themselves when constructed so preset mistakes fail
 early.
 
+If an individual rule panics, `core.Run` converts it to a `meta.rule-panic`
+violation with Error severity and continues running the remaining rules. This
+keeps the report available while still marking the analysis as unreliable by
+default.
+
 ## Build Patterns
 
 Prefer a preset when your layout matches one of the built-ins:

--- a/plugins/go-arch-guard/skills/go-arch-guard/SKILL.md
+++ b/plugins/go-arch-guard/skills/go-arch-guard/SKILL.md
@@ -75,6 +75,8 @@ if err != nil {
 수동 작성 시에도 같은 흐름을 따른다: `analyzer.Load`로 패키지를 로드하고,
 프리셋 아키텍처로 `core.NewContext`를 만든 뒤, 권장 ruleset을 `core.Run`에 넘긴다.
 세부 rule을 개별로 다뤄야 할 때만 `core.NewRuleSet(...)`으로 직접 조합한다.
+rule이 panic을 내면 `core.Run`은 `meta.rule-panic` Error violation으로 변환하고
+나머지 rule 실행을 계속한다.
 
 프리셋 매핑:
 

--- a/rules/dependency/blast_radius.go
+++ b/rules/dependency/blast_radius.go
@@ -31,11 +31,12 @@ func (r *BlastRadius) Check(ctx *core.Context) []core.Violation {
 	if warns := validateModule(pkgs, projectModule); len(warns) > 0 {
 		return warns
 	}
-	if !hasInternalPackages(pkgs, projectModule) {
+	internalRoot := ctx.Arch().Layout.InternalRoot
+	if !hasInternalPackages(pkgs, projectModule, internalRoot) {
 		return []core.Violation{metaLayoutNotSupported("dependency.blast-radius", projectModule)}
 	}
 
-	internalPrefix := projectModule + "/internal/"
+	internalPrefix := projectModule + "/" + internalRoot + "/"
 	internalPkgs := make(map[string]bool)
 	for _, pkg := range pkgs {
 		if strings.HasPrefix(pkg.PkgPath, internalPrefix) &&

--- a/rules/dependency/blast_radius.go
+++ b/rules/dependency/blast_radius.go
@@ -12,11 +12,8 @@ import (
 type BlastRadius struct{ severity core.Severity }
 
 func NewBlastRadius(opts ...Option) *BlastRadius {
-	r := &BlastRadius{severity: core.Warning}
-	for _, opt := range opts {
-		r.severity = opt.severity()
-	}
-	return r
+	cfg := newConfig(opts, core.Warning)
+	return &BlastRadius{severity: cfg.severity}
 }
 
 func (r *BlastRadius) Spec() core.RuleSpec {
@@ -30,13 +27,17 @@ func (r *BlastRadius) Spec() core.RuleSpec {
 
 func (r *BlastRadius) Check(ctx *core.Context) []core.Violation {
 	projectModule := analysisutil.ResolveModuleFromContext(ctx, "")
-	if warns := validateModule(ctx.Pkgs(), projectModule); len(warns) > 0 {
+	pkgs := ctx.Pkgs()
+	if warns := validateModule(pkgs, projectModule); len(warns) > 0 {
 		return warns
+	}
+	if !hasInternalPackages(pkgs, projectModule) {
+		return []core.Violation{metaLayoutNotSupported("dependency.blast-radius", projectModule)}
 	}
 
 	internalPrefix := projectModule + "/internal/"
 	internalPkgs := make(map[string]bool)
-	for _, pkg := range ctx.Pkgs() {
+	for _, pkg := range pkgs {
 		if strings.HasPrefix(pkg.PkgPath, internalPrefix) &&
 			!isExcludedPackage(ctx, pkg.PkgPath, projectModule) {
 			internalPkgs[pkg.PkgPath] = true

--- a/rules/dependency/blast_radius_test.go
+++ b/rules/dependency/blast_radius_test.go
@@ -68,6 +68,12 @@ func TestBlastRadiusDetectsOutlier(t *testing.T) {
 	}
 }
 
+func TestBlastRadiusFlatLayoutEmitsMetaWarning(t *testing.T) {
+	ctx := loadFlatLayoutContext(t)
+	violations := dependency.NewBlastRadius().Check(ctx)
+	assertExactlyOneMetaLayoutNotSupported(t, violations, "dependency.blast-radius")
+}
+
 func TestBlastRadiusExclude(t *testing.T) {
 	ctx := loadContextWithExclude(t,
 		"../../testdata/blast",

--- a/rules/dependency/custom_root_test.go
+++ b/rules/dependency/custom_root_test.go
@@ -1,0 +1,38 @@
+package dependency_test
+
+import (
+	"testing"
+
+	"github.com/NamhaeSusan/go-arch-guard/rules/dependency"
+)
+
+func TestIsolationCustomInternalRootRecognizesProject(t *testing.T) {
+	arch := dddArchitecture()
+	arch.Layout.InternalRoot = "packages"
+	ctx := loadContext(t, "../../testdata/custom_root", "github.com/kimtaeyun/testproject-customroot", arch, "...")
+
+	violations := dependency.NewIsolation().Check(ctx)
+	for _, v := range violations {
+		if v.Rule == "meta.layout-not-supported" {
+			t.Fatalf("custom InternalRoot=packages must not emit layout-not-supported: %s", v.String())
+		}
+	}
+}
+
+func TestIsolationCustomInternalRootEmitsMetaForMissingRoot(t *testing.T) {
+	arch := dddArchitecture()
+	arch.Layout.InternalRoot = "src" // src/ does not exist in the fixture
+	ctx := loadContext(t, "../../testdata/custom_root", "github.com/kimtaeyun/testproject-customroot", arch, "...")
+
+	violations := dependency.NewIsolation().Check(ctx)
+	var meta int
+	for _, v := range violations {
+		if v.Rule == "meta.layout-not-supported" {
+			meta++
+		}
+	}
+	if meta != 1 {
+		t.Fatalf("expected exactly 1 meta.layout-not-supported when InternalRoot points to a missing dir, got %d: %+v", meta, violations)
+	}
+}
+

--- a/rules/dependency/isolation.go
+++ b/rules/dependency/isolation.go
@@ -51,11 +51,11 @@ func (r *Isolation) Check(ctx *core.Context) []core.Violation {
 	if warns := validateModule(pkgs, projectModule); len(warns) > 0 {
 		return warns
 	}
-	if !hasInternalPackages(pkgs, projectModule) {
+	if !hasInternalPackages(pkgs, projectModule, layout.InternalRoot) {
 		return []core.Violation{metaLayoutNotSupported("dependency.isolation", projectModule)}
 	}
 
-	internalPrefix := projectModule + "/internal/"
+	internalPrefix := projectModule + "/" + layout.InternalRoot + "/"
 	cmdPrefix := projectModule + "/cmd"
 	var violations []core.Violation
 
@@ -171,7 +171,7 @@ func (r *Isolation) checkSharedImport(pkg *packages.Package, imp classified, imp
 		return []core.Violation{r.violation(file, line,
 			"isolation.pkg-imports-orchestration",
 			fmt.Sprintf("%s/ must not import %s", layout.SharedDir, layout.OrchestrationDir),
-			fmt.Sprintf("move %s-aware code to internal/%s or cmd/", layout.OrchestrationDir, layout.OrchestrationDir),
+			fmt.Sprintf("move %s-aware code to %s/%s or cmd/", layout.OrchestrationDir, layout.InternalRoot, layout.OrchestrationDir),
 		)}
 	}
 	return nil
@@ -183,13 +183,13 @@ func (r *Isolation) checkOrchestrationDependent(pkg *packages.Package, src class
 		return []core.Violation{r.violation(file, line,
 			"isolation.domain-imports-orchestration",
 			fmt.Sprintf("domain %q must not import %s", src.Domain, layout.OrchestrationDir),
-			fmt.Sprintf("move cross-domain coordination to internal/%s callers instead of domain internals", layout.OrchestrationDir),
+			fmt.Sprintf("move cross-domain coordination to %s/%s callers instead of domain internals", layout.InternalRoot, layout.OrchestrationDir),
 		)}
 	}
 	return []core.Violation{r.violation(file, line,
 		"isolation.stray-imports-orchestration",
 		fmt.Sprintf("package %q must not import %s", pkg.PkgPath, layout.OrchestrationDir),
-		fmt.Sprintf("only cmd/ and internal/%s may depend on %s", layout.OrchestrationDir, layout.OrchestrationDir),
+		fmt.Sprintf("only cmd/ and %s/%s may depend on %s", layout.InternalRoot, layout.OrchestrationDir, layout.OrchestrationDir),
 	)}
 }
 
@@ -207,7 +207,7 @@ func (r *Isolation) strayDomainViolation(pkg *packages.Package, imp classified, 
 	return []core.Violation{r.violation(file, line,
 		"isolation.stray-imports-domain",
 		fmt.Sprintf("package %q must not import domain %q", pkg.PkgPath, imp.Domain),
-		fmt.Sprintf("move domain orchestration to internal/%s or app wiring to cmd/", layout.OrchestrationDir),
+		fmt.Sprintf("move domain orchestration to %s/%s or app wiring to cmd/", layout.InternalRoot, layout.OrchestrationDir),
 	)}
 }
 
@@ -247,7 +247,7 @@ func (r *Isolation) checkTransportImport(pkg *packages.Package, projectRoot, imp
 		return []core.Violation{r.violation(file, line,
 			"isolation.transport-imports-unclassified",
 			fmt.Sprintf("transport package %q must not import unclassified internal package %q", pkg.PkgPath, impPath),
-			fmt.Sprintf("move the dependency into internal/%s (expose via Container), internal/%s, or another transport package", layout.AppDir, layout.SharedDir),
+			fmt.Sprintf("move the dependency into %s/%s (expose via Container), %s/%s, or another transport package", layout.InternalRoot, layout.AppDir, layout.InternalRoot, layout.SharedDir),
 		)}
 	default:
 		return nil
@@ -410,11 +410,11 @@ func metaNoMatchingPackages(message string) core.Violation {
 }
 
 // hasInternalPackages reports whether any loaded package lives under
-// <module>/internal/. The dependency rules in this package operate only on
-// internal/-based layouts; flat-layout projects are signaled via
-// metaLayoutNotSupported instead of silently producing zero violations.
-func hasInternalPackages(pkgs []*packages.Package, projectModule string) bool {
-	prefix := projectModule + "/internal/"
+// <module>/<internalRoot>/. The dependency rules in this package operate
+// only on internal-root-based layouts; flat-layout projects are signaled
+// via metaLayoutNotSupported instead of silently producing zero violations.
+func hasInternalPackages(pkgs []*packages.Package, projectModule, internalRoot string) bool {
+	prefix := projectModule + "/" + internalRoot + "/"
 	for _, pkg := range pkgs {
 		if strings.HasPrefix(pkg.PkgPath, prefix) {
 			return true

--- a/rules/dependency/isolation.go
+++ b/rules/dependency/isolation.go
@@ -12,25 +12,10 @@ import (
 
 type Isolation struct{ severity core.Severity }
 
-type Option interface {
-	severity() core.Severity
-}
-
-type severityOption core.Severity
-
 func NewIsolation(opts ...Option) *Isolation {
-	r := &Isolation{severity: core.Error}
-	for _, opt := range opts {
-		r.severity = opt.severity()
-	}
-	return r
+	cfg := newConfig(opts, core.Error)
+	return &Isolation{severity: cfg.severity}
 }
-
-func WithSeverity(s core.Severity) Option {
-	return severityOption(s)
-}
-
-func (o severityOption) severity() core.Severity { return core.Severity(o) }
 
 func (r *Isolation) Spec() core.RuleSpec {
 	return core.RuleSpec{
@@ -62,153 +47,181 @@ func (r *Isolation) Check(ctx *core.Context) []core.Violation {
 
 	projectModule := analysisutil.ResolveModuleFromContext(ctx, "")
 	projectRoot := analysisutil.ResolveRootFromContext(ctx, "")
-	if warns := validateModule(ctx.Pkgs(), projectModule); len(warns) > 0 {
+	pkgs := ctx.Pkgs()
+	if warns := validateModule(pkgs, projectModule); len(warns) > 0 {
 		return warns
+	}
+	if !hasInternalPackages(pkgs, projectModule) {
+		return []core.Violation{metaLayoutNotSupported("dependency.isolation", projectModule)}
 	}
 
 	internalPrefix := projectModule + "/internal/"
 	cmdPrefix := projectModule + "/cmd"
 	var violations []core.Violation
 
-	for _, pkg := range ctx.Pkgs() {
+	for _, pkg := range pkgs {
 		if isExcludedPackage(ctx, pkg.PkgPath, projectModule) {
 			continue
 		}
-
 		if pkg.PkgPath == cmdPrefix || strings.HasPrefix(pkg.PkgPath, cmdPrefix+"/") {
-			if !arch.Structure.RequireAlias {
-				continue
-			}
-			for impPath := range pkg.Imports {
-				if !strings.HasPrefix(impPath, internalPrefix) {
-					continue
-				}
-				imp := classifyInternalPackage(arch, impPath, internalPrefix)
-				if imp.Kind != kindDomain {
-					continue
-				}
-				file, line := analysisutil.FindImportPosition(pkg, impPath, projectRoot)
-				violations = append(violations, r.violation(file, line,
-					"isolation.cmd-deep-import",
-					fmt.Sprintf("cmd/ must only import domain alias, not sub-package %q", impPath),
-					fmt.Sprintf("import the domain alias package instead: %s%s/%s", internalPrefix, layout.DomainDir, imp.Domain),
-				))
-			}
+			violations = append(violations, r.checkCmdPackage(pkg, arch, projectRoot, internalPrefix)...)
 			continue
 		}
-
 		if !strings.HasPrefix(pkg.PkgPath, internalPrefix) {
 			continue
 		}
-
 		src := classifyInternalPackage(arch, pkg.PkgPath, internalPrefix)
 		if src.Kind == kindApp {
 			continue
 		}
-
 		for impPath := range pkg.Imports {
 			if !strings.HasPrefix(impPath, internalPrefix) {
 				continue
 			}
-
 			imp := classifyInternalPackage(arch, impPath, internalPrefix)
-			if imp.Kind == kindShared && src.Kind != kindShared {
-				continue
-			}
-
-			if src.Kind == kindTransport {
-				violations = append(violations, r.checkTransportImport(pkg, projectRoot, impPath, layout, imp)...)
-				continue
-			}
-
-			if (src.Kind == kindDomain || src.Kind == kindDomainRoot) &&
-				(imp.Kind == kindDomain || imp.Kind == kindDomainRoot) &&
-				src.Domain != "" && src.Domain == imp.Domain {
-				continue
-			}
-
-			if src.Kind == kindOrchestration {
-				if imp.Kind != kindDomain || !arch.Structure.RequireAlias {
-					continue
-				}
-				label := layout.OrchestrationDir
-				if isOrchestrationHandlerWith(arch, pkg.PkgPath, internalPrefix) {
-					label = layout.OrchestrationDir + " handler"
-				}
-				file, line := analysisutil.FindImportPosition(pkg, impPath, projectRoot)
-				violations = append(violations, r.violation(file, line,
-					"isolation.orchestration-deep-import",
-					fmt.Sprintf("%s must only import domain alias, not sub-package %q", label, impPath),
-					fmt.Sprintf("import the domain alias package instead: %s%s/%s", internalPrefix, layout.DomainDir, imp.Domain),
-				))
-				continue
-			}
-
-			if src.Kind == kindShared {
-				if imp.Kind == kindDomain || imp.Kind == kindDomainRoot {
-					file, line := analysisutil.FindImportPosition(pkg, impPath, projectRoot)
-					violations = append(violations, r.violation(file, line,
-						"isolation.pkg-imports-domain",
-						fmt.Sprintf("%s/ must not import domain %q", layout.SharedDir, imp.Domain),
-						fmt.Sprintf("%s/ should only contain shared utilities with no domain or orchestration dependencies", layout.SharedDir),
-					))
-					continue
-				}
-				if imp.Kind == kindOrchestration {
-					file, line := analysisutil.FindImportPosition(pkg, impPath, projectRoot)
-					violations = append(violations, r.violation(file, line,
-						"isolation.pkg-imports-orchestration",
-						fmt.Sprintf("%s/ must not import %s", layout.SharedDir, layout.OrchestrationDir),
-						fmt.Sprintf("move %s-aware code to internal/%s or cmd/", layout.OrchestrationDir, layout.OrchestrationDir),
-					))
-					continue
-				}
-			}
-
-			if imp.Kind == kindOrchestration {
-				file, line := analysisutil.FindImportPosition(pkg, impPath, projectRoot)
-				if src.Kind == kindDomain || src.Kind == kindDomainRoot {
-					violations = append(violations, r.violation(file, line,
-						"isolation.domain-imports-orchestration",
-						fmt.Sprintf("domain %q must not import %s", src.Domain, layout.OrchestrationDir),
-						fmt.Sprintf("move cross-domain coordination to internal/%s callers instead of domain internals", layout.OrchestrationDir),
-					))
-					continue
-				}
-				violations = append(violations, r.violation(file, line,
-					"isolation.stray-imports-orchestration",
-					fmt.Sprintf("package %q must not import %s", pkg.PkgPath, layout.OrchestrationDir),
-					fmt.Sprintf("only cmd/ and internal/%s may depend on %s", layout.OrchestrationDir, layout.OrchestrationDir),
-				))
-				continue
-			}
-
-			if (src.Kind == kindDomain || src.Kind == kindDomainRoot) &&
-				(imp.Kind == kindDomain || imp.Kind == kindDomainRoot) &&
-				src.Domain != "" && imp.Domain != "" && src.Domain != imp.Domain {
-				file, line := analysisutil.FindImportPosition(pkg, impPath, projectRoot)
-				violations = append(violations, r.violation(file, line,
-					"isolation.cross-domain",
-					fmt.Sprintf("domain %q must not import domain %q", src.Domain, imp.Domain),
-					fmt.Sprintf("use %s/ for cross-domain orchestration or move shared types to %s/", layout.OrchestrationDir, layout.SharedDir),
-				))
-				continue
-			}
-
-			if src.Kind == kindUnclassified &&
-				(imp.Kind == kindDomain || imp.Kind == kindDomainRoot) {
-				file, line := analysisutil.FindImportPosition(pkg, impPath, projectRoot)
-				violations = append(violations, r.violation(file, line,
-					"isolation.stray-imports-domain",
-					fmt.Sprintf("package %q must not import domain %q", pkg.PkgPath, imp.Domain),
-					fmt.Sprintf("move domain orchestration to internal/%s or app wiring to cmd/", layout.OrchestrationDir),
-				))
-				continue
-			}
+			violations = append(violations, r.checkInternalImport(pkg, src, imp, impPath, arch, projectRoot, internalPrefix)...)
 		}
 	}
 
 	return violations
+}
+
+func (r *Isolation) checkCmdPackage(pkg *packages.Package, arch core.Architecture, projectRoot, internalPrefix string) []core.Violation {
+	if !arch.Structure.RequireAlias {
+		return nil
+	}
+	var violations []core.Violation
+	layout := arch.Layout
+	for impPath := range pkg.Imports {
+		if !strings.HasPrefix(impPath, internalPrefix) {
+			continue
+		}
+		imp := classifyInternalPackage(arch, impPath, internalPrefix)
+		if imp.Kind != kindDomain {
+			continue
+		}
+		file, line := analysisutil.FindImportPosition(pkg, impPath, projectRoot)
+		violations = append(violations, r.violation(file, line,
+			"isolation.cmd-deep-import",
+			fmt.Sprintf("cmd/ must only import domain alias, not sub-package %q", impPath),
+			fmt.Sprintf("import the domain alias package instead: %s%s/%s", internalPrefix, layout.DomainDir, imp.Domain),
+		))
+	}
+	return violations
+}
+
+func (r *Isolation) checkInternalImport(pkg *packages.Package, src, imp classified, impPath string, arch core.Architecture, projectRoot, internalPrefix string) []core.Violation {
+	if imp.Kind == kindShared && src.Kind != kindShared {
+		return nil
+	}
+	if src.Kind == kindTransport {
+		return r.checkTransportImport(pkg, projectRoot, impPath, arch.Layout, imp)
+	}
+	if isSameDomain(src, imp) {
+		return nil
+	}
+	switch src.Kind {
+	case kindOrchestration:
+		return r.checkOrchestrationDeepImport(pkg, imp, impPath, arch, projectRoot, internalPrefix)
+	case kindShared:
+		if v := r.checkSharedImport(pkg, imp, impPath, arch.Layout, projectRoot); v != nil {
+			return v
+		}
+	}
+	if imp.Kind == kindOrchestration {
+		return r.checkOrchestrationDependent(pkg, src, impPath, arch.Layout, projectRoot)
+	}
+	if isCrossDomain(src, imp) {
+		return r.crossDomainViolation(pkg, src, imp, impPath, arch.Layout, projectRoot)
+	}
+	if src.Kind == kindUnclassified && isDomainKind(imp.Kind) {
+		return r.strayDomainViolation(pkg, imp, impPath, arch.Layout, projectRoot)
+	}
+	return nil
+}
+
+func (r *Isolation) checkOrchestrationDeepImport(pkg *packages.Package, imp classified, impPath string, arch core.Architecture, projectRoot, internalPrefix string) []core.Violation {
+	if imp.Kind != kindDomain || !arch.Structure.RequireAlias {
+		return nil
+	}
+	layout := arch.Layout
+	label := layout.OrchestrationDir
+	if isOrchestrationHandlerWith(arch, pkg.PkgPath, internalPrefix) {
+		label = layout.OrchestrationDir + " handler"
+	}
+	file, line := analysisutil.FindImportPosition(pkg, impPath, projectRoot)
+	return []core.Violation{r.violation(file, line,
+		"isolation.orchestration-deep-import",
+		fmt.Sprintf("%s must only import domain alias, not sub-package %q", label, impPath),
+		fmt.Sprintf("import the domain alias package instead: %s%s/%s", internalPrefix, layout.DomainDir, imp.Domain),
+	)}
+}
+
+func (r *Isolation) checkSharedImport(pkg *packages.Package, imp classified, impPath string, layout core.LayoutModel, projectRoot string) []core.Violation {
+	switch {
+	case isDomainKind(imp.Kind):
+		file, line := analysisutil.FindImportPosition(pkg, impPath, projectRoot)
+		return []core.Violation{r.violation(file, line,
+			"isolation.pkg-imports-domain",
+			fmt.Sprintf("%s/ must not import domain %q", layout.SharedDir, imp.Domain),
+			fmt.Sprintf("%s/ should only contain shared utilities with no domain or orchestration dependencies", layout.SharedDir),
+		)}
+	case imp.Kind == kindOrchestration:
+		file, line := analysisutil.FindImportPosition(pkg, impPath, projectRoot)
+		return []core.Violation{r.violation(file, line,
+			"isolation.pkg-imports-orchestration",
+			fmt.Sprintf("%s/ must not import %s", layout.SharedDir, layout.OrchestrationDir),
+			fmt.Sprintf("move %s-aware code to internal/%s or cmd/", layout.OrchestrationDir, layout.OrchestrationDir),
+		)}
+	}
+	return nil
+}
+
+func (r *Isolation) checkOrchestrationDependent(pkg *packages.Package, src classified, impPath string, layout core.LayoutModel, projectRoot string) []core.Violation {
+	file, line := analysisutil.FindImportPosition(pkg, impPath, projectRoot)
+	if isDomainKind(src.Kind) {
+		return []core.Violation{r.violation(file, line,
+			"isolation.domain-imports-orchestration",
+			fmt.Sprintf("domain %q must not import %s", src.Domain, layout.OrchestrationDir),
+			fmt.Sprintf("move cross-domain coordination to internal/%s callers instead of domain internals", layout.OrchestrationDir),
+		)}
+	}
+	return []core.Violation{r.violation(file, line,
+		"isolation.stray-imports-orchestration",
+		fmt.Sprintf("package %q must not import %s", pkg.PkgPath, layout.OrchestrationDir),
+		fmt.Sprintf("only cmd/ and internal/%s may depend on %s", layout.OrchestrationDir, layout.OrchestrationDir),
+	)}
+}
+
+func (r *Isolation) crossDomainViolation(pkg *packages.Package, src, imp classified, impPath string, layout core.LayoutModel, projectRoot string) []core.Violation {
+	file, line := analysisutil.FindImportPosition(pkg, impPath, projectRoot)
+	return []core.Violation{r.violation(file, line,
+		"isolation.cross-domain",
+		fmt.Sprintf("domain %q must not import domain %q", src.Domain, imp.Domain),
+		fmt.Sprintf("use %s/ for cross-domain orchestration or move shared types to %s/", layout.OrchestrationDir, layout.SharedDir),
+	)}
+}
+
+func (r *Isolation) strayDomainViolation(pkg *packages.Package, imp classified, impPath string, layout core.LayoutModel, projectRoot string) []core.Violation {
+	file, line := analysisutil.FindImportPosition(pkg, impPath, projectRoot)
+	return []core.Violation{r.violation(file, line,
+		"isolation.stray-imports-domain",
+		fmt.Sprintf("package %q must not import domain %q", pkg.PkgPath, imp.Domain),
+		fmt.Sprintf("move domain orchestration to internal/%s or app wiring to cmd/", layout.OrchestrationDir),
+	)}
+}
+
+func isDomainKind(k internalKind) bool {
+	return k == kindDomain || k == kindDomainRoot
+}
+
+func isSameDomain(a, b classified) bool {
+	return isDomainKind(a.Kind) && isDomainKind(b.Kind) && a.Domain != "" && a.Domain == b.Domain
+}
+
+func isCrossDomain(a, b classified) bool {
+	return isDomainKind(a.Kind) && isDomainKind(b.Kind) &&
+		a.Domain != "" && b.Domain != "" && a.Domain != b.Domain
 }
 
 func (r *Isolation) checkTransportImport(pkg *packages.Package, projectRoot, impPath string, layout core.LayoutModel, imp classified) []core.Violation {
@@ -391,6 +404,30 @@ func metaNoMatchingPackages(message string) core.Violation {
 		Rule:              "meta.no-matching-packages",
 		Message:           message,
 		Fix:               "verify the module argument matches go.mod",
+		DefaultSeverity:   core.Warning,
+		EffectiveSeverity: core.Warning,
+	}
+}
+
+// hasInternalPackages reports whether any loaded package lives under
+// <module>/internal/. The dependency rules in this package operate only on
+// internal/-based layouts; flat-layout projects are signaled via
+// metaLayoutNotSupported instead of silently producing zero violations.
+func hasInternalPackages(pkgs []*packages.Package, projectModule string) bool {
+	prefix := projectModule + "/internal/"
+	for _, pkg := range pkgs {
+		if strings.HasPrefix(pkg.PkgPath, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func metaLayoutNotSupported(ruleID, projectModule string) core.Violation {
+	return core.Violation{
+		Rule:              "meta.layout-not-supported",
+		Message:           fmt.Sprintf("%s requires an internal/-based layout; no internal/ packages found in module %q", ruleID, projectModule),
+		Fix:               "use this rule with internal/-based presets (DDD, CleanArch, Hexagonal, ModularMonolith), or remove it from your ruleset for flat layouts",
 		DefaultSeverity:   core.Warning,
 		EffectiveSeverity: core.Warning,
 	}

--- a/rules/dependency/isolation_test.go
+++ b/rules/dependency/isolation_test.go
@@ -2,6 +2,7 @@ package dependency_test
 
 import (
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/NamhaeSusan/go-arch-guard/analyzer"
@@ -78,6 +79,21 @@ func TestIsolationDDDAppServerTransport(t *testing.T) {
 	assertHasRule(t, violations, "isolation.transport-imports-domain")
 }
 
+func TestIsolationFlatLayoutEmitsMetaWarning(t *testing.T) {
+	ctx := loadFlatLayoutContext(t)
+	violations := dependency.NewIsolation().Check(ctx)
+	assertExactlyOneMetaLayoutNotSupported(t, violations, "dependency.isolation")
+}
+
+func TestIsolationDDDProjectHasNoMetaLayoutWarning(t *testing.T) {
+	ctx := loadContext(t, "../../testdata/valid", "github.com/kimtaeyun/testproject-dc", dddArchitecture(), "internal/...")
+	for _, v := range dependency.NewIsolation().Check(ctx) {
+		if v.Rule == "meta.layout-not-supported" {
+			t.Fatalf("internal/-based project must not emit meta.layout-not-supported: %s", v.String())
+		}
+	}
+}
+
 func TestIsolationExclude(t *testing.T) {
 	ctx := loadContextWithExclude(t,
 		"../../testdata/invalid",
@@ -94,6 +110,27 @@ func TestIsolationExclude(t *testing.T) {
 			v.File == "internal/config/orchestration.go" {
 			t.Fatalf("expected config package to be excluded, got %s", v.String())
 		}
+	}
+}
+
+func loadFlatLayoutContext(t *testing.T) *core.Context {
+	t.Helper()
+	return loadContext(t, "../../testdata/flat", "github.com/kimtaeyun/testproject-flat", dddArchitecture(), "...")
+}
+
+func assertExactlyOneMetaLayoutNotSupported(t *testing.T, violations []core.Violation, ruleID string) {
+	t.Helper()
+	var count int
+	for _, v := range violations {
+		if v.Rule == "meta.layout-not-supported" {
+			count++
+			if !strings.Contains(v.Message, ruleID) {
+				t.Fatalf("meta message should mention %q, got %q", ruleID, v.Message)
+			}
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly 1 meta.layout-not-supported, got %d: %+v", count, violations)
 	}
 }
 

--- a/rules/dependency/layer_direction.go
+++ b/rules/dependency/layer_direction.go
@@ -37,12 +37,13 @@ func (r *LayerDirection) Check(ctx *core.Context) []core.Violation {
 	if warns := validateModule(pkgs, projectModule); len(warns) > 0 {
 		return warns
 	}
-	if !hasInternalPackages(pkgs, projectModule) {
+	arch := ctx.Arch()
+	if !hasInternalPackages(pkgs, projectModule, arch.Layout.InternalRoot) {
 		return []core.Violation{metaLayoutNotSupported("dependency.layer-direction", projectModule)}
 	}
-	internalPrefix := projectModule + "/internal/"
+	internalPrefix := projectModule + "/" + arch.Layout.InternalRoot + "/"
 
-	if ctx.Arch().Layout.DomainDir == "" {
+	if arch.Layout.DomainDir == "" {
 		return r.checkFlat(ctx, projectModule, projectRoot, internalPrefix)
 	}
 	return r.checkDomain(ctx, projectModule, projectRoot, internalPrefix)
@@ -81,7 +82,7 @@ func (r *LayerDirection) checkDomain(ctx *core.Context, projectModule, projectRo
 					file, line := analysisutil.FindImportPosition(pkg, impPath, projectRoot)
 					violations = append(violations, r.violation(file, line,
 						"layer.inner-imports-pkg",
-						fmt.Sprintf("inner sublayer %q must not import internal/%s in domain %q", src.Sublayer, arch.Layout.SharedDir, src.Domain),
+						fmt.Sprintf("inner sublayer %q must not import %s/%s in domain %q", src.Sublayer, arch.Layout.InternalRoot, arch.Layout.SharedDir, src.Domain),
 						"keep core and event layers self-contained; move shared concerns outward to app, handler, or infra",
 					))
 				}
@@ -132,7 +133,7 @@ func (r *LayerDirection) checkFlat(ctx *core.Context, projectModule, projectRoot
 					file, line := analysisutil.FindImportPosition(pkg, impPath, projectRoot)
 					violations = append(violations, r.violation(file, line,
 						"layer.inner-imports-pkg",
-						fmt.Sprintf("inner sublayer %q must not import internal/%s", src.Sublayer, arch.Layout.SharedDir),
+						fmt.Sprintf("inner sublayer %q must not import %s/%s", src.Sublayer, arch.Layout.InternalRoot, arch.Layout.SharedDir),
 						"keep inner layers self-contained; move shared concerns to an outer layer",
 					))
 				}

--- a/rules/dependency/layer_direction.go
+++ b/rules/dependency/layer_direction.go
@@ -13,11 +13,8 @@ import (
 type LayerDirection struct{ severity core.Severity }
 
 func NewLayerDirection(opts ...Option) *LayerDirection {
-	r := &LayerDirection{severity: core.Error}
-	for _, opt := range opts {
-		r.severity = opt.severity()
-	}
-	return r
+	cfg := newConfig(opts, core.Error)
+	return &LayerDirection{severity: cfg.severity}
 }
 
 func (r *LayerDirection) Spec() core.RuleSpec {
@@ -36,8 +33,12 @@ func (r *LayerDirection) Spec() core.RuleSpec {
 func (r *LayerDirection) Check(ctx *core.Context) []core.Violation {
 	projectModule := analysisutil.ResolveModuleFromContext(ctx, "")
 	projectRoot := analysisutil.ResolveRootFromContext(ctx, "")
-	if warns := validateModule(ctx.Pkgs(), projectModule); len(warns) > 0 {
+	pkgs := ctx.Pkgs()
+	if warns := validateModule(pkgs, projectModule); len(warns) > 0 {
 		return warns
+	}
+	if !hasInternalPackages(pkgs, projectModule) {
+		return []core.Violation{metaLayoutNotSupported("dependency.layer-direction", projectModule)}
 	}
 	internalPrefix := projectModule + "/internal/"
 

--- a/rules/dependency/layer_direction_test.go
+++ b/rules/dependency/layer_direction_test.go
@@ -61,6 +61,12 @@ func TestLayerDirectionInvalidProject(t *testing.T) {
 	}
 }
 
+func TestLayerDirectionFlatLayoutEmitsMetaWarning(t *testing.T) {
+	ctx := loadFlatLayoutContext(t)
+	violations := dependency.NewLayerDirection().Check(ctx)
+	assertExactlyOneMetaLayoutNotSupported(t, violations, "dependency.layer-direction")
+}
+
 func TestLayerDirectionExclude(t *testing.T) {
 	ctx := loadContextWithExclude(t,
 		"../../testdata/invalid",

--- a/rules/dependency/option.go
+++ b/rules/dependency/option.go
@@ -1,0 +1,23 @@
+package dependency
+
+import "github.com/NamhaeSusan/go-arch-guard/core"
+
+type Option func(*ruleConfig)
+
+type ruleConfig struct {
+	severity core.Severity
+}
+
+func WithSeverity(severity core.Severity) Option {
+	return func(cfg *ruleConfig) {
+		cfg.severity = severity
+	}
+}
+
+func newConfig(opts []Option, severity core.Severity) ruleConfig {
+	cfg := ruleConfig{severity: severity}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return cfg
+}

--- a/rules/interfaces/container.go
+++ b/rules/interfaces/container.go
@@ -5,7 +5,6 @@ import (
 	"go/ast"
 	"go/token"
 	"sort"
-	"strings"
 
 	"github.com/NamhaeSusan/go-arch-guard/core"
 	"github.com/NamhaeSusan/go-arch-guard/core/analysisutil"
@@ -13,15 +12,11 @@ import (
 )
 
 type Container struct {
-	cfg config
+	cfg ruleConfig
 }
 
 func NewContainer(opts ...Option) *Container {
-	cfg := config{severity: core.Warning}
-	for _, opt := range opts {
-		opt(&cfg)
-	}
-	return &Container{cfg: cfg}
+	return &Container{cfg: newConfig(opts, core.Warning)}
 }
 
 func (r *Container) Spec() core.RuleSpec {
@@ -59,7 +54,7 @@ func (r *Container) checkPackage(pkg *packages.Package) []core.Violation {
 	}
 
 	for _, file := range pkg.Syntax {
-		if isTestFile(pkg, file) {
+		if analysisutil.IsTestFile(file, pkg.Fset) {
 			continue
 		}
 		ast.Inspect(file, func(n ast.Node) bool {
@@ -160,13 +155,21 @@ func countTypeRefs(expr ast.Expr, ifaces map[string]token.Position, usage map[st
 	case *ast.FuncType:
 		countFieldListRefs(e.Params, ifaces, usage, kind)
 		countFieldListRefs(e.Results, ifaces, usage, kind)
+	case *ast.IndexExpr:
+		countTypeRefs(e.X, ifaces, usage, kind)
+		countTypeRefs(e.Index, ifaces, usage, kind)
+	case *ast.IndexListExpr:
+		countTypeRefs(e.X, ifaces, usage, kind)
+		for _, idx := range e.Indices {
+			countTypeRefs(idx, ifaces, usage, kind)
+		}
 	}
 }
 
 func collectNonTestInterfaces(pkg *packages.Package) map[string]token.Position {
 	result := make(map[string]token.Position)
 	for _, file := range pkg.Syntax {
-		if isTestFile(pkg, file) {
+		if analysisutil.IsTestFile(file, pkg.Fset) {
 			continue
 		}
 		for _, decl := range file.Decls {
@@ -186,11 +189,6 @@ func collectNonTestInterfaces(pkg *packages.Package) map[string]token.Position {
 		}
 	}
 	return result
-}
-
-func isTestFile(pkg *packages.Package, file *ast.File) bool {
-	pos := pkg.Fset.Position(file.Pos())
-	return strings.HasSuffix(pos.Filename, "_test.go")
 }
 
 var _ core.Rule = (*Container)(nil)

--- a/rules/interfaces/container_test.go
+++ b/rules/interfaces/container_test.go
@@ -62,6 +62,27 @@ func New() Reader { return &reader{} }
 	assertLacksRule(t, violations, "interface.container-only")
 }
 
+func TestContainerHandlesGenericTypeArguments(t *testing.T) {
+	root := writeFixture(t, "example.com/container-generics", map[string]string{
+		"internal/wire/wire.go": `package wire
+
+type Reader interface {
+	Read() string
+}
+
+type Cache[T any] struct {
+	v T
+}
+
+func New() *Cache[Reader] { return &Cache[Reader]{} }
+`,
+	})
+
+	violations := interfaces.NewContainer().Check(loadContext(t, root, flatArchitecture(), "example.com/container-generics"))
+
+	assertLacksRule(t, violations, "interface.container-only")
+}
+
 func TestContainerWithSeverity(t *testing.T) {
 	rule := interfaces.NewContainer(interfaces.WithSeverity(core.Error))
 

--- a/rules/interfaces/cross_domain.go
+++ b/rules/interfaces/cross_domain.go
@@ -36,16 +36,17 @@ func (r *CrossDomainAnonymous) Check(ctx *core.Context) []core.Violation {
 	}
 	pkgs := ctx.Pkgs()
 	projectModule := analysisutil.ResolveModuleFromContext(ctx, "")
-	if !hasInternalPackages(pkgs, projectModule) {
+	arch := ctx.Arch()
+	if !hasInternalPackages(pkgs, projectModule, arch.Layout.InternalRoot) {
 		return []core.Violation{metaLayoutNotSupported("interfaces.cross-domain-anonymous", projectModule)}
 	}
-	if ctx.Arch().Layout.DomainDir == "" {
+	if arch.Layout.DomainDir == "" {
 		return nil
 	}
 
 	var violations []core.Violation
 	for _, pkg := range pkgs {
-		violations = append(violations, r.checkPackage(pkg, ctx.Arch())...)
+		violations = append(violations, r.checkPackage(pkg, arch)...)
 	}
 	return violations
 }
@@ -144,7 +145,7 @@ func (r *CrossDomainAnonymous) checkAnonymousInterface(iface *ast.InterfaceType,
 		Line:              pos.Line,
 		Rule:              "interface.cross-domain-anonymous",
 		Message:           fmt.Sprintf("anonymous interface declared in package %q references types from domain(s) %v", pkg.PkgPath, domains),
-		Fix:               "move this adapter/abstraction into internal/" + arch.Layout.OrchestrationDir + "/",
+		Fix:               "move this adapter/abstraction into " + arch.Layout.InternalRoot + "/" + arch.Layout.OrchestrationDir + "/",
 		DefaultSeverity:   r.cfg.severity,
 		EffectiveSeverity: r.cfg.severity,
 	}}
@@ -194,7 +195,7 @@ func owningDomainForPath(pkgPath string, arch core.Architecture) string {
 	}
 	parts := strings.Split(pkgPath, "/")
 	for i := 0; i+2 < len(parts); i++ {
-		if parts[i] == "internal" && parts[i+1] == arch.Layout.DomainDir {
+		if parts[i] == arch.Layout.InternalRoot && parts[i+1] == arch.Layout.DomainDir {
 			return parts[i+2]
 		}
 	}
@@ -207,7 +208,7 @@ func isOrchestrationPath(pkgPath string, arch core.Architecture) bool {
 	}
 	parts := strings.Split(pkgPath, "/")
 	for i := 0; i+1 < len(parts); i++ {
-		if parts[i] == "internal" && parts[i+1] == arch.Layout.OrchestrationDir {
+		if parts[i] == arch.Layout.InternalRoot && parts[i+1] == arch.Layout.OrchestrationDir {
 			return true
 		}
 	}

--- a/rules/interfaces/cross_domain.go
+++ b/rules/interfaces/cross_domain.go
@@ -12,15 +12,11 @@ import (
 )
 
 type CrossDomainAnonymous struct {
-	cfg config
+	cfg ruleConfig
 }
 
 func NewCrossDomainAnonymous(opts ...Option) *CrossDomainAnonymous {
-	cfg := config{severity: core.Error}
-	for _, opt := range opts {
-		opt(&cfg)
-	}
-	return &CrossDomainAnonymous{cfg: cfg}
+	return &CrossDomainAnonymous{cfg: newConfig(opts, core.Error)}
 }
 
 func (r *CrossDomainAnonymous) Spec() core.RuleSpec {
@@ -35,12 +31,20 @@ func (r *CrossDomainAnonymous) Spec() core.RuleSpec {
 }
 
 func (r *CrossDomainAnonymous) Check(ctx *core.Context) []core.Violation {
-	if ctx == nil || ctx.Arch().Layout.DomainDir == "" {
+	if ctx == nil {
+		return nil
+	}
+	pkgs := ctx.Pkgs()
+	projectModule := analysisutil.ResolveModuleFromContext(ctx, "")
+	if !hasInternalPackages(pkgs, projectModule) {
+		return []core.Violation{metaLayoutNotSupported("interfaces.cross-domain-anonymous", projectModule)}
+	}
+	if ctx.Arch().Layout.DomainDir == "" {
 		return nil
 	}
 
 	var violations []core.Violation
-	for _, pkg := range ctx.Pkgs() {
+	for _, pkg := range pkgs {
 		violations = append(violations, r.checkPackage(pkg, ctx.Arch())...)
 	}
 	return violations
@@ -54,7 +58,7 @@ func (r *CrossDomainAnonymous) checkPackage(pkg *packages.Package, arch core.Arc
 
 	var violations []core.Violation
 	for _, file := range pkg.Syntax {
-		if isTestFile(pkg, file) {
+		if analysisutil.IsTestFile(file, pkg.Fset) {
 			continue
 		}
 		for _, decl := range file.Decls {

--- a/rules/interfaces/layout_meta.go
+++ b/rules/interfaces/layout_meta.go
@@ -9,14 +9,15 @@ import (
 )
 
 // hasInternalPackages reports whether any loaded package lives under
-// <module>/internal/. Pattern and CrossDomainAnonymous classify packages by
-// their internal/<DomainDir>/<sublayer> position, so flat-layout projects
-// produce no useful violations and should be signaled via metaLayoutNotSupported.
-func hasInternalPackages(pkgs []*packages.Package, projectModule string) bool {
+// <module>/<internalRoot>/. Pattern and CrossDomainAnonymous classify
+// packages by their <internalRoot>/<DomainDir>/<sublayer> position, so
+// flat-layout projects produce no useful violations and should be
+// signaled via metaLayoutNotSupported.
+func hasInternalPackages(pkgs []*packages.Package, projectModule, internalRoot string) bool {
 	if projectModule == "" {
 		return false
 	}
-	prefix := projectModule + "/internal/"
+	prefix := projectModule + "/" + internalRoot + "/"
 	for _, pkg := range pkgs {
 		if strings.HasPrefix(pkg.PkgPath, prefix) {
 			return true

--- a/rules/interfaces/layout_meta.go
+++ b/rules/interfaces/layout_meta.go
@@ -1,0 +1,36 @@
+package interfaces
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/NamhaeSusan/go-arch-guard/core"
+	"golang.org/x/tools/go/packages"
+)
+
+// hasInternalPackages reports whether any loaded package lives under
+// <module>/internal/. Pattern and CrossDomainAnonymous classify packages by
+// their internal/<DomainDir>/<sublayer> position, so flat-layout projects
+// produce no useful violations and should be signaled via metaLayoutNotSupported.
+func hasInternalPackages(pkgs []*packages.Package, projectModule string) bool {
+	if projectModule == "" {
+		return false
+	}
+	prefix := projectModule + "/internal/"
+	for _, pkg := range pkgs {
+		if strings.HasPrefix(pkg.PkgPath, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func metaLayoutNotSupported(ruleID, projectModule string) core.Violation {
+	return core.Violation{
+		Rule:              "meta.layout-not-supported",
+		Message:           fmt.Sprintf("%s requires an internal/-based layout; no internal/ packages found in module %q", ruleID, projectModule),
+		Fix:               "use this rule with internal/-based presets (DDD, CleanArch, Hexagonal, ModularMonolith), or remove it from your ruleset for flat layouts",
+		DefaultSeverity:   core.Warning,
+		EffectiveSeverity: core.Warning,
+	}
+}

--- a/rules/interfaces/layout_meta_test.go
+++ b/rules/interfaces/layout_meta_test.go
@@ -1,0 +1,59 @@
+package interfaces_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/NamhaeSusan/go-arch-guard/analyzer"
+	"github.com/NamhaeSusan/go-arch-guard/core"
+	"github.com/NamhaeSusan/go-arch-guard/rules/interfaces"
+)
+
+func loadFlatContext(t *testing.T) *core.Context {
+	t.Helper()
+	pkgs, err := analyzer.Load("../../testdata/flat", "...")
+	if err != nil {
+		t.Fatalf("load packages: %v", err)
+	}
+	// domainArchitecture() is used deliberately: hasInternalPackages
+	// short-circuits before DomainDir is read, so the arch config is
+	// irrelevant for the meta path. Using a non-empty DomainDir also
+	// proves the meta guard fires before the DomainDir-empty guard.
+	return core.NewContext(pkgs, "github.com/kimtaeyun/testproject-flat", "../../testdata/flat", domainArchitecture(), nil)
+}
+
+func assertExactlyOneMeta(t *testing.T, violations []core.Violation, ruleID string) {
+	t.Helper()
+	var count int
+	for _, v := range violations {
+		if v.Rule == "meta.layout-not-supported" {
+			count++
+			if !strings.Contains(v.Message, ruleID) {
+				t.Fatalf("meta message should mention %q, got %q", ruleID, v.Message)
+			}
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly 1 meta.layout-not-supported, got %d: %+v", count, violations)
+	}
+}
+
+func TestPatternFlatLayoutEmitsMetaWarning(t *testing.T) {
+	violations := interfaces.NewPattern().Check(loadFlatContext(t))
+	assertExactlyOneMeta(t, violations, "interfaces.pattern")
+}
+
+func TestCrossDomainAnonymousFlatLayoutEmitsMetaWarning(t *testing.T) {
+	violations := interfaces.NewCrossDomainAnonymous().Check(loadFlatContext(t))
+	assertExactlyOneMeta(t, violations, "interfaces.cross-domain-anonymous")
+}
+
+func TestContainerFlatLayoutDoesNotEmitMeta(t *testing.T) {
+	// Container is layout-agnostic and must not emit meta warnings.
+	violations := interfaces.NewContainer().Check(loadFlatContext(t))
+	for _, v := range violations {
+		if v.Rule == "meta.layout-not-supported" {
+			t.Fatalf("Container must not emit meta.layout-not-supported: %+v", v)
+		}
+	}
+}

--- a/rules/interfaces/option.go
+++ b/rules/interfaces/option.go
@@ -1,0 +1,30 @@
+package interfaces
+
+import "github.com/NamhaeSusan/go-arch-guard/core"
+
+type Option func(*ruleConfig)
+
+type ruleConfig struct {
+	severity   core.Severity
+	maxMethods int
+}
+
+func WithSeverity(severity core.Severity) Option {
+	return func(cfg *ruleConfig) {
+		cfg.severity = severity
+	}
+}
+
+func WithMaxMethods(n int) Option {
+	return func(cfg *ruleConfig) {
+		cfg.maxMethods = n
+	}
+}
+
+func newConfig(opts []Option, severity core.Severity) ruleConfig {
+	cfg := ruleConfig{severity: severity}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return cfg
+}

--- a/rules/interfaces/pattern.go
+++ b/rules/interfaces/pattern.go
@@ -41,13 +41,14 @@ func (r *Pattern) Check(ctx *core.Context) []core.Violation {
 	}
 	pkgs := ctx.Pkgs()
 	projectModule := analysisutil.ResolveModuleFromContext(ctx, "")
-	if !hasInternalPackages(pkgs, projectModule) {
+	arch := ctx.Arch()
+	if !hasInternalPackages(pkgs, projectModule, arch.Layout.InternalRoot) {
 		return []core.Violation{metaLayoutNotSupported("interfaces.pattern", projectModule)}
 	}
 
 	var violations []core.Violation
 	for _, pkg := range pkgs {
-		if isExcludedInterfacePatternPkg(ctx.Arch(), pkg) {
+		if isExcludedInterfacePatternPkg(arch, pkg) {
 			continue
 		}
 
@@ -70,7 +71,7 @@ func isExcludedInterfacePatternPkg(arch core.Architecture, pkg *packages.Package
 	parts := strings.Split(pkg.PkgPath, "/")
 	internalIdx := -1
 	for i, p := range parts {
-		if p == "internal" {
+		if p == arch.Layout.InternalRoot {
 			internalIdx = i
 			break
 		}

--- a/rules/interfaces/pattern.go
+++ b/rules/interfaces/pattern.go
@@ -12,35 +12,12 @@ import (
 	"golang.org/x/tools/go/packages"
 )
 
-type Option func(*config)
-
-type config struct {
-	severity   core.Severity
-	maxMethods int
-}
-
-func WithSeverity(s core.Severity) Option {
-	return func(c *config) {
-		c.severity = s
-	}
-}
-
-func WithMaxMethods(n int) Option {
-	return func(c *config) {
-		c.maxMethods = n
-	}
-}
-
 type Pattern struct {
-	cfg config
+	cfg ruleConfig
 }
 
 func NewPattern(opts ...Option) *Pattern {
-	cfg := config{severity: core.Error}
-	for _, opt := range opts {
-		opt(&cfg)
-	}
-	return &Pattern{cfg: cfg}
+	return &Pattern{cfg: newConfig(opts, core.Error)}
 }
 
 func (r *Pattern) Spec() core.RuleSpec {
@@ -62,9 +39,14 @@ func (r *Pattern) Check(ctx *core.Context) []core.Violation {
 	if ctx == nil {
 		return nil
 	}
+	pkgs := ctx.Pkgs()
+	projectModule := analysisutil.ResolveModuleFromContext(ctx, "")
+	if !hasInternalPackages(pkgs, projectModule) {
+		return []core.Violation{metaLayoutNotSupported("interfaces.pattern", projectModule)}
+	}
 
 	var violations []core.Violation
-	for _, pkg := range ctx.Pkgs() {
+	for _, pkg := range pkgs {
 		if isExcludedInterfacePatternPkg(ctx.Arch(), pkg) {
 			continue
 		}
@@ -211,8 +193,19 @@ func (r *Pattern) checkExportedImpl(pkg *packages.Package) []core.Violation {
 		return nil
 	}
 
+	structNames := make([]string, 0, len(structs))
+	for name := range structs {
+		structNames = append(structNames, name)
+	}
+	sort.Strings(structNames)
+	ifaceNames := make([]string, 0, len(typedIfaces))
+	for name := range typedIfaces {
+		ifaceNames = append(ifaceNames, name)
+	}
+	sort.Strings(ifaceNames)
+
 	var violations []core.Violation
-	for structName := range structs {
+	for _, structName := range structNames {
 		obj := scope.Lookup(structName)
 		if obj == nil {
 			continue
@@ -222,7 +215,8 @@ func (r *Pattern) checkExportedImpl(pkg *packages.Package) []core.Violation {
 			continue
 		}
 		ptrType := types.NewPointer(named)
-		for ifaceName, iface := range typedIfaces {
+		for _, ifaceName := range ifaceNames {
+			iface := typedIfaces[ifaceName]
 			if !types.Implements(named, iface) && !types.Implements(ptrType, iface) {
 				continue
 			}
@@ -330,9 +324,49 @@ func formatTypeExpr(expr ast.Expr) string {
 		return "[]" + formatTypeExpr(e.Elt)
 	case *ast.MapType:
 		return "map[" + formatTypeExpr(e.Key) + "]" + formatTypeExpr(e.Value)
+	case *ast.ChanType:
+		switch e.Dir {
+		case ast.SEND:
+			return "chan<- " + formatTypeExpr(e.Value)
+		case ast.RECV:
+			return "<-chan " + formatTypeExpr(e.Value)
+		default:
+			return "chan " + formatTypeExpr(e.Value)
+		}
+	case *ast.FuncType:
+		return "func" + formatFieldList(e.Params) + formatFuncResults(e.Results)
+	case *ast.IndexExpr:
+		return formatTypeExpr(e.X) + "[" + formatTypeExpr(e.Index) + "]"
+	case *ast.IndexListExpr:
+		parts := make([]string, 0, len(e.Indices))
+		for _, idx := range e.Indices {
+			parts = append(parts, formatTypeExpr(idx))
+		}
+		return formatTypeExpr(e.X) + "[" + strings.Join(parts, ", ") + "]"
 	default:
 		return "unknown"
 	}
+}
+
+func formatFieldList(fields *ast.FieldList) string {
+	if fields == nil {
+		return "()"
+	}
+	parts := make([]string, 0, len(fields.List))
+	for _, f := range fields.List {
+		parts = append(parts, formatTypeExpr(f.Type))
+	}
+	return "(" + strings.Join(parts, ", ") + ")"
+}
+
+func formatFuncResults(fields *ast.FieldList) string {
+	if fields == nil || len(fields.List) == 0 {
+		return ""
+	}
+	if len(fields.List) == 1 && len(fields.List[0].Names) == 0 {
+		return " " + formatTypeExpr(fields.List[0].Type)
+	}
+	return " " + formatFieldList(fields)
 }
 
 func (r *Pattern) violation(pkg *packages.Package, line int, id, message, fix string) core.Violation {

--- a/rules/interfaces/pattern_test.go
+++ b/rules/interfaces/pattern_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/NamhaeSusan/go-arch-guard/analyzer"
@@ -126,6 +127,45 @@ func TestPatternWithSeverity(t *testing.T) {
 		if v.DefaultSeverity != core.Warning {
 			t.Fatalf("%s DefaultSeverity = %v, want Warning", v.ID, v.DefaultSeverity)
 		}
+	}
+}
+
+func TestPatternConstructorReturnsInterfaceFormatsGenericReturn(t *testing.T) {
+	root := writeFixture(t, "example.com/pattern-generic-return", map[string]string{
+		"internal/store/store.go": `package store
+
+type Store interface {
+	Get(id string) string
+}
+
+type Cache[T any] struct{ v T }
+
+type s struct{}
+
+func (impl *s) Get(id string) string { return "" }
+
+// New does not return an interface — should be flagged with a readable type name.
+func New() *Cache[Store] { return &Cache[Store]{} }
+`,
+	})
+
+	violations := interfaces.NewPattern().Check(loadContext(t, root, flatArchitecture(), "example.com/pattern-generic-return"))
+
+	var found bool
+	for _, v := range violations {
+		if v.Rule != "interface.constructor-returns-interface" {
+			continue
+		}
+		found = true
+		if !strings.Contains(v.Message, "*Cache[Store]") {
+			t.Fatalf("Message should format generic type *Cache[Store], got %q", v.Message)
+		}
+		if strings.Contains(v.Message, "unknown") {
+			t.Fatalf("Message must not say 'unknown', got %q", v.Message)
+		}
+	}
+	if !found {
+		t.Fatalf("expected constructor-returns-interface violation, got %+v", violations)
 	}
 }
 

--- a/rules/naming/no_hand_mock.go
+++ b/rules/naming/no_hand_mock.go
@@ -72,7 +72,7 @@ func (r *NoHandMock) checkFile(path, relPath string) []core.Violation {
 		if !ok || fd.Recv == nil || len(fd.Recv.List) == 0 {
 			continue
 		}
-		recvName := receiverTypeName(fd.Recv.List[0].Type)
+		recvName := analysisutil.ReceiverTypeName(fd.Recv.List[0].Type)
 		line, ok := structs[recvName]
 		if !ok {
 			continue
@@ -113,16 +113,6 @@ func collectMockStructs(fset *token.FileSet, file *ast.File) map[string]int {
 		}
 	}
 	return result
-}
-
-func receiverTypeName(expr ast.Expr) string {
-	if star, ok := expr.(*ast.StarExpr); ok {
-		expr = star.X
-	}
-	if ident, ok := expr.(*ast.Ident); ok {
-		return ident.Name
-	}
-	return ""
 }
 
 var _ core.Rule = (*NoHandMock)(nil)

--- a/rules/naming/no_stutter.go
+++ b/rules/naming/no_stutter.go
@@ -9,26 +9,6 @@ import (
 	"github.com/NamhaeSusan/go-arch-guard/core/analysisutil"
 )
 
-type Option func(*ruleConfig)
-
-type ruleConfig struct {
-	severity core.Severity
-}
-
-func WithSeverity(severity core.Severity) Option {
-	return func(cfg *ruleConfig) {
-		cfg.severity = severity
-	}
-}
-
-func newConfig(opts []Option, severity core.Severity) ruleConfig {
-	cfg := ruleConfig{severity: severity}
-	for _, opt := range opts {
-		opt(&cfg)
-	}
-	return cfg
-}
-
 type NoStutter struct {
 	severity core.Severity
 }

--- a/rules/naming/option.go
+++ b/rules/naming/option.go
@@ -1,0 +1,23 @@
+package naming
+
+import "github.com/NamhaeSusan/go-arch-guard/core"
+
+type Option func(*ruleConfig)
+
+type ruleConfig struct {
+	severity core.Severity
+}
+
+func WithSeverity(severity core.Severity) Option {
+	return func(cfg *ruleConfig) {
+		cfg.severity = severity
+	}
+}
+
+func newConfig(opts []Option, severity core.Severity) ruleConfig {
+	cfg := ruleConfig{severity: severity}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return cfg
+}

--- a/rules/naming/repo_file_interface.go
+++ b/rules/naming/repo_file_interface.go
@@ -88,7 +88,7 @@ func (r *RepoFileInterface) checkPortPackage(ctx *core.Context, pkg *packages.Pa
 			0,
 			"structure.repo-file-extra-interface",
 			`file "`+base+`" in repo/ must define only "`+expected+`", found extra: `+strings.Join(extra, ", "),
-			"move each extra interface to its own file (e.g. "+strings.ToLower(extra[0])+".go)",
+			"move each extra interface to its own file (e.g. "+pascalToSnake(extra[0])+".go)",
 		))
 	}
 	return violations

--- a/rules/naming/repo_file_interface.go
+++ b/rules/naming/repo_file_interface.go
@@ -106,22 +106,22 @@ func (r *RepoFileInterface) checkInterfacePlacement(ctx *core.Context, pkg *pack
 		if ctx.IsExcluded(filePath) {
 			continue
 		}
-		for _, info := range inspectTypeSpecs(file, pkg) {
-			if info.isIface && isRepoPortName(info.name) {
+		for _, info := range analysisutil.InspectTypeSpecs(file, pkg.Fset) {
+			if info.IsInterface && isRepoPortName(info.Name) {
 				violations = append(violations, r.violation(
-					info.file,
-					info.line,
+					filePath,
+					info.Line,
 					"structure.interface-placement",
-					`interface "`+info.name+`" matches repository-port naming and must be defined in `+repoName+`/, not in `+path.Base(path.Dir(pkg.PkgPath))+`/`,
+					`interface "`+info.Name+`" matches repository-port naming and must be defined in `+repoName+`/, not in `+path.Base(path.Dir(pkg.PkgPath))+`/`,
 					"move to "+repoName+"/, or rename if it's a consumer-defined interface",
 				))
 			}
-			if info.aliasFrom != "" && analysisutil.MatchPortSublayer(arch.Layers, info.aliasFrom) != "" {
+			if info.AliasFrom != "" && analysisutil.MatchPortSublayer(arch.Layers, info.AliasFrom) != "" {
 				violations = append(violations, r.violation(
-					info.file,
-					info.line,
+					filePath,
+					info.Line,
 					"structure.interface-placement",
-					`type alias "`+info.name+`" re-exports interface from `+repoName+` - suspected cross-domain dependency; use `+arch.Layout.OrchestrationDir+`/ instead`,
+					`type alias "`+info.Name+`" re-exports interface from `+repoName+` - suspected cross-domain dependency; use `+arch.Layout.OrchestrationDir+`/ instead`,
 					"remove alias and move cross-domain coordination to "+arch.Layout.OrchestrationDir+"/",
 				))
 			}
@@ -168,50 +168,6 @@ func isDomainPackage(arch core.Architecture, pkgPath string) bool {
 
 func isRepoPortName(name string) bool {
 	return strings.HasSuffix(name, "Repository") || strings.HasSuffix(name, "Repo")
-}
-
-type typeSpecInfo struct {
-	name      string
-	file      string
-	line      int
-	isIface   bool
-	aliasFrom string
-}
-
-func inspectTypeSpecs(file *ast.File, pkg *packages.Package) []typeSpecInfo {
-	var result []typeSpecInfo
-	for _, decl := range file.Decls {
-		gd, ok := decl.(*ast.GenDecl)
-		if !ok {
-			continue
-		}
-		for _, spec := range gd.Specs {
-			ts, ok := spec.(*ast.TypeSpec)
-			if !ok {
-				continue
-			}
-			pos := pkg.Fset.Position(ts.Name.Pos())
-			info := typeSpecInfo{
-				name: ts.Name.Name,
-				file: analysisutil.RelativePathForPackage(pkg, pos.Filename),
-				line: pos.Line,
-			}
-			if _, ok := ts.Type.(*ast.InterfaceType); ok {
-				info.isIface = true
-			}
-			if ts.Assign != 0 {
-				if sel, ok := ts.Type.(*ast.SelectorExpr); ok {
-					if ident, ok := sel.X.(*ast.Ident); ok {
-						info.aliasFrom = analysisutil.ResolveIdentImportPath(file, ident.Name)
-					}
-				}
-			}
-			if info.isIface || info.aliasFrom != "" {
-				result = append(result, info)
-			}
-		}
-	}
-	return result
 }
 
 var _ core.Rule = (*RepoFileInterface)(nil)

--- a/rules/naming/repo_file_interface.go
+++ b/rules/naming/repo_file_interface.go
@@ -62,7 +62,7 @@ func (r *RepoFileInterface) checkPortPackage(ctx *core.Context, pkg *packages.Pa
 		if ctx.IsExcluded(relPath) {
 			continue
 		}
-		expected := snakeToPascal(strings.TrimSuffix(base, ".go"))
+		expected := analysisutil.SnakeToPascal(strings.TrimSuffix(base, ".go"))
 		ifaces := collectInterfacesFromFile(file)
 		if _, ok := ifaces[expected]; !ok {
 			violations = append(violations, r.violation(
@@ -140,19 +140,6 @@ func (r *RepoFileInterface) violation(file string, line int, rule, message, fix 
 		DefaultSeverity:   r.severity,
 		EffectiveSeverity: r.severity,
 	}
-}
-
-func snakeToPascal(s string) string {
-	parts := strings.Split(s, "_")
-	var b strings.Builder
-	for _, part := range parts {
-		if part == "" {
-			continue
-		}
-		b.WriteString(strings.ToUpper(part[:1]))
-		b.WriteString(part[1:])
-	}
-	return b.String()
 }
 
 func collectInterfacesFromFile(file *ast.File) map[string]*ast.InterfaceType {

--- a/rules/naming/repo_file_interface.go
+++ b/rules/naming/repo_file_interface.go
@@ -163,7 +163,7 @@ func collectInterfacesFromFile(file *ast.File) map[string]*ast.InterfaceType {
 }
 
 func isDomainPackage(arch core.Architecture, pkgPath string) bool {
-	return arch.Layout.DomainDir != "" && strings.Contains(pkgPath, "/internal/"+arch.Layout.DomainDir+"/")
+	return arch.Layout.DomainDir != "" && strings.Contains(pkgPath, "/"+arch.Layout.InternalRoot+"/"+arch.Layout.DomainDir+"/")
 }
 
 func isRepoPortName(name string) bool {

--- a/rules/naming/repo_file_interface_test.go
+++ b/rules/naming/repo_file_interface_test.go
@@ -51,6 +51,30 @@ func TestRepoFileInterfaceFlagsExtraInterfaces(t *testing.T) {
 	}
 }
 
+func TestRepoFileInterfaceExtraInterfaceFixUsesSnakeCase(t *testing.T) {
+	ctx := tempContext(t, map[string]string{
+		"internal/domain/order/core/repo/order.go": "package repo\n\ntype Order interface { Find() }\ntype UserRepository interface { Save() }\n",
+	}, dddArch())
+
+	got := naming.NewRepoFileInterface().Check(ctx)
+	var found bool
+	for _, v := range got {
+		if v.Rule != "structure.repo-file-extra-interface" {
+			continue
+		}
+		found = true
+		if !strings.Contains(v.Fix, "user_repository.go") {
+			t.Fatalf("Fix = %q, want it to suggest user_repository.go", v.Fix)
+		}
+		if strings.Contains(v.Fix, "userrepository.go") {
+			t.Fatalf("Fix = %q, must not suggest userrepository.go", v.Fix)
+		}
+	}
+	if !found {
+		t.Fatalf("expected extra-interface violation, got %+v", got)
+	}
+}
+
 func TestRepoFileInterfaceFlagsRepositoryPortOutsidePortLayer(t *testing.T) {
 	got := naming.NewRepoFileInterface().Check(invalidContext(t, nil))
 

--- a/rules/naming/snake_case_files.go
+++ b/rules/naming/snake_case_files.go
@@ -75,19 +75,29 @@ func isSnakeCase(filename string) bool {
 
 func toSnakeCase(filename string) string {
 	ext := filepath.Ext(filename)
-	name := strings.TrimSuffix(filename, ext)
+	return pascalToSnake(strings.TrimSuffix(filename, ext)) + ext
+}
+
+// pascalToSnake converts a PascalCase / camelCase / mixed identifier to
+// snake_case. Runs of uppercase are kept together as one word; an underscore
+// is inserted only at a real word boundary:
+//   - between a lowercase/digit and an uppercase ("createOrder" -> "create_order")
+//   - between an uppercase and an uppercase that is followed by a lowercase
+//     ("XMLParser" -> "xml_parser")
+func pascalToSnake(name string) string {
+	runes := []rune(name)
 	var result []rune
-	for i, r := range name {
-		if unicode.IsUpper(r) {
-			if i > 0 {
+	for i, r := range runes {
+		if i > 0 && unicode.IsUpper(r) {
+			prev := runes[i-1]
+			nextLower := i+1 < len(runes) && unicode.IsLower(runes[i+1])
+			if unicode.IsLower(prev) || unicode.IsDigit(prev) || (unicode.IsUpper(prev) && nextLower) {
 				result = append(result, '_')
 			}
-			result = append(result, unicode.ToLower(r))
-			continue
 		}
-		result = append(result, r)
+		result = append(result, unicode.ToLower(r))
 	}
-	return string(result) + ext
+	return string(result)
 }
 
 var _ core.Rule = (*SnakeCaseFiles)(nil)

--- a/rules/naming/snake_case_files_test.go
+++ b/rules/naming/snake_case_files_test.go
@@ -33,6 +33,30 @@ func TestSnakeCaseFilesFlagsNonSnakeCaseGoFile(t *testing.T) {
 	}
 }
 
+func TestSnakeCaseFilesFixHandlesUppercaseRuns(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"createOrder.go", "create_order.go"},
+		{"XMLParser.go", "xml_parser.go"},
+		{"HTTP.go", "http.go"},
+		{"HTTPServer.go", "http_server.go"},
+		{"parseHTTPRequest.go", "parse_http_request.go"},
+	}
+	for _, tc := range cases {
+		ctx := tempContext(t, map[string]string{
+			"internal/domain/order/app/" + tc.in: "package app\n",
+		}, dddArch())
+		got := naming.NewSnakeCaseFiles().Check(ctx)
+		if len(got) != 1 {
+			t.Fatalf("%s: len = %d, want 1: %+v", tc.in, len(got), got)
+		}
+		if !strings.Contains(got[0].Fix, tc.want) {
+			t.Fatalf("%s: Fix = %q, want it to contain %q", tc.in, got[0].Fix, tc.want)
+		}
+	}
+}
+
 func TestSnakeCaseFilesSkipsExcludedPath(t *testing.T) {
 	ctx := core.NewContext(loadInvalid(t), "github.com/kimtaeyun/testproject-dc-invalid", "../../testdata/invalid", dddArch(), []string{"internal/domain/order/handler/..."})
 

--- a/rules/structural/alias.go
+++ b/rules/structural/alias.go
@@ -1,7 +1,6 @@
 package structural
 
 import (
-	"go/ast"
 	"go/parser"
 	"go/token"
 	"os"
@@ -21,33 +20,13 @@ const (
 	aliasContractExport = "structure.domain-alias-contract-reexport"
 )
 
-type Option func(any)
-
-func WithSeverity(s core.Severity) Option {
-	return func(rule any) {
-		switch r := rule.(type) {
-		case *Alias:
-			r.severity = s
-		case *Placement:
-			r.severity = s
-		case *BannedPackage:
-			r.severity = s
-		case *ModelRequired:
-			r.severity = s
-		case *InternalTopLevel:
-			r.severity = s
-		}
-	}
-}
-
 type Alias struct {
 	severity core.Severity
 }
 
 func NewAlias(opts ...Option) *Alias {
-	r := &Alias{severity: core.Error}
-	applyOptions(r, opts)
-	return r
+	cfg := newConfig(opts, core.Error)
+	return &Alias{severity: cfg.severity}
 }
 
 func (r *Alias) Spec() core.RuleSpec {
@@ -68,6 +47,9 @@ func (r *Alias) Spec() core.RuleSpec {
 func (r *Alias) Check(ctx *core.Context) []core.Violation {
 	if ctx == nil {
 		return nil
+	}
+	if !hasInternalDir(ctx.Root()) {
+		return []core.Violation{metaLayoutNotSupported(ruleAlias)}
 	}
 	arch := ctx.Arch()
 	if arch.Layout.DomainDir == "" || !arch.Structure.RequireAlias {
@@ -148,70 +130,23 @@ func (r *Alias) checkAliasTypes(aliasPath, aliasRel, aliasName string, arch core
 		return nil
 	}
 	var violations []core.Violation
-	for _, info := range inspectTypeSpecs(file, fset) {
-		if info.isInterface {
+	for _, info := range analysisutil.InspectTypeSpecs(file, fset) {
+		if info.IsInterface {
 			v := violation(r.severity, aliasNoInterface, aliasRel,
-				aliasName+` re-exports interface "`+info.name+`" - suspected cross-domain dependency; use `+arch.Layout.OrchestrationDir+`/ instead`,
+				aliasName+` re-exports interface "`+info.Name+`" - suspected cross-domain dependency; use `+arch.Layout.OrchestrationDir+`/ instead`,
 				"move cross-domain coordination to "+arch.Layout.OrchestrationDir+"/handler/ or "+arch.Layout.OrchestrationDir+"/")
-			v.Line = info.line
+			v.Line = info.Line
 			violations = append(violations, v)
 		}
-		if src := analysisutil.MatchContractSublayer(arch.Layers, info.aliasFrom); src != "" {
+		if src := analysisutil.MatchContractSublayer(arch.Layers, info.AliasFrom); src != "" {
 			v := violation(r.severity, aliasContractExport, aliasRel,
-				aliasName+` re-exports "`+info.name+`" from `+src+` - suspected cross-domain dependency; use `+arch.Layout.OrchestrationDir+`/ instead`,
+				aliasName+` re-exports "`+info.Name+`" from `+src+` - suspected cross-domain dependency; use `+arch.Layout.OrchestrationDir+`/ instead`,
 				"move cross-domain coordination to "+arch.Layout.OrchestrationDir+"/handler/ or "+arch.Layout.OrchestrationDir+"/")
-			v.Line = info.line
+			v.Line = info.Line
 			violations = append(violations, v)
 		}
 	}
 	return violations
-}
-
-type typeSpecInfo struct {
-	name        string
-	line        int
-	isInterface bool
-	aliasFrom   string
-}
-
-func inspectTypeSpecs(file *ast.File, fset *token.FileSet) []typeSpecInfo {
-	var result []typeSpecInfo
-	for _, decl := range file.Decls {
-		gen, ok := decl.(*ast.GenDecl)
-		if !ok {
-			continue
-		}
-		for _, spec := range gen.Specs {
-			typeSpec, ok := spec.(*ast.TypeSpec)
-			if !ok {
-				continue
-			}
-			info := typeSpecInfo{
-				name: typeSpec.Name.Name,
-				line: fset.Position(typeSpec.Name.Pos()).Line,
-			}
-			if _, ok := typeSpec.Type.(*ast.InterfaceType); ok {
-				info.isInterface = true
-			}
-			if typeSpec.Assign != 0 {
-				if sel, ok := typeSpec.Type.(*ast.SelectorExpr); ok {
-					if ident, ok := sel.X.(*ast.Ident); ok {
-						info.aliasFrom = analysisutil.ResolveIdentImportPath(file, ident.Name)
-					}
-				}
-			}
-			if info.isInterface || info.aliasFrom != "" {
-				result = append(result, info)
-			}
-		}
-	}
-	return result
-}
-
-func applyOptions(rule any, opts []Option) {
-	for _, opt := range opts {
-		opt(rule)
-	}
 }
 
 func withSeverity(spec core.RuleSpec, severity core.Severity) core.RuleSpec {

--- a/rules/structural/alias.go
+++ b/rules/structural/alias.go
@@ -48,15 +48,15 @@ func (r *Alias) Check(ctx *core.Context) []core.Violation {
 	if ctx == nil {
 		return nil
 	}
-	if !hasInternalDir(ctx.Root()) {
+	arch := ctx.Arch()
+	if !hasInternalDir(ctx.Root(), arch.Layout.InternalRoot) {
 		return []core.Violation{metaLayoutNotSupported(ruleAlias)}
 	}
-	arch := ctx.Arch()
 	if arch.Layout.DomainDir == "" || !arch.Structure.RequireAlias {
 		return nil
 	}
 
-	domainDir := filepath.Join(ctx.Root(), "internal", filepath.FromSlash(arch.Layout.DomainDir))
+	domainDir := filepath.Join(ctx.Root(), arch.Layout.InternalRoot, filepath.FromSlash(arch.Layout.DomainDir))
 	entries, err := os.ReadDir(domainDir)
 	if err != nil {
 		return nil
@@ -68,7 +68,7 @@ func (r *Alias) Check(ctx *core.Context) []core.Violation {
 			continue
 		}
 		domainName := entry.Name()
-		relPath := filepath.ToSlash(filepath.Join("internal", arch.Layout.DomainDir, domainName))
+		relPath := filepath.ToSlash(filepath.Join(arch.Layout.InternalRoot, arch.Layout.DomainDir, domainName))
 		if ctx.IsExcluded(relPath + "/") {
 			continue
 		}

--- a/rules/structural/banned_package.go
+++ b/rules/structural/banned_package.go
@@ -19,9 +19,8 @@ type BannedPackage struct {
 }
 
 func NewBannedPackage(opts ...Option) *BannedPackage {
-	r := &BannedPackage{severity: core.Warning}
-	applyOptions(r, opts)
-	return r
+	cfg := newConfig(opts, core.Warning)
+	return &BannedPackage{severity: cfg.severity}
 }
 
 func (r *BannedPackage) Spec() core.RuleSpec {
@@ -39,6 +38,9 @@ func (r *BannedPackage) Spec() core.RuleSpec {
 func (r *BannedPackage) Check(ctx *core.Context) []core.Violation {
 	if ctx == nil {
 		return nil
+	}
+	if !hasInternalDir(ctx.Root()) {
+		return []core.Violation{metaLayoutNotSupported(ruleBannedPackage)}
 	}
 	internalDir := filepath.Join(ctx.Root(), "internal")
 	var violations []core.Violation

--- a/rules/structural/banned_package.go
+++ b/rules/structural/banned_package.go
@@ -39,10 +39,11 @@ func (r *BannedPackage) Check(ctx *core.Context) []core.Violation {
 	if ctx == nil {
 		return nil
 	}
-	if !hasInternalDir(ctx.Root()) {
+	arch := ctx.Arch()
+	if !hasInternalDir(ctx.Root(), arch.Layout.InternalRoot) {
 		return []core.Violation{metaLayoutNotSupported(ruleBannedPackage)}
 	}
-	internalDir := filepath.Join(ctx.Root(), "internal")
+	internalDir := filepath.Join(ctx.Root(), arch.Layout.InternalRoot)
 	var violations []core.Violation
 	_ = filepath.WalkDir(internalDir, func(path string, entry fs.DirEntry, err error) error {
 		if err != nil || !entry.IsDir() {
@@ -53,7 +54,7 @@ func (r *BannedPackage) Check(ctx *core.Context) []core.Violation {
 			return nil
 		}
 		rel = filepath.ToSlash(rel)
-		if rel == "internal" {
+		if rel == arch.Layout.InternalRoot {
 			return nil
 		}
 		if ctx.IsExcluded(rel + "/") {
@@ -63,7 +64,6 @@ func (r *BannedPackage) Check(ctx *core.Context) []core.Violation {
 			return nil
 		}
 		name := entry.Name()
-		arch := ctx.Arch()
 		for _, banned := range arch.Naming.BannedPkgNames {
 			if name == banned {
 				violations = append(violations, violation(r.severity, bannedPackage, rel+"/",

--- a/rules/structural/internal_top_level.go
+++ b/rules/structural/internal_top_level.go
@@ -38,33 +38,33 @@ func (r *InternalTopLevel) Check(ctx *core.Context) []core.Violation {
 	if ctx == nil {
 		return nil
 	}
-	if !hasInternalDir(ctx.Root()) {
+	arch := ctx.Arch()
+	if !hasInternalDir(ctx.Root(), arch.Layout.InternalRoot) {
 		return []core.Violation{metaLayoutNotSupported(ruleInternalTopLevel)}
 	}
-	internalDir := filepath.Join(ctx.Root(), "internal")
+	internalDir := filepath.Join(ctx.Root(), arch.Layout.InternalRoot)
 	entries, err := os.ReadDir(internalDir)
 	if err != nil {
 		return nil
 	}
 
-	arch := ctx.Arch()
 	allowedNames := make([]string, 0, len(arch.Layers.InternalTopLevel))
 	for name := range arch.Layers.InternalTopLevel {
-		allowedNames = append(allowedNames, "internal/"+name+"/")
+		allowedNames = append(allowedNames, arch.Layout.InternalRoot+"/"+name+"/")
 	}
 	sort.Strings(allowedNames)
 	allowedHint := strings.Join(allowedNames, ", ")
 
 	var violations []core.Violation
 	for _, entry := range entries {
-		relPath := filepath.ToSlash(filepath.Join("internal", entry.Name()))
+		relPath := filepath.ToSlash(filepath.Join(arch.Layout.InternalRoot, entry.Name()))
 		if entry.IsDir() {
 			if ctx.IsExcluded(relPath+"/") || arch.Layers.InternalTopLevel[entry.Name()] {
 				continue
 			}
 			violations = append(violations, violation(r.severity, internalTopLevel, relPath+"/",
-				`internal/ top-level package "`+entry.Name()+`" is not allowed`,
-				"use only "+allowedHint+" at the internal/ top level"))
+				arch.Layout.InternalRoot+`/ top-level package "`+entry.Name()+`" is not allowed`,
+				"use only "+allowedHint+" at the "+arch.Layout.InternalRoot+"/ top level"))
 			continue
 		}
 
@@ -75,7 +75,7 @@ func (r *InternalTopLevel) Check(ctx *core.Context) []core.Violation {
 			continue
 		}
 		violations = append(violations, violation(r.severity, internalTopLevel, relPath,
-			`internal/ top-level Go file "`+entry.Name()+`" is not allowed`,
+			arch.Layout.InternalRoot+`/ top-level Go file "`+entry.Name()+`" is not allowed`,
 			"move code under "+allowedHint))
 	}
 	return violations

--- a/rules/structural/internal_top_level.go
+++ b/rules/structural/internal_top_level.go
@@ -1,9 +1,9 @@
 package structural
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/NamhaeSusan/go-arch-guard/core"
@@ -19,9 +19,8 @@ type InternalTopLevel struct {
 }
 
 func NewInternalTopLevel(opts ...Option) *InternalTopLevel {
-	r := &InternalTopLevel{severity: core.Error}
-	applyOptions(r, opts)
-	return r
+	cfg := newConfig(opts, core.Error)
+	return &InternalTopLevel{severity: cfg.severity}
 }
 
 func (r *InternalTopLevel) Spec() core.RuleSpec {
@@ -39,6 +38,9 @@ func (r *InternalTopLevel) Check(ctx *core.Context) []core.Violation {
 	if ctx == nil {
 		return nil
 	}
+	if !hasInternalDir(ctx.Root()) {
+		return []core.Violation{metaLayoutNotSupported(ruleInternalTopLevel)}
+	}
 	internalDir := filepath.Join(ctx.Root(), "internal")
 	entries, err := os.ReadDir(internalDir)
 	if err != nil {
@@ -50,6 +52,8 @@ func (r *InternalTopLevel) Check(ctx *core.Context) []core.Violation {
 	for name := range arch.Layers.InternalTopLevel {
 		allowedNames = append(allowedNames, "internal/"+name+"/")
 	}
+	sort.Strings(allowedNames)
+	allowedHint := strings.Join(allowedNames, ", ")
 
 	var violations []core.Violation
 	for _, entry := range entries {
@@ -60,7 +64,7 @@ func (r *InternalTopLevel) Check(ctx *core.Context) []core.Violation {
 			}
 			violations = append(violations, violation(r.severity, internalTopLevel, relPath+"/",
 				`internal/ top-level package "`+entry.Name()+`" is not allowed`,
-				fmt.Sprintf("use only %v at the internal/ top level", allowedNames)))
+				"use only "+allowedHint+" at the internal/ top level"))
 			continue
 		}
 
@@ -72,7 +76,7 @@ func (r *InternalTopLevel) Check(ctx *core.Context) []core.Violation {
 		}
 		violations = append(violations, violation(r.severity, internalTopLevel, relPath,
 			`internal/ top-level Go file "`+entry.Name()+`" is not allowed`,
-			fmt.Sprintf("move code under %v", allowedNames)))
+			"move code under "+allowedHint))
 	}
 	return violations
 }

--- a/rules/structural/internal_top_level_test.go
+++ b/rules/structural/internal_top_level_test.go
@@ -1,6 +1,7 @@
 package structural_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/NamhaeSusan/go-arch-guard/rules/structural"
@@ -15,5 +16,29 @@ func TestInternalTopLevel(t *testing.T) {
 	t.Run("detects invalid fixture unexpected internal top-level package", func(t *testing.T) {
 		violations := runRule(t, "../../testdata/invalid", structural.NewInternalTopLevel())
 		assertViolation(t, violations, "structure.internal-top-level", "internal/config/")
+	})
+
+	t.Run("allowedNames hint is deterministic and comma-joined", func(t *testing.T) {
+		var prev string
+		for i := range 5 {
+			violations := runRule(t, "../../testdata/invalid", structural.NewInternalTopLevel())
+			var msg string
+			for _, v := range violations {
+				if v.Rule == "structure.internal-top-level" {
+					msg = v.Fix
+					break
+				}
+			}
+			if msg == "" {
+				t.Fatalf("no internal-top-level violation found")
+			}
+			if strings.Contains(msg, "[") || strings.Contains(msg, "]") {
+				t.Fatalf("Fix should use comma-joined names, got %q", msg)
+			}
+			if i > 0 && msg != prev {
+				t.Fatalf("Fix non-deterministic: run %d %q != run 0 %q", i, msg, prev)
+			}
+			prev = msg
+		}
 	})
 }

--- a/rules/structural/layout_meta.go
+++ b/rules/structural/layout_meta.go
@@ -8,14 +8,15 @@ import (
 	"github.com/NamhaeSusan/go-arch-guard/core"
 )
 
-// hasInternalDir reports whether <root>/internal exists as a directory. The
-// structural rules walk the filesystem rather than ctx.Pkgs(), so this is a
-// pre-flight check used to decide whether the rule applies at all.
-func hasInternalDir(root string) bool {
+// hasInternalDir reports whether <root>/<internalRoot> exists as a
+// directory. The structural rules walk the filesystem rather than
+// ctx.Pkgs(), so this is a pre-flight check used to decide whether the
+// rule applies at all.
+func hasInternalDir(root, internalRoot string) bool {
 	if root == "" {
 		return false
 	}
-	info, err := os.Stat(filepath.Join(root, "internal"))
+	info, err := os.Stat(filepath.Join(root, internalRoot))
 	return err == nil && info.IsDir()
 }
 

--- a/rules/structural/layout_meta.go
+++ b/rules/structural/layout_meta.go
@@ -1,0 +1,30 @@
+package structural
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/NamhaeSusan/go-arch-guard/core"
+)
+
+// hasInternalDir reports whether <root>/internal exists as a directory. The
+// structural rules walk the filesystem rather than ctx.Pkgs(), so this is a
+// pre-flight check used to decide whether the rule applies at all.
+func hasInternalDir(root string) bool {
+	if root == "" {
+		return false
+	}
+	info, err := os.Stat(filepath.Join(root, "internal"))
+	return err == nil && info.IsDir()
+}
+
+func metaLayoutNotSupported(ruleID string) core.Violation {
+	return core.Violation{
+		Rule:              "meta.layout-not-supported",
+		Message:           fmt.Sprintf("%s requires an internal/-based layout; internal/ directory not found", ruleID),
+		Fix:               "use this rule with internal/-based presets (DDD, CleanArch, Hexagonal, ModularMonolith), or remove it from your ruleset for flat layouts",
+		DefaultSeverity:   core.Warning,
+		EffectiveSeverity: core.Warning,
+	}
+}

--- a/rules/structural/layout_meta_test.go
+++ b/rules/structural/layout_meta_test.go
@@ -1,0 +1,57 @@
+package structural_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/NamhaeSusan/go-arch-guard/core"
+	"github.com/NamhaeSusan/go-arch-guard/rules/structural"
+)
+
+func TestStructuralRulesEmitMetaOnFlatLayout(t *testing.T) {
+	cases := []struct {
+		ruleID string
+		rule   core.Rule
+	}{
+		{"structural.alias", structural.NewAlias()},
+		{"structural.placement", structural.NewPlacement()},
+		{"structural.banned-package", structural.NewBannedPackage()},
+		{"structural.model-required", structural.NewModelRequired()},
+		{"structural.internal-top-level", structural.NewInternalTopLevel()},
+	}
+	for _, tc := range cases {
+		t.Run(tc.ruleID, func(t *testing.T) {
+			violations := runRule(t, "../../testdata/flat", tc.rule)
+			var count int
+			for _, v := range violations {
+				if v.Rule == "meta.layout-not-supported" {
+					count++
+					if !strings.Contains(v.Message, tc.ruleID) {
+						t.Fatalf("meta message should mention %q, got %q", tc.ruleID, v.Message)
+					}
+				}
+			}
+			if count != 1 {
+				t.Fatalf("expected exactly 1 meta.layout-not-supported, got %d: %+v", count, violations)
+			}
+		})
+	}
+}
+
+func TestStructuralRulesNoMetaOnDDDLayout(t *testing.T) {
+	cases := []core.Rule{
+		structural.NewAlias(),
+		structural.NewPlacement(),
+		structural.NewBannedPackage(),
+		structural.NewModelRequired(),
+		structural.NewInternalTopLevel(),
+	}
+	for _, rule := range cases {
+		violations := runRule(t, "../../testdata/valid", rule)
+		for _, v := range violations {
+			if v.Rule == "meta.layout-not-supported" {
+				t.Fatalf("internal/-based project must not emit meta.layout-not-supported: %s", v.String())
+			}
+		}
+	}
+}

--- a/rules/structural/model_required.go
+++ b/rules/structural/model_required.go
@@ -17,9 +17,8 @@ type ModelRequired struct {
 }
 
 func NewModelRequired(opts ...Option) *ModelRequired {
-	r := &ModelRequired{severity: core.Error}
-	applyOptions(r, opts)
-	return r
+	cfg := newConfig(opts, core.Error)
+	return &ModelRequired{severity: cfg.severity}
 }
 
 func (r *ModelRequired) Spec() core.RuleSpec {
@@ -36,6 +35,9 @@ func (r *ModelRequired) Spec() core.RuleSpec {
 func (r *ModelRequired) Check(ctx *core.Context) []core.Violation {
 	if ctx == nil {
 		return nil
+	}
+	if !hasInternalDir(ctx.Root()) {
+		return []core.Violation{metaLayoutNotSupported(ruleModelRequired)}
 	}
 	arch := ctx.Arch()
 	if arch.Layout.DomainDir == "" || !arch.Structure.RequireModel {

--- a/rules/structural/model_required.go
+++ b/rules/structural/model_required.go
@@ -36,15 +36,15 @@ func (r *ModelRequired) Check(ctx *core.Context) []core.Violation {
 	if ctx == nil {
 		return nil
 	}
-	if !hasInternalDir(ctx.Root()) {
+	arch := ctx.Arch()
+	if !hasInternalDir(ctx.Root(), arch.Layout.InternalRoot) {
 		return []core.Violation{metaLayoutNotSupported(ruleModelRequired)}
 	}
-	arch := ctx.Arch()
 	if arch.Layout.DomainDir == "" || !arch.Structure.RequireModel {
 		return nil
 	}
 
-	domainDir := filepath.Join(ctx.Root(), "internal", filepath.FromSlash(arch.Layout.DomainDir))
+	domainDir := filepath.Join(ctx.Root(), arch.Layout.InternalRoot, filepath.FromSlash(arch.Layout.DomainDir))
 	entries, err := os.ReadDir(domainDir)
 	if err != nil {
 		return nil
@@ -54,7 +54,7 @@ func (r *ModelRequired) Check(ctx *core.Context) []core.Violation {
 		if !entry.IsDir() {
 			continue
 		}
-		relPath := filepath.ToSlash(filepath.Join("internal", arch.Layout.DomainDir, entry.Name()))
+		relPath := filepath.ToSlash(filepath.Join(arch.Layout.InternalRoot, arch.Layout.DomainDir, entry.Name()))
 		if ctx.IsExcluded(relPath + "/") {
 			continue
 		}

--- a/rules/structural/option.go
+++ b/rules/structural/option.go
@@ -1,0 +1,23 @@
+package structural
+
+import "github.com/NamhaeSusan/go-arch-guard/core"
+
+type Option func(*ruleConfig)
+
+type ruleConfig struct {
+	severity core.Severity
+}
+
+func WithSeverity(severity core.Severity) Option {
+	return func(cfg *ruleConfig) {
+		cfg.severity = severity
+	}
+}
+
+func newConfig(opts []Option, severity core.Severity) ruleConfig {
+	cfg := ruleConfig{severity: severity}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return cfg
+}

--- a/rules/structural/placement.go
+++ b/rules/structural/placement.go
@@ -176,12 +176,23 @@ func matchesDomainLayer(arch core.Architecture, rel, name string) bool {
 	return len(parts) == 4 && parts[0] == "internal" && parts[1] == arch.Layout.DomainDir && parts[2] != "" && parts[3] == name
 }
 
+// isDTOAllowedSublayer reports whether the file at rel sits in one of the
+// DTOAllowedLayers. The check tries every nested depth from the sublayer
+// start position so DTOAllowedLayers entries like "core/repo" match nested
+// directories — "core" is tested first, then "core/repo", and so on. The
+// last segment of parts is the filename, so it is excluded from candidates.
 func isDTOAllowedSublayer(arch core.Architecture, rel string) bool {
 	domainDepth := len(strings.Split(arch.Layout.DomainDir, "/"))
 	parts := strings.Split(rel, "/")
-	sublayerIdx := 1 + domainDepth + 1
-	if len(parts) <= sublayerIdx {
+	sublayerStart := 1 + domainDepth + 1
+	if len(parts) <= sublayerStart {
 		return false
 	}
-	return slices.Contains(arch.Structure.DTOAllowedLayers, parts[sublayerIdx])
+	for depth := 1; sublayerStart+depth < len(parts); depth++ {
+		candidate := strings.Join(parts[sublayerStart:sublayerStart+depth], "/")
+		if slices.Contains(arch.Structure.DTOAllowedLayers, candidate) {
+			return true
+		}
+	}
+	return false
 }

--- a/rules/structural/placement.go
+++ b/rules/structural/placement.go
@@ -1,7 +1,6 @@
 package structural
 
 import (
-	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -23,9 +22,8 @@ type Placement struct {
 }
 
 func NewPlacement(opts ...Option) *Placement {
-	r := &Placement{severity: core.Error}
-	applyOptions(r, opts)
-	return r
+	cfg := newConfig(opts, core.Error)
+	return &Placement{severity: cfg.severity}
 }
 
 func (r *Placement) Spec() core.RuleSpec {
@@ -45,10 +43,10 @@ func (r *Placement) Check(ctx *core.Context) []core.Violation {
 	if ctx == nil {
 		return nil
 	}
-	internalDir := filepath.Join(ctx.Root(), "internal")
-	if _, err := os.Stat(internalDir); err != nil {
-		return nil
+	if !hasInternalDir(ctx.Root()) {
+		return []core.Violation{metaLayoutNotSupported(rulePlacement)}
 	}
+	internalDir := filepath.Join(ctx.Root(), "internal")
 	arch := ctx.Arch()
 	violations := r.checkLayerPlacement(ctx, internalDir, arch)
 	violations = append(violations, r.checkMiddlewarePlacement(ctx, internalDir, arch)...)
@@ -84,7 +82,7 @@ func (r *Placement) checkLayerPlacement(ctx *core.Context, internalDir string, a
 		}
 		violations = append(violations, violation(r.severity, misplacedLayer, rel+"/",
 			`layer package "`+name+`" is misplaced`,
-			fmt.Sprintf("place layer packages only in configured domain slices or %s handler", arch.Layout.OrchestrationDir)))
+			"place layer packages only in configured domain slices or "+arch.Layout.OrchestrationDir+" handler"))
 		return nil
 	})
 	return violations
@@ -143,7 +141,7 @@ func (r *Placement) checkDTOPlacement(ctx *core.Context, internalDir string, arc
 		}
 		violations = append(violations, violation(r.severity, dtoPlacement, rel,
 			`"`+name+`" found in forbidden layer`,
-			fmt.Sprintf("DTOs belong in %v", arch.Structure.DTOAllowedLayers)))
+			"DTOs belong in "+strings.Join(arch.Structure.DTOAllowedLayers, ", ")))
 		return nil
 	})
 	return violations

--- a/rules/structural/placement.go
+++ b/rules/structural/placement.go
@@ -43,11 +43,11 @@ func (r *Placement) Check(ctx *core.Context) []core.Violation {
 	if ctx == nil {
 		return nil
 	}
-	if !hasInternalDir(ctx.Root()) {
+	arch := ctx.Arch()
+	if !hasInternalDir(ctx.Root(), arch.Layout.InternalRoot) {
 		return []core.Violation{metaLayoutNotSupported(rulePlacement)}
 	}
-	internalDir := filepath.Join(ctx.Root(), "internal")
-	arch := ctx.Arch()
+	internalDir := filepath.Join(ctx.Root(), arch.Layout.InternalRoot)
 	violations := r.checkLayerPlacement(ctx, internalDir, arch)
 	violations = append(violations, r.checkMiddlewarePlacement(ctx, internalDir, arch)...)
 	if arch.Layout.DomainDir != "" {
@@ -67,7 +67,7 @@ func (r *Placement) checkLayerPlacement(ctx *core.Context, internalDir string, a
 			return nil
 		}
 		rel = filepath.ToSlash(rel)
-		if rel == "internal" {
+		if rel == arch.Layout.InternalRoot {
 			return nil
 		}
 		if ctx.IsExcluded(rel + "/") {
@@ -89,7 +89,7 @@ func (r *Placement) checkLayerPlacement(ctx *core.Context, internalDir string, a
 }
 
 func (r *Placement) checkMiddlewarePlacement(ctx *core.Context, internalDir string, arch core.Architecture) []core.Violation {
-	allowedPath := filepath.ToSlash(filepath.Join("internal", arch.Layout.SharedDir, "middleware"))
+	allowedPath := filepath.ToSlash(filepath.Join(arch.Layout.InternalRoot, arch.Layout.SharedDir, "middleware"))
 	var violations []core.Violation
 	_ = filepath.WalkDir(internalDir, func(path string, entry fs.DirEntry, err error) error {
 		if err != nil || !entry.IsDir() || entry.Name() != "middleware" {
@@ -153,19 +153,19 @@ func isMisplacedLayerDir(arch core.Architecture, rel, name string) bool {
 	}
 	switch name {
 	case "app", "infra":
-		if name == "app" && arch.Layout.AppDir != "" && rel == filepath.ToSlash(filepath.Join("internal", arch.Layout.AppDir)) {
+		if name == "app" && arch.Layout.AppDir != "" && rel == filepath.ToSlash(filepath.Join(arch.Layout.InternalRoot, arch.Layout.AppDir)) {
 			return false
 		}
 		return !matchesDomainLayer(arch, rel, name)
 	case "handler":
 		if arch.Layout.ServerDir != "" {
-			serverBase := filepath.ToSlash(filepath.Join("internal", arch.Layout.ServerDir))
+			serverBase := filepath.ToSlash(filepath.Join(arch.Layout.InternalRoot, arch.Layout.ServerDir))
 			if strings.HasPrefix(rel, serverBase+"/") || rel == serverBase {
 				return false
 			}
 		}
 		return !matchesDomainLayer(arch, rel, name) &&
-			rel != filepath.ToSlash(filepath.Join("internal", arch.Layout.OrchestrationDir, "handler"))
+			rel != filepath.ToSlash(filepath.Join(arch.Layout.InternalRoot, arch.Layout.OrchestrationDir, "handler"))
 	default:
 		return false
 	}
@@ -173,7 +173,7 @@ func isMisplacedLayerDir(arch core.Architecture, rel, name string) bool {
 
 func matchesDomainLayer(arch core.Architecture, rel, name string) bool {
 	parts := strings.Split(rel, "/")
-	return len(parts) == 4 && parts[0] == "internal" && parts[1] == arch.Layout.DomainDir && parts[2] != "" && parts[3] == name
+	return len(parts) == 4 && parts[0] == arch.Layout.InternalRoot && parts[1] == arch.Layout.DomainDir && parts[2] != "" && parts[3] == name
 }
 
 // isDTOAllowedSublayer reports whether the file at rel sits in one of the

--- a/rules/structural/placement_test.go
+++ b/rules/structural/placement_test.go
@@ -1,8 +1,10 @@
 package structural_test
 
 import (
+	"path/filepath"
 	"testing"
 
+	"github.com/NamhaeSusan/go-arch-guard/core"
 	"github.com/NamhaeSusan/go-arch-guard/rules/structural"
 )
 
@@ -19,4 +21,36 @@ func TestPlacement(t *testing.T) {
 		assertViolation(t, violations, "structure.middleware-placement", "internal/handler/middleware/")
 		assertViolation(t, violations, "structure.dto-placement", "internal/domain/user/core/model/user_dto.go")
 	})
+}
+
+func TestPlacementDTOAllowedLayersAcceptsNestedSublayer(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "alias.go"), "package order\n")
+	writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "core", "model", "order.go"), "package model\n")
+	writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "core", "repo", "order_dto.go"), "package repo\n")
+
+	arch := dddArch()
+	arch.Structure.DTOAllowedLayers = []string{"core/repo"}
+	ctx := core.NewContext(nil, "github.com/example/app", root, arch, nil)
+	violations := core.Run(ctx, core.NewRuleSet(structural.NewPlacement()))
+
+	for _, v := range violations {
+		if v.Rule == "structure.dto-placement" {
+			t.Fatalf("DTO under core/repo must be allowed when DTOAllowedLayers contains core/repo, got %s", v.String())
+		}
+	}
+}
+
+func TestPlacementDTOAllowedLayersStillRejectsUnlistedNestedSublayer(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "alias.go"), "package order\n")
+	writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "core", "model", "order.go"), "package model\n")
+	writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "core", "svc", "order_dto.go"), "package svc\n")
+
+	arch := dddArch()
+	arch.Structure.DTOAllowedLayers = []string{"core/repo"}
+	ctx := core.NewContext(nil, "github.com/example/app", root, arch, nil)
+	violations := core.Run(ctx, core.NewRuleSet(structural.NewPlacement()))
+
+	assertViolation(t, violations, "structure.dto-placement", "internal/domain/order/core/svc/order_dto.go")
 }

--- a/rules/tx/boundary.go
+++ b/rules/tx/boundary.go
@@ -180,7 +180,7 @@ func (r *Boundary) walkInternalPackages(ctx *core.Context, visit func(*packages.
 	if module == "" {
 		return
 	}
-	internalPrefix := module + "/internal/"
+	internalPrefix := module + "/" + ctx.Arch().Layout.InternalRoot + "/"
 	for _, pkg := range ctx.Pkgs() {
 		if !strings.HasPrefix(pkg.PkgPath, internalPrefix) {
 			continue

--- a/rules/types/no_setter.go
+++ b/rules/types/no_setter.go
@@ -3,6 +3,7 @@ package types
 import (
 	"fmt"
 	"go/ast"
+	"slices"
 	"strings"
 	"unicode"
 
@@ -148,10 +149,5 @@ func autoExcludedPackage(pkg *packages.Package) bool {
 
 func hasPathSegment(path, segment string) bool {
 	path = analysisutil.NormalizeMatchPath(path)
-	for _, part := range strings.Split(path, "/") {
-		if part == segment {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(strings.Split(path, "/"), segment)
 }

--- a/rules/types/no_setter.go
+++ b/rules/types/no_setter.go
@@ -34,11 +34,8 @@ type NoSetter struct {
 }
 
 func NewNoSetter(opts ...Option) *NoSetter {
-	r := &NoSetter{severity: core.Warning}
-	for _, opt := range opts {
-		opt.applyNoSetter(r)
-	}
-	return r
+	cfg := newConfig(opts, core.Warning)
+	return &NoSetter{severity: cfg.severity}
 }
 
 func (r *NoSetter) Spec() core.RuleSpec {
@@ -128,19 +125,14 @@ func receiverTypeString(fd *ast.FuncDecl) string {
 	if fd.Recv == nil || len(fd.Recv.List) == 0 {
 		return ""
 	}
-	return receiverTypeName(fd.Recv.List[0].Type)
+	return analysisutil.ReceiverTypeName(fd.Recv.List[0].Type)
 }
 
 func isFluentBuilder(fd *ast.FuncDecl) bool {
 	if fd.Type.Results == nil || len(fd.Type.Results.List) != 1 {
 		return false
 	}
-	result := fd.Type.Results.List[0].Type
-	if star, ok := result.(*ast.StarExpr); ok {
-		result = star.X
-	}
-	ident, ok := result.(*ast.Ident)
-	return ok && ident.Name == receiverTypeString(fd)
+	return analysisutil.ReceiverTypeName(fd.Type.Results.List[0].Type) == receiverTypeString(fd)
 }
 
 func autoExcludedFile(filename string) bool {

--- a/rules/types/no_setter_test.go
+++ b/rules/types/no_setter_test.go
@@ -1,6 +1,8 @@
 package types_test
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -64,6 +66,58 @@ func TestNoSetterFlagsClassicSetters(t *testing.T) {
 		if v.DefaultSeverity != core.Warning || v.EffectiveSeverity != core.Warning {
 			t.Fatalf("setter severity = default %v effective %v, want Warning/Warning", v.DefaultSeverity, v.EffectiveSeverity)
 		}
+	}
+}
+
+func TestNoSetterHandlesGenericReceivers(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "go.mod"), []byte("module example.com/gen\n\ngo 1.25.0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "internal", "model"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	src := `package model
+
+type Stack[T any] struct{ items []T }
+func (s *Stack[T]) SetTop(v T) { s.items[len(s.items)-1] = v }
+
+type Builder[T any] struct{ v T }
+func (b *Builder[T]) SetValue(v T) *Builder[T] { b.v = v; return b }
+
+type Pair[K comparable, V any] struct{ k K; v V }
+func (p *Pair[K, V]) SetKey(k K) { p.k = k }
+`
+	if err := os.WriteFile(filepath.Join(root, "internal", "model", "gen.go"), []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	pkgs, err := analyzer.Load(root, "internal/...")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := core.NewContext(pkgs, "example.com/gen", root, core.Architecture{}, nil)
+	got := types.NewNoSetter().Check(ctx)
+
+	var setTop, setKey, setValue int
+	for _, v := range got {
+		switch {
+		case strings.Contains(v.Message, "SetTop"):
+			setTop++
+		case strings.Contains(v.Message, "SetKey"):
+			setKey++
+		case strings.Contains(v.Message, "SetValue"):
+			setValue++
+		}
+	}
+	if setTop != 1 {
+		t.Fatalf("Stack[T].SetTop: got %d violations, want 1: %+v", setTop, got)
+	}
+	if setKey != 1 {
+		t.Fatalf("Pair[K,V].SetKey: got %d violations, want 1: %+v", setKey, got)
+	}
+	if setValue != 0 {
+		t.Fatalf("Builder[T].SetValue is fluent: got %d violations, want 0: %+v", setValue, got)
 	}
 }
 

--- a/rules/types/option.go
+++ b/rules/types/option.go
@@ -1,0 +1,23 @@
+package types
+
+import "github.com/NamhaeSusan/go-arch-guard/core"
+
+type Option func(*ruleConfig)
+
+type ruleConfig struct {
+	severity core.Severity
+}
+
+func WithSeverity(severity core.Severity) Option {
+	return func(cfg *ruleConfig) {
+		cfg.severity = severity
+	}
+}
+
+func newConfig(opts []Option, severity core.Severity) ruleConfig {
+	cfg := ruleConfig{severity: severity}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	return cfg
+}

--- a/rules/types/type_pattern.go
+++ b/rules/types/type_pattern.go
@@ -36,33 +36,9 @@ type TypePattern struct {
 	severity core.Severity
 }
 
-type Option interface {
-	applyNoSetter(*NoSetter)
-	applyTypePattern(*TypePattern)
-}
-
-type severityOption struct {
-	severity core.Severity
-}
-
-func WithSeverity(s core.Severity) Option {
-	return severityOption{severity: s}
-}
-
-func (o severityOption) applyNoSetter(r *NoSetter) {
-	r.severity = o.severity
-}
-
-func (o severityOption) applyTypePattern(r *TypePattern) {
-	r.severity = o.severity
-}
-
 func NewTypePattern(opts ...Option) *TypePattern {
-	r := &TypePattern{severity: core.Error}
-	for _, opt := range opts {
-		opt.applyTypePattern(r)
-	}
-	return r
+	cfg := newConfig(opts, core.Error)
+	return &TypePattern{severity: cfg.severity}
 }
 
 func (r *TypePattern) Spec() core.RuleSpec {
@@ -88,7 +64,7 @@ func (r *TypePattern) Check(ctx *core.Context) []core.Violation {
 }
 
 func (r *TypePattern) checkPackage(ctx *core.Context, pkg *packages.Package, pattern core.TypePattern) []core.Violation {
-	if pkg == nil || !strings.HasSuffix(pkg.PkgPath, "/internal/"+pattern.Dir) {
+	if pkg == nil || !strings.HasSuffix(pkg.PkgPath, "/"+pattern.Dir) {
 		return nil
 	}
 
@@ -110,7 +86,7 @@ func (r *TypePattern) checkPackage(ctx *core.Context, pkg *packages.Package, pat
 			continue
 		}
 
-		expectedType := snakeToPascal(suffix) + pattern.TypeSuffix
+		expectedType := analysisutil.SnakeToPascal(suffix) + pattern.TypeSuffix
 		if !hasExportedType(file, expectedType) {
 			violations = append(violations, core.Violation{
 				File:              relPath,
@@ -173,35 +149,11 @@ func collectMethods(pkg *packages.Package) map[string]bool {
 			if !ok || fd.Recv == nil || len(fd.Recv.List) == 0 {
 				continue
 			}
-			typeName := receiverTypeName(fd.Recv.List[0].Type)
+			typeName := analysisutil.ReceiverTypeName(fd.Recv.List[0].Type)
 			if typeName != "" {
 				result[typeName+"."+fd.Name.Name] = true
 			}
 		}
 	}
 	return result
-}
-
-func receiverTypeName(expr ast.Expr) string {
-	if star, ok := expr.(*ast.StarExpr); ok {
-		expr = star.X
-	}
-	ident, ok := expr.(*ast.Ident)
-	if !ok {
-		return ""
-	}
-	return ident.Name
-}
-
-func snakeToPascal(s string) string {
-	parts := strings.Split(s, "_")
-	var b strings.Builder
-	for _, part := range parts {
-		if part == "" {
-			continue
-		}
-		b.WriteString(strings.ToUpper(part[:1]))
-		b.WriteString(part[1:])
-	}
-	return b.String()
 }

--- a/rules/types/type_pattern_test.go
+++ b/rules/types/type_pattern_test.go
@@ -1,12 +1,25 @@
 package types_test
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/NamhaeSusan/go-arch-guard/analyzer"
 	"github.com/NamhaeSusan/go-arch-guard/core"
 	types "github.com/NamhaeSusan/go-arch-guard/rules/types"
 )
+
+func writeTempFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
 
 func typePatternArch() core.Architecture {
 	return core.Architecture{
@@ -68,6 +81,53 @@ func TestTypePatternFlagsMissingTypeAndMethod(t *testing.T) {
 
 	if mismatch != 1 || missingMethod != 1 {
 		t.Fatalf("mismatch=%d missingMethod=%d, want 1/1; all violations: %+v", mismatch, missingMethod, got)
+	}
+}
+
+func TestTypePatternMatchesFlatLayout(t *testing.T) {
+	root := t.TempDir()
+	writeTempFile(t, filepath.Join(root, "go.mod"), "module example.com/flat\n\ngo 1.25.0\n")
+	writeTempFile(t, filepath.Join(root, "worker", "worker_order.go"), "package worker\n\ntype OrderWorker struct{}\n\nfunc (w *OrderWorker) Process() {}\n")
+	writeTempFile(t, filepath.Join(root, "worker", "worker_payment.go"), "package worker\n\ntype Payment struct{}\n")
+
+	pkgs, err := analyzer.Load(root, "worker/...")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := core.NewContext(pkgs, "example.com/flat", root, typePatternArch(), nil)
+	got := types.NewTypePattern().Check(ctx)
+
+	var mismatch int
+	for _, v := range got {
+		if v.Rule == "naming.type-pattern-mismatch" && strings.Contains(v.File, "worker_payment.go") {
+			mismatch++
+		}
+		if strings.Contains(v.File, "worker_order.go") {
+			t.Fatalf("valid worker should not be flagged: %+v", v)
+		}
+	}
+	if mismatch != 1 {
+		t.Fatalf("expected 1 mismatch in flat layout, got %d: %+v", mismatch, got)
+	}
+}
+
+func TestTypePatternIgnoresPrefixSubstringDirs(t *testing.T) {
+	root := t.TempDir()
+	writeTempFile(t, filepath.Join(root, "go.mod"), "module example.com/edge\n\ngo 1.25.0\n")
+	writeTempFile(t, filepath.Join(root, "oldworker", "worker_thing.go"), "package oldworker\n\ntype Thing struct{}\n")
+	writeTempFile(t, filepath.Join(root, "worker", "sub", "worker_other.go"), "package sub\n\ntype Other struct{}\n")
+
+	pkgs, err := analyzer.Load(root, "...")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := core.NewContext(pkgs, "example.com/edge", root, typePatternArch(), nil)
+	got := types.NewTypePattern().Check(ctx)
+
+	for _, v := range got {
+		if strings.Contains(v.File, "oldworker") || strings.Contains(v.File, "worker/sub") {
+			t.Fatalf("non-matching dir incorrectly flagged: %+v", v)
+		}
 	}
 }
 

--- a/testdata/custom_root/go.mod
+++ b/testdata/custom_root/go.mod
@@ -1,0 +1,3 @@
+module github.com/kimtaeyun/testproject-customroot
+
+go 1.23

--- a/testdata/custom_root/packages/domain/order/alias.go
+++ b/testdata/custom_root/packages/domain/order/alias.go
@@ -1,0 +1,1 @@
+package order

--- a/testdata/custom_root/packages/domain/order/core/model/order.go
+++ b/testdata/custom_root/packages/domain/order/core/model/order.go
@@ -1,0 +1,3 @@
+package model
+
+type Order struct{ ID string }

--- a/testdata/flat/go.mod
+++ b/testdata/flat/go.mod
@@ -1,0 +1,3 @@
+module github.com/kimtaeyun/testproject-flat
+
+go 1.23

--- a/testdata/flat/worker/worker.go
+++ b/testdata/flat/worker/worker.go
@@ -1,0 +1,5 @@
+package worker
+
+type Worker struct{}
+
+func (w *Worker) Process() {}


### PR DESCRIPTION
> **Consolidated PR**: this branch accumulates the full codex review series (originally PRs #44, #48, #53, #58, #63, #68, #72, plus the InternalRoot migration). The intermediate PRs were merged into the stacked chain rather than into main; this PR ports all 12 commits onto main directly.

## What's in this PR (12 commits, top to bottom)

| # | Commit | Origin |
|---|---|---|
| 1 | refactor(rules/naming): split option.go and fix snake_case helpers | original PR #39 (already merged) — would normally be skipped, but the merge commit graph put it under this branch |
| 2 | refactor(types/analysisutil): unify Option, extract SnakeToPascal/ReceiverTypeName, support generics, drop internal/ hardcoding | PR #44 |
| 3 | refactor(dependency): unify Option, decompose Isolation.Check (~156 -> ~46 LOC), signal flat layouts | PR #48 |
| 4 | refactor(structural/analysisutil): unify Option, dedupe InspectTypeSpecs, signal flat layouts, fix non-determinism | PR #53 |
| 5 | refactor(interfaces/analysisutil): unify Option, signal flat layouts, fix non-determinism, support generics | PR #58 |
| 6 | chore(types): modernize hasPathSegment with slices.Contains | go fix follow-up |
| 7 | chore(core): apply goimports comment indentation fix to runner.go | goimports follow-up |
| 8 | fix(core): close 4 data-model gaps found by codex review (#63) | PR #63 (DTOAllowedLayers nested, meta dedup, NewContext clone, IsExcluded normalization) |
| 9 | test(core): add 4 regression guards from codex review | PR #68 (cloneArchitecture coverage, zero-value Validate, nil rule, severity level 5) |
| 10 | feat(core): rule panic recovery, layer model docs, Pkgs() contract guard | PR #72 |
| 11 | fix: make rule panic meta violations errors | hotfix on top of PR-3 (rule panic now defaults to Error, not Warning) |
| 12 | feat(core/rules): introduce LayoutModel.InternalRoot to remove internal/ hardcoding | PR #75 original scope |

## Public API summary

- **All 5 rule packages** (naming, types, dependency, structural, interfaces) now share the same Option pattern: \`type Option func(*ruleConfig)\`.
- **\`core/analysisutil\`** gains shared helpers: \`SnakeToPascal\`, \`ReceiverTypeName\` (with generic support), \`InspectTypeSpecs\`/\`TypeSpecInfo\`, \`IsTestFile\`.
- **\`meta.layout-not-supported\`** Warning emitted by 10 layout-dependent rules when used on flat-layout projects.
- **\`meta.rule-panic\`** Error emitted when a rule panics; other rules continue to run.
- **\`LayoutModel.InternalRoot\`** new field; empty value normalizes to \`\"internal\"\` in \`cloneArchitecture\`. 14 consumer files migrated. Custom roots (\`\"packages\"\`, \`\"src\"\`, etc.) supported end to end.
- **\`Architecture\` validation tightened**: empty-string rejection in \`LayerDirNames\`/\`InternalTopLevel\` keys, \`PortLayers ⊆ Sublayers\` etc.
- **Bug fixes**: \`DTOAllowedLayers\` nested entries actually work; meta dedup preserves distinct messages; \`NewContext\` deep-clones Architecture at construction; \`IsExcluded\` normalizes leading/trailing slashes.

## Backward compat

- All existing \`Architecture\` instances work unchanged (cloneArchitecture normalizes the new InternalRoot to \`\"internal\"\`).
- \`RuleSet.With(nil)\` now silently drops nil instead of panicking deep in Run.
- Rule panics now produce a violation instead of crashing.

## Test plan

- [x] \`go test ./...\` — 16/16 packages green
- [x] \`make lint\` — 0 issues
- [x] code-reviewer agent — APPROVE (multiple rounds across the series)
- [x] codex parallel review of \`core/\` — 3 agents (foundation/execution/data-model groups), all findings landed across PR-1, PR-2, PR-3, PR-4