### PR TITLE
docs: reflect post-codex-review changes across user docs

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -191,13 +191,14 @@ arch := core.Architecture{
 
 | 필드 | 설명 |
 |------|------|
-| `LayerModel.Sublayers` | authoritative 서브레이어 이름 목록 |
-| `LayerModel.Direction` | 허용 import 방향 매트릭스 |
-| `LayerModel.PortLayers` | repo/gateway 같은 순수 인터페이스 레이어 |
-| `LayerModel.ContractLayers` | 계약 레이어. 모든 port layer를 포함해야 함 |
+| `LayerModel.Sublayers` | authoritative 서브레이어 경로 목록 (`"core/repo"`); direction/port/contract 룰의 권위 |
+| `LayerModel.Direction` | 허용 import 방향 매트릭스 (key는 `Sublayers`에 있어야 함) |
+| `LayerModel.PortLayers` | repo/gateway 같은 순수 인터페이스 레이어 (`Sublayers`에 있어야 함) |
+| `LayerModel.ContractLayers` | 계약 레이어; `PortLayers`의 superset이어야 함 |
 | `LayerModel.PkgRestricted` | 공유 패키지 import 금지 서브레이어 |
-| `LayerModel.InternalTopLevel` | `internal/` 아래 허용 최상위 디렉토리 |
-| `LayerModel.LayerDirNames` | 배치 검사에서 layer-like로 취급할 디렉토리명 |
+| `LayerModel.InternalTopLevel` | 패키지 루트 아래 허용 최상위 디렉토리 |
+| `LayerModel.LayerDirNames` | 파일/디렉토리 배치 룰이 인식하는 레이어 **basename** (`"repo"`); 의도적으로 `Sublayers`에 있을 필요 없음 |
+| `LayoutModel.InternalRoot` | 프로젝트 상대 패키지 루트 디렉토리; 빈 값은 `"internal"`로 정규화됨 (`"packages"`, `"src"` 등 비표준 레이아웃 지원) |
 | `LayoutModel.DomainDir` | 도메인 최상위 디렉토리명. 플랫 레이아웃은 빈 값 |
 | `LayoutModel.OrchestrationDir` | 오케스트레이션 최상위 디렉토리명 |
 | `LayoutModel.SharedDir` | 공유 패키지 최상위 디렉토리명 |
@@ -229,6 +230,19 @@ arch.Layers.Direction = map[string][]string{
 arch.Structure.RequireAlias = false
 arch.Structure.RequireModel = false
 ```
+
+### 비표준 패키지 루트 (`internal/` 외 레이아웃)
+
+표준 `internal/` 대신 `packages/`, `src/` 같은 다른 디렉토리에 패키지를 두는 프로젝트는 `Layout.InternalRoot`를 설정하면 됩니다:
+
+```go
+arch := presets.DDD()
+arch.Layout.InternalRoot = "packages" // packages/domain/order/...
+```
+
+빈 `InternalRoot`는 생성 시점에 `"internal"`로 정규화되므로 기존 설정은 그대로 동작합니다. 레이아웃 의존 룰은 `<root>/<InternalRoot>/` 디렉토리가 없을 때 violation을 묵묵히 0개로 반환하지 않고 `meta.layout-not-supported` (Warning)를 emit합니다.
+
+`scaffold.ArchitectureTest`도 `ArchitectureTestOptions.InternalRoot`로 같은 필드를 인식해 생성된 `architecture_test.go`가 실제 레이아웃과 매칭됩니다.
 
 ## 격리 규칙
 
@@ -772,6 +786,21 @@ ctx := core.NewContext(pkgs, "", "", presets.DDD(), []string{"internal/legacy/..
 ctx := core.NewContext(pkgs, "", "", presets.CleanArch(), nil)
 ```
 
+Exclude 패턴은 정규화 후 매칭됩니다: `/internal/foo`, `internal/foo`, `internal/foo/`, `./internal/foo`는 모두 같은 경로를 가리킵니다.
+
+### Meta Violations
+
+런타임이 환경/설정 이슈를 알리는 `meta.*` violation 집합. 빌드를 자동 차단하지 않으며 `(Rule, Message)` pair로 dedup되어 서로 다른 메시지는 모두 보존됩니다.
+
+| ID | Severity | 발생 시점 |
+|---|---|---|
+| `meta.no-matching-packages` | Warning | 설정한 모듈 path가 로드된 패키지와 매칭 안 됨 |
+| `meta.layout-not-supported` | Warning | 레이아웃 의존 룰을 `<root>/<InternalRoot>/` 디렉토리 없는 프로젝트에 실행 |
+| `meta.rule-panic` | Error | 룰의 `Check`가 panic; panic은 캡처되고 다른 룰은 계속 실행됨 |
+| `meta.unknown-violation-id` | per rule | 룰이 `Spec().Violations`에 선언하지 않은 violation ID emit |
+
+`core.WithSeverityOverride(...)`로 강제 실패시키거나 `RuleSet.Without(...)`로 필터링 가능.
+
 ## TUI 뷰어
 
 ```bash
@@ -795,13 +824,13 @@ go run github.com/NamhaeSusan/go-arch-guard/cmd/tui --preset hexagonal .
 | `core.Run(ctx, ruleset, opts...)` | ruleset 실행 후 `[]core.Violation` 반환; rule panic은 `meta.rule-panic` Error violation으로 변환 |
 | `core.RuleSet` | rule과 violation 필터를 담는 불변 컬렉션 |
 | `core.NewRuleSet(ruleValues...)` | 불변 ruleset 생성 |
-| `(rs).With(ruleValues...)` / `(rs).Without(ids...)` | rule 추가 또는 violation ID 필터링 |
+| `(rs).With(ruleValues...)` / `(rs).Without(ids...)` | rule 추가 (nil은 자동 무시) 또는 violation ID 필터링 |
 | `core.WithSeverityOverride(violationID, sev)` | 특정 violation ID의 effective severity override |
 | `report.AssertNoViolations(t, violations)` | Error 위반 시 테스트 실패 |
 | `report.BuildJSONReport(violations)` | 기계가 읽기 쉬운 JSON 리포트 구성 |
 | `report.MarshalJSONReport(violations)` | JSON 리포트 직렬화 |
 | `report.WriteJSONReport(w, violations)` | JSON 리포트 쓰기 |
-| `scaffold.ArchitectureTest(preset, opts)` | 프리셋별 `architecture_test.go` 템플릿 생성 |
+| `scaffold.ArchitectureTest(preset, opts)` | 프리셋별 `architecture_test.go` 템플릿 생성 (`opts.InternalRoot`로 비표준 패키지 루트 지원) |
 | `presets.DDD()` / `presets.RecommendedDDD()` | DDD 아키텍처와 권장 ruleset |
 | `presets.CleanArch()` / `presets.RecommendedCleanArch()` | Clean Architecture 아키텍처와 ruleset |
 | `presets.Layered()` / `presets.RecommendedLayered()` | Layered 아키텍처와 ruleset |

--- a/README.md
+++ b/README.md
@@ -203,13 +203,14 @@ Architecture fields:
 
 | Field | Description |
 |-------|-------------|
-| `LayerModel.Sublayers` | authoritative layer vocabulary |
-| `LayerModel.Direction` | allowed import direction matrix |
-| `LayerModel.PortLayers` | pure interface layers such as repo or gateway |
-| `LayerModel.ContractLayers` | contract layers; must include every port layer |
+| `LayerModel.Sublayers` | authoritative layer-path vocabulary (`"core/repo"`); referenced by direction, port, and contract rules |
+| `LayerModel.Direction` | allowed import direction matrix (keys must be in `Sublayers`) |
+| `LayerModel.PortLayers` | pure interface layers such as repo or gateway (must be in `Sublayers`) |
+| `LayerModel.ContractLayers` | contract layers; must be a superset of `PortLayers` |
 | `LayerModel.PkgRestricted` | sublayers that must not import shared packages |
-| `LayerModel.InternalTopLevel` | allowed top-level directories under `internal/` |
-| `LayerModel.LayerDirNames` | directory names considered layer-like for placement checks |
+| `LayerModel.InternalTopLevel` | allowed top-level directories under the package root |
+| `LayerModel.LayerDirNames` | layer **basenames** (`"repo"`) recognized by file/directory placement rules; intentionally NOT required to appear in `Sublayers` |
+| `LayoutModel.InternalRoot` | project-relative package-root directory; defaults to `"internal"` when empty (set to `"packages"`, `"src"`, etc. for non-default layouts) |
 | `LayoutModel.DomainDir` | top-level directory name for domains; empty for flat layouts |
 | `LayoutModel.OrchestrationDir` | top-level directory name for orchestration |
 | `LayoutModel.SharedDir` | top-level directory name for shared packages |
@@ -241,6 +242,25 @@ arch.Layers.Direction = map[string][]string{
 arch.Structure.RequireAlias = false
 arch.Structure.RequireModel = false
 ```
+
+### Custom package root (non-`internal/` layouts)
+
+Projects that keep their packages under `packages/`, `src/`, or any other directory
+instead of the canonical `internal/` can set `Layout.InternalRoot`:
+
+```go
+arch := presets.DDD()
+arch.Layout.InternalRoot = "packages" // packages/domain/order/...
+```
+
+Empty `InternalRoot` is normalized to `"internal"` at construction, so existing
+configurations keep working unchanged. Layout-dependent rules emit
+`meta.layout-not-supported` (Warning) when no `<root>/<InternalRoot>/` directory
+is found, instead of silently producing zero violations.
+
+`scaffold.ArchitectureTest` honors the same field via
+`ArchitectureTestOptions.InternalRoot` so generated `architecture_test.go`
+matches the project's actual layout.
 
 ## Isolation Rules
 
@@ -803,7 +823,22 @@ ctx := core.NewContext(pkgs, "", "", presets.DDD(), []string{"internal/legacy/..
 violations := core.Run(ctx, presets.RecommendedDDD())
 ```
 
-Patterns are project-relative paths with forward slashes. `...` matches the root and all descendants.
+Patterns are project-relative paths with forward slashes. `...` matches the root and all descendants. Equivalent shapes (`/internal/foo`, `internal/foo`, `internal/foo/`, `./internal/foo`) all match the same paths after normalization.
+
+### Meta Violations
+
+The runner emits a small set of `meta.*` violations to surface environmental issues
+without blocking builds by default. They are deduped by `(Rule, Message)` pair so distinct
+diagnostics survive even when multiple rules emit the same ID.
+
+| ID | Severity | When |
+|---|---|---|
+| `meta.no-matching-packages` | Warning | the configured project module does not match any loaded package |
+| `meta.layout-not-supported` | Warning | a layout-dependent rule is run against a project without a recognized package root (`<root>/<InternalRoot>/`) |
+| `meta.rule-panic` | Error | a rule's `Check` panicked; the panic is captured and other rules continue to run |
+| `meta.unknown-violation-id` | per rule | a rule emits a violation ID it didn't declare in `Spec().Violations` |
+
+Promote any of them to a hard failure with `core.WithSeverityOverride(...)`, or filter them out with `RuleSet.Without(...)`.
 
 ## TUI Viewer
 
@@ -830,13 +865,13 @@ Features: health-status tree coloring, imports/reverse dependencies/coupling met
 | `core.Run(ctx, ruleset, opts...)` | execute a ruleset and return `[]core.Violation`; rule panics become `meta.rule-panic` Error violations |
 | `core.RuleSet` | immutable collection of rules plus violation filters |
 | `core.NewRuleSet(ruleValues...)` | create an immutable ruleset |
-| `(rs).With(ruleValues...)` / `(rs).Without(ids...)` | append rules or filter violation IDs |
+| `(rs).With(ruleValues...)` / `(rs).Without(ids...)` | append rules (nil entries are silently dropped) or filter violation IDs |
 | `core.WithSeverityOverride(violationID, sev)` | override effective severity for one violation ID |
 | `report.AssertNoViolations(t, violations)` | fail test on Error violations |
 | `report.BuildJSONReport(violations)` | build a machine-readable JSON-friendly report |
 | `report.MarshalJSONReport(violations)` | marshal a machine-readable JSON report |
 | `report.WriteJSONReport(w, violations)` | write a machine-readable JSON report |
-| `scaffold.ArchitectureTest(preset, opts)` | generate a preset-specific `architecture_test.go` template |
+| `scaffold.ArchitectureTest(preset, opts)` | generate a preset-specific `architecture_test.go` template (`opts.InternalRoot` overrides the canonical `internal/`) |
 | `presets.DDD()` / `presets.RecommendedDDD()` | DDD architecture and recommended ruleset |
 | `presets.CleanArch()` / `presets.RecommendedCleanArch()` | Clean Architecture architecture and ruleset |
 | `presets.Layered()` / `presets.RecommendedLayered()` | layered architecture and ruleset |

--- a/docs/model-concepts.md
+++ b/docs/model-concepts.md
@@ -66,16 +66,17 @@ layers := core.LayerModel{
 
 ## LayoutModel
 
-`LayoutModel` describes the `internal/` directory topology. Empty fields
+`LayoutModel` describes the package-root directory topology. Empty fields
 disable the corresponding classification.
 
 | Field | Meaning |
 |-------|---------|
-| `DomainDir` | Directory that contains domain slices, for example `internal/domain/{name}/`. Empty means flat layout. |
-| `OrchestrationDir` | Directory for cross-domain coordination, for example `internal/orchestration/`. |
-| `SharedDir` | Shared internal package tree, usually `internal/pkg/`. |
-| `AppDir` | Composition root such as `internal/app/`. Rules can allow this layer to wire everything. |
-| `ServerDir` | Transport root such as `internal/server/http/` or `internal/server/grpc/`. |
+| `InternalRoot` | Project-relative directory that holds rule-managed packages. Defaults to `"internal"` when empty. Set to `"packages"`, `"src"`, etc. for projects that don't use the canonical Go `internal/` convention. The empty-to-`"internal"` normalization happens once in `cloneArchitecture`, so rules always read the resolved value. |
+| `DomainDir` | Directory that contains domain slices, for example `<InternalRoot>/domain/{name}/`. Empty means flat layout. |
+| `OrchestrationDir` | Directory for cross-domain coordination, for example `<InternalRoot>/orchestration/`. |
+| `SharedDir` | Shared internal package tree, usually `<InternalRoot>/pkg/`. |
+| `AppDir` | Composition root such as `<InternalRoot>/app/`. Rules can allow this layer to wire everything. |
+| `ServerDir` | Transport root such as `<InternalRoot>/server/http/` or `<InternalRoot>/server/grpc/`. |
 
 Domain layout example:
 

--- a/docs/presets.md
+++ b/docs/presets.md
@@ -4,6 +4,11 @@ Detailed layout diagrams and direction tables for each built-in preset.
 
 For custom architectures, see [Architecture Concepts](model-concepts.md).
 
+> **Note**: All preset layouts below use `internal/` as the canonical Go package root.
+> Projects that keep packages under a different directory (`packages/`, `src/`, etc.)
+> should set `arch.Layout.InternalRoot` accordingly — the same layout structure applies,
+> just under a different root.
+
 ## DDD Layout
 
 ```text

--- a/plugins/go-arch-guard/skills/go-arch-guard-batch/SKILL.md
+++ b/plugins/go-arch-guard/skills/go-arch-guard-batch/SKILL.md
@@ -45,7 +45,7 @@ if err != nil {
 }
 ```
 
-생성된 결과를 `architecture_test.go`에 저장한다.
+생성된 결과를 `architecture_test.go`에 저장한다. 비표준 패키지 루트(`packages/`, `src/`)를 쓰면 `ArchitectureTestOptions{..., InternalRoot: "packages"}`로 같이 지정한다.
 
 ### Step 3: 검증
 

--- a/plugins/go-arch-guard/skills/go-arch-guard-consumer/SKILL.md
+++ b/plugins/go-arch-guard/skills/go-arch-guard-consumer/SKILL.md
@@ -45,7 +45,7 @@ if err != nil {
 }
 ```
 
-생성된 결과를 `architecture_test.go`에 저장한다.
+생성된 결과를 `architecture_test.go`에 저장한다. 비표준 패키지 루트(`packages/`, `src/`)를 쓰면 `ArchitectureTestOptions{..., InternalRoot: "packages"}`로 같이 지정한다.
 
 ### Step 3: 검증
 

--- a/plugins/go-arch-guard/skills/go-arch-guard-event-pipeline/SKILL.md
+++ b/plugins/go-arch-guard/skills/go-arch-guard-event-pipeline/SKILL.md
@@ -44,6 +44,8 @@ if err != nil {
 }
 ```
 
+비표준 패키지 루트(`packages/`, `src/`)를 쓰면 `ArchitectureTestOptions{..., InternalRoot: "packages"}`로 같이 지정한다.
+
 ### Step 3: 검증
 
 ```bash

--- a/plugins/go-arch-guard/skills/go-arch-guard/SKILL.md
+++ b/plugins/go-arch-guard/skills/go-arch-guard/SKILL.md
@@ -68,6 +68,18 @@ if err != nil {
 }
 ```
 
+비표준 패키지 루트(`packages/`, `src/` 등)를 쓰는 프로젝트는 `InternalRoot`도 함께 지정한다 — 그래야 생성된 `analyzer.Load(".", "<root>/...", "cmd/...")`가 실제 레이아웃과 매칭된다:
+
+```go
+src, err := scaffold.ArchitectureTest(
+    scaffold.PresetDDD,
+    scaffold.ArchitectureTestOptions{
+        PackageName:  "myapp_test",
+        InternalRoot: "packages",
+    },
+)
+```
+
 생성된 결과를 `architecture_test.go`에 저장한다. 생성 템플릿은 내부에서
 `core.NewContext(...)`, `presets.{Preset}()`, `presets.Recommended{Preset}()`,
 `core.Run(...)`, `report.AssertNoViolations(...)`를 사용한다.
@@ -275,14 +287,16 @@ arch := core.Architecture{
 
 전체 필드: `LayerModel.Sublayers`, `LayerModel.Direction`, `LayerModel.PkgRestricted`,
 `LayerModel.InternalTopLevel`, `LayerModel.LayerDirNames`, `LayerModel.PortLayers`,
-`LayerModel.ContractLayers`, `LayoutModel.DomainDir`, `LayoutModel.OrchestrationDir`,
-`LayoutModel.SharedDir`, `LayoutModel.AppDir`, `LayoutModel.ServerDir`,
-`NamingPolicy.BannedPkgNames`, `NamingPolicy.LegacyPkgNames`, `NamingPolicy.AliasFileName`,
-`StructurePolicy.RequireAlias`, `StructurePolicy.RequireModel`, `StructurePolicy.ModelPath`,
+`LayerModel.ContractLayers`, `LayoutModel.InternalRoot` (default `"internal"`,
+`"packages"`/`"src"` 등 비표준 패키지 루트 지원), `LayoutModel.DomainDir`,
+`LayoutModel.OrchestrationDir`, `LayoutModel.SharedDir`, `LayoutModel.AppDir`,
+`LayoutModel.ServerDir`, `NamingPolicy.BannedPkgNames`, `NamingPolicy.LegacyPkgNames`,
+`NamingPolicy.AliasFileName`, `StructurePolicy.RequireAlias`,
+`StructurePolicy.RequireModel`, `StructurePolicy.ModelPath`,
 `StructurePolicy.DTOAllowedLayers`, `StructurePolicy.TypePatterns`,
 `StructurePolicy.InterfacePatternExclude`
 
-검증은 `arch.Validate()` 또는 `core.Validate(arch)`로 수행한다.
+검증은 `arch.Validate()` 또는 `core.Validate(arch)`로 수행한다. 빈 `InternalRoot`는 `cloneArchitecture` 시점에 `"internal"`로 정규화되므로 룰에서는 항상 비어있지 않은 값을 읽는다.
 
 ---
 
@@ -307,6 +321,19 @@ ctx := core.NewContext(pkgs, "", "", presets.DDD(), []string{"internal/legacy/..
 core.Run(ctx, presets.RecommendedDDD(),
     core.WithSeverityOverride("isolation.cross-domain", core.Warning))
 ```
+
+Exclude 패턴은 정규화 후 매칭됨: `/internal/foo`, `internal/foo`, `internal/foo/`, `./internal/foo` 모두 동일.
+
+### Meta Violations
+
+런타임이 환경 이슈를 알리는 `meta.*` violation. `(Rule, Message)` pair로 dedup.
+
+| ID | Severity | 의미 |
+|---|---|---|
+| `meta.no-matching-packages` | Warning | 모듈 path가 로드된 패키지와 매칭 안 됨 |
+| `meta.layout-not-supported` | Warning | 레이아웃 의존 룰이 `<root>/<InternalRoot>/`를 못 찾음 |
+| `meta.rule-panic` | Error | 룰 panic 발생; 다른 룰은 계속 실행 |
+| `meta.unknown-violation-id` | per rule | 룰이 미선언 violation ID emit |
 
 ### Tx Boundary (opt-in)
 


### PR DESCRIPTION
Companion PR to #75 (LayoutModel.InternalRoot, already merged) and #76 (scaffold InternalRoot, open). Brings every user-facing document up to date with the public API changes shipped during the codex review series.

## Files changed

| File | What |
|---|---|
| \`README.md\` | New InternalRoot field row in Architecture Fields table; new \"Custom package root\" section; new \"Meta Violations\" subsection covering the four \`meta.*\` IDs; \`RuleSet.With(nil)\` behavior note; \`IsExcluded\` normalization equivalence note; \`scaffold.ArchitectureTest\`'s \`InternalRoot\` option mentioned in the API reference. |
| \`README.ko.md\` | Same changes, Korean. |
| \`docs/model-concepts.md\` | \`LayoutModel\` field table rewritten to lead with InternalRoot and explain the cloneArchitecture-time normalization. |
| \`docs/presets.md\` | Top-of-file note that preset layouts all use \`internal/\` as the canonical root and how to opt into a different one. |
| \`plugins/.../go-arch-guard/SKILL.md\` | InternalRoot in the full-fields list; new \`meta.*\` violations summary; custom-root scaffold call signature. |
| \`plugins/.../go-arch-guard-{batch,consumer,event-pipeline}/SKILL.md\` | One-line note about the InternalRoot option for non-default layouts. |

## Why this is a separate PR

\`#75\` was merged to main after the stacked-PR chain consolidated. \`#76\`
(scaffold) is open and depends on the same field. Documentation can land
independently because it only describes shipped behavior; nothing here
gates on \`#76\`'s merge.

## Test plan

- [x] \`go test ./...\` — green (no code changes)
- [x] Markdown rendered locally — tables and code fences intact