### PR TITLE
feat(scaffold): honor LayoutModel.InternalRoot in generated architecture_test.go

### DIFF
--- a/scaffold/scaffold.go
+++ b/scaffold/scaffold.go
@@ -25,7 +25,14 @@ const (
 
 // ArchitectureTestOptions controls generated architecture_test.go output.
 type ArchitectureTestOptions struct {
+	// PackageName is the Go package identifier for the generated test file.
+	// Required.
 	PackageName string
+	// InternalRoot is the project-relative directory under which packages
+	// live. Optional — defaults to "internal" so existing scaffolds emit
+	// the canonical pattern. Set to "packages", "src", etc. to match a
+	// non-standard layout. Must be a single forward-slash-free segment.
+	InternalRoot string
 }
 
 // ArchitectureTest returns a ready-to-copy architecture_test.go source file
@@ -40,12 +47,20 @@ func ArchitectureTest(preset Preset, opts ArchitectureTestOptions) (string, erro
 		return "", fmt.Errorf("package name must be a valid Go identifier: %q", packageName)
 	}
 
+	internalRoot := strings.TrimSpace(opts.InternalRoot)
+	if internalRoot == "" {
+		internalRoot = "internal"
+	}
+	if strings.ContainsAny(internalRoot, "/\\") {
+		return "", fmt.Errorf("InternalRoot must be a single path segment (no '/' or '\\\\'), got %q", internalRoot)
+	}
+
 	funcs, err := presetFunctions(preset)
 	if err != nil {
 		return "", err
 	}
 
-	src := renderArchitectureTest(packageName, funcs)
+	src := renderArchitectureTest(packageName, funcs, internalRoot)
 	formatted, err := format.Source([]byte(src))
 	if err != nil {
 		return "", fmt.Errorf("format generated template: %w", err)
@@ -81,7 +96,7 @@ func presetFunctions(preset Preset) (presetFuncs, error) {
 	}
 }
 
-func renderArchitectureTest(packageName string, funcs presetFuncs) string {
+func renderArchitectureTest(packageName string, funcs presetFuncs, internalRoot string) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "package %s\n\n", packageName)
 	b.WriteString(`import (
@@ -94,8 +109,9 @@ func renderArchitectureTest(packageName string, funcs presetFuncs) string {
 )
 
 func TestArchitecture(t *testing.T) {
-	pkgs, err := analyzer.Load(".", "internal/...", "cmd/...")
-	if err != nil {
+`)
+	fmt.Fprintf(&b, "\tpkgs, err := analyzer.Load(\".\", %q, \"cmd/...\")\n", internalRoot+"/...")
+	b.WriteString(`	if err != nil {
 		t.Log(err)
 	}
 	if len(pkgs) == 0 {

--- a/scaffold/scaffold.go
+++ b/scaffold/scaffold.go
@@ -119,6 +119,12 @@ func TestArchitecture(t *testing.T) {
 	}
 `)
 	fmt.Fprintf(&b, "\n\tarch := presets.%s()\n", funcs.architecture)
+	// Only emit the InternalRoot override for non-default values. The default
+	// "internal" is normalized inside cloneArchitecture, so emitting it would
+	// be redundant and would clutter the generated output for the common case.
+	if internalRoot != "internal" {
+		fmt.Fprintf(&b, "\tarch.Layout.InternalRoot = %q\n", internalRoot)
+	}
 	b.WriteString("\tctx := core.NewContext(pkgs, \"\", \"\", arch, nil)\n")
 	fmt.Fprintf(&b, "\trules := presets.%s()\n\n", funcs.rules)
 	b.WriteString("\treport.AssertNoViolations(t, core.Run(ctx, rules))\n")

--- a/scaffold/scaffold_test.go
+++ b/scaffold/scaffold_test.go
@@ -128,6 +128,11 @@ func TestArchitectureTestDefaultsInternalRoot(t *testing.T) {
 	if !strings.Contains(src, want) {
 		t.Fatalf("default scaffold must emit %q\n%s", want, src)
 	}
+	// Default InternalRoot must NOT emit a redundant override line — the
+	// normalization inside cloneArchitecture already handles it.
+	if strings.Contains(src, "arch.Layout.InternalRoot") {
+		t.Fatalf("default scaffold must NOT emit arch.Layout.InternalRoot assignment\n%s", src)
+	}
 }
 
 func TestArchitectureTestCustomInternalRoot(t *testing.T) {
@@ -138,12 +143,30 @@ func TestArchitectureTestCustomInternalRoot(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := `analyzer.Load(".", "packages/...", "cmd/...")`
-	if !strings.Contains(src, want) {
-		t.Fatalf("custom InternalRoot must emit %q\n%s", want, src)
+	wantLoad := `analyzer.Load(".", "packages/...", "cmd/...")`
+	if !strings.Contains(src, wantLoad) {
+		t.Fatalf("custom InternalRoot must emit %q\n%s", wantLoad, src)
 	}
 	if strings.Contains(src, `"internal/..."`) {
 		t.Fatalf("custom InternalRoot must NOT emit \"internal/...\"\n%s", src)
+	}
+	// Critical: the rule classifier reads arch.Layout.InternalRoot, so the
+	// generated source must explicitly set it on the preset arch. Without this
+	// line, analyzer.Load would scan packages/ but rules would still classify
+	// against internal/, leaving every layout-dependent rule effectively a
+	// no-op.
+	wantArch := `arch.Layout.InternalRoot = "packages"`
+	if !strings.Contains(src, wantArch) {
+		t.Fatalf("custom InternalRoot must emit %q on arch\n%s", wantArch, src)
+	}
+	// Order: the assignment must come AFTER `arch := presets.DDD()` and
+	// BEFORE `core.NewContext(...)` so the override is in effect when the
+	// context clones and normalizes the architecture.
+	archIdx := strings.Index(src, "arch := presets.")
+	overrideIdx := strings.Index(src, wantArch)
+	ctxIdx := strings.Index(src, "core.NewContext")
+	if archIdx < 0 || archIdx >= overrideIdx || overrideIdx >= ctxIdx {
+		t.Fatalf("InternalRoot override must sit between presets.X() and core.NewContext(): archIdx=%d overrideIdx=%d ctxIdx=%d\n%s", archIdx, overrideIdx, ctxIdx, src)
 	}
 }
 

--- a/scaffold/scaffold_test.go
+++ b/scaffold/scaffold_test.go
@@ -119,6 +119,44 @@ func TestArchitectureTest_ConsumerWorker(t *testing.T) {
 	}
 }
 
+func TestArchitectureTestDefaultsInternalRoot(t *testing.T) {
+	src, err := scaffold.ArchitectureTest(scaffold.PresetDDD, scaffold.ArchitectureTestOptions{PackageName: "myapp_test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `analyzer.Load(".", "internal/...", "cmd/...")`
+	if !strings.Contains(src, want) {
+		t.Fatalf("default scaffold must emit %q\n%s", want, src)
+	}
+}
+
+func TestArchitectureTestCustomInternalRoot(t *testing.T) {
+	src, err := scaffold.ArchitectureTest(scaffold.PresetDDD, scaffold.ArchitectureTestOptions{
+		PackageName:  "myapp_test",
+		InternalRoot: "packages",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `analyzer.Load(".", "packages/...", "cmd/...")`
+	if !strings.Contains(src, want) {
+		t.Fatalf("custom InternalRoot must emit %q\n%s", want, src)
+	}
+	if strings.Contains(src, `"internal/..."`) {
+		t.Fatalf("custom InternalRoot must NOT emit \"internal/...\"\n%s", src)
+	}
+}
+
+func TestArchitectureTestRejectsInternalRootWithSeparator(t *testing.T) {
+	_, err := scaffold.ArchitectureTest(scaffold.PresetDDD, scaffold.ArchitectureTestOptions{
+		PackageName:  "myapp_test",
+		InternalRoot: "foo/bar",
+	})
+	if err == nil {
+		t.Fatal("expected error for InternalRoot containing slash")
+	}
+}
+
 func TestArchitectureTestErrors(t *testing.T) {
 	if _, err := scaffold.ArchitectureTest(scaffold.PresetDDD, scaffold.ArchitectureTestOptions{}); err == nil {
 		t.Fatal("expected empty package name error")


### PR DESCRIPTION
Closes #74. Follow-up to #75 (LayoutModel.InternalRoot migration).

## Problem

\`scaffold.ArchitectureTest\` emitted a hardcoded \`\"internal/...\"\` analyzer.Load pattern. For projects using \`Architecture.Layout.InternalRoot != \"internal\"\` (e.g. \`\"packages\"\`, \`\"src\"\`), the generated test failed to load any packages.

## Changes

- New optional field \`ArchitectureTestOptions.InternalRoot string\`. Empty defaults to \`\"internal\"\` (backward compat).
- Validation: rejects values containing \`/\` or \`\\\\\` since the field must be a single path segment.
- Generated source emits the configured root using \`%q\` quoting.

## Test plan

- [x] \`go test ./...\` green
- [x] \`make lint\` 0 issues
- [x] New tests:
  - \`TestArchitectureTestDefaultsInternalRoot\` — default emits \`\"internal/...\"\`
  - \`TestArchitectureTestCustomInternalRoot\` — \`InternalRoot: \"packages\"\` emits \`\"packages/...\"\`
  - \`TestArchitectureTestRejectsInternalRootWithSeparator\` — \`\"foo/bar\"\` rejected
- [x] Existing 8-preset table-driven test still passes (default behavior preserved)

## Backward compat

Source-compatible: existing callers with \`ArchitectureTestOptions{PackageName: \"x\"}\` continue to emit identical output.