### PR TITLE
fix(report): sort BuildJSONReport input, drop omitempty for stable shape

### DIFF
--- a/report/example_test.go
+++ b/report/example_test.go
@@ -34,8 +34,11 @@ func ExampleMarshalJSONReport() {
 	//   },
 	//   "violations": [
 	//     {
+	//       "file": "",
+	//       "line": 0,
 	//       "rule": "test.rule",
 	//       "message": "bad import",
+	//       "fix": "",
 	//       "effectiveSeverity": "error",
 	//       "defaultSeverity": "error"
 	//     }

--- a/report/json.go
+++ b/report/json.go
@@ -23,13 +23,17 @@ type JSONSummary struct {
 	Rules    []string `json:"rules"`
 }
 
-// JSONViolation is a JSON-friendly view of a core.Violation.
+// JSONViolation is a JSON-friendly view of a core.Violation. Every field is
+// always emitted (no `omitempty`) so consumers see one stable shape per
+// violation regardless of severity or violation source — meta.* violations
+// without a file or line still emit `"file": ""` and `"line": 0` rather than
+// dropping the keys, which would force parsers to handle two object shapes.
 type JSONViolation struct {
-	File              string `json:"file,omitempty"`
-	Line              int    `json:"line,omitempty"`
+	File              string `json:"file"`
+	Line              int    `json:"line"`
 	Rule              string `json:"rule"`
 	Message           string `json:"message"`
-	Fix               string `json:"fix,omitempty"`
+	Fix               string `json:"fix"`
 	EffectiveSeverity string `json:"effectiveSeverity"`
 	DefaultSeverity   string `json:"defaultSeverity"`
 }
@@ -41,16 +45,37 @@ type JSONReport struct {
 	Violations []JSONViolation `json:"violations"`
 }
 
-// BuildJSONReport converts violations into a machine-readable report.
+// BuildJSONReport converts violations into a machine-readable report. The
+// violations slice is sorted by (File, Line, Rule, Message) on a defensive
+// copy before serialization so the JSON output is byte-stable regardless of
+// the caller's input order. core.Run already sorts the same way, but direct
+// callers (custom runners, third-party rule pipelines) cannot be assumed to
+// sort, and unstable JSON breaks every downstream comparison and snapshot.
 func BuildJSONReport(violations []core.Violation) JSONReport {
 	report := JSONReport{
 		Schema:     jsonReportSchema,
 		Violations: make([]JSONViolation, 0, len(violations)),
 	}
+
+	sorted := make([]core.Violation, len(violations))
+	copy(sorted, violations)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		if sorted[i].File != sorted[j].File {
+			return sorted[i].File < sorted[j].File
+		}
+		if sorted[i].Line != sorted[j].Line {
+			return sorted[i].Line < sorted[j].Line
+		}
+		if sorted[i].Rule != sorted[j].Rule {
+			return sorted[i].Rule < sorted[j].Rule
+		}
+		return sorted[i].Message < sorted[j].Message
+	})
+
 	files := make(map[string]struct{})
 	ruleSet := make(map[string]struct{})
 
-	for _, v := range violations {
+	for _, v := range sorted {
 		report.Violations = append(report.Violations, JSONViolation{
 			File:              v.File,
 			Line:              v.Line,

--- a/report/json_test.go
+++ b/report/json_test.go
@@ -43,7 +43,13 @@ func TestBuildJSONReport(t *testing.T) {
 	if len(got.Summary.Rules) != 2 || got.Summary.Rules[0] != "blast.high-coupling" || got.Summary.Rules[1] != "isolation.cross-domain" {
 		t.Fatalf("unexpected rules summary: %+v", got.Summary.Rules)
 	}
-	if got.Violations[0].EffectiveSeverity != "error" || got.Violations[1].EffectiveSeverity != "warning" {
+	// Output is sorted by (File, Line, Rule, Message). Both violations share
+	// the same File, so the Line=0 entry (blast.high-coupling) sorts ahead
+	// of the Line=12 entry (isolation.cross-domain).
+	if got.Violations[0].Rule != "blast.high-coupling" || got.Violations[1].Rule != "isolation.cross-domain" {
+		t.Fatalf("violations not sorted: %+v", got.Violations)
+	}
+	if got.Violations[0].EffectiveSeverity != "warning" || got.Violations[1].EffectiveSeverity != "error" {
 		t.Fatalf("unexpected effective severities: %+v", got.Violations)
 	}
 	if got.Violations[0].DefaultSeverity != "error" || got.Violations[1].DefaultSeverity != "error" {
@@ -83,6 +89,70 @@ func TestBuildJSONReport_NilViolations(t *testing.T) {
 	}
 	if !bytes.Contains(data, []byte(`"violations":[]`)) {
 		t.Fatalf("nil violations must marshal as [] not null: %s", data)
+	}
+}
+
+func TestBuildJSONReport_MetaViolationStableShape(t *testing.T) {
+	// Meta violations (e.g. meta.no-matching-packages, meta.rule-panic)
+	// often have empty File and zero Line. The JSON output must still emit
+	// the file/line/fix keys with zero values so consumers see one stable
+	// shape per violation. omitempty on these fields would force parsers
+	// to handle two object shapes.
+	violations := []core.Violation{{
+		Rule:              "meta.rule-panic",
+		Message:           `rule "fake.bombs" panicked: boom`,
+		DefaultSeverity:   core.Error,
+		EffectiveSeverity: core.Error,
+	}}
+	data, err := report.MarshalJSONReport(violations)
+	if err != nil {
+		t.Fatalf("MarshalJSONReport() error = %v", err)
+	}
+	for _, frag := range []string{`"file": ""`, `"line": 0`, `"fix": ""`, `"rule": "meta.rule-panic"`} {
+		if !bytes.Contains(data, []byte(frag)) {
+			t.Errorf("meta violation JSON missing %q\n%s", frag, data)
+		}
+	}
+}
+
+func TestBuildJSONReport_SortsRegardlessOfInputOrder(t *testing.T) {
+	// Regression guard: BuildJSONReport must produce byte-stable output for
+	// equivalent inputs. core.Run already sorts, but BuildJSONReport is
+	// public and accepts any caller-provided slice.
+	a := []core.Violation{
+		{File: "z.go", Line: 1, Rule: "r2", Message: "m1", DefaultSeverity: core.Error, EffectiveSeverity: core.Error},
+		{File: "a.go", Line: 5, Rule: "r1", Message: "m1", DefaultSeverity: core.Error, EffectiveSeverity: core.Error},
+		{File: "a.go", Line: 5, Rule: "r1", Message: "m0", DefaultSeverity: core.Error, EffectiveSeverity: core.Error},
+	}
+	b := []core.Violation{
+		{File: "a.go", Line: 5, Rule: "r1", Message: "m0", DefaultSeverity: core.Error, EffectiveSeverity: core.Error},
+		{File: "z.go", Line: 1, Rule: "r2", Message: "m1", DefaultSeverity: core.Error, EffectiveSeverity: core.Error},
+		{File: "a.go", Line: 5, Rule: "r1", Message: "m1", DefaultSeverity: core.Error, EffectiveSeverity: core.Error},
+	}
+
+	dataA, err := report.MarshalJSONReport(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dataB, err := report.MarshalJSONReport(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(dataA, dataB) {
+		t.Fatalf("BuildJSONReport must be order-insensitive\nA:\n%s\nB:\n%s", dataA, dataB)
+	}
+}
+
+func TestBuildJSONReport_DoesNotMutateInput(t *testing.T) {
+	// BuildJSONReport sorts on a defensive copy. The caller's slice must
+	// not be reordered.
+	violations := []core.Violation{
+		{File: "z.go", Rule: "r2", Message: "m1", DefaultSeverity: core.Error, EffectiveSeverity: core.Error},
+		{File: "a.go", Rule: "r1", Message: "m0", DefaultSeverity: core.Error, EffectiveSeverity: core.Error},
+	}
+	_ = report.BuildJSONReport(violations)
+	if violations[0].File != "z.go" || violations[1].File != "a.go" {
+		t.Fatalf("input slice mutated: %+v", violations)
 	}
 }
 

--- a/report/report_test.go
+++ b/report/report_test.go
@@ -2,6 +2,7 @@ package report_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/NamhaeSusan/go-arch-guard/core"
@@ -11,6 +12,7 @@ import (
 type fakeTB struct {
 	testing.TB
 	errors []string
+	logs   []string
 	failed bool
 }
 
@@ -21,7 +23,9 @@ func (f *fakeTB) Errorf(format string, args ...any) {
 
 func (f *fakeTB) Helper() {}
 
-func (f *fakeTB) Log(args ...any) {}
+func (f *fakeTB) Log(args ...any) {
+	f.logs = append(f.logs, fmt.Sprint(args...))
+}
 
 func TestAssertNoViolations(t *testing.T) {
 	t.Run("no violations passes", func(t *testing.T) {
@@ -49,6 +53,45 @@ func TestAssertNoViolations(t *testing.T) {
 		})
 		if tb.failed {
 			t.Error("expected test to pass with warning-only violations")
+		}
+	})
+
+	t.Run("logs every violation with file/line/rule/message/fix and severity", func(t *testing.T) {
+		// Regression guard for the human/bot debugging output. AssertNoViolations
+		// is the primary signal a CI log carries, so the log line must keep
+		// every field that helps a reader (or remediation bot) locate the
+		// offending code: severity, file:line, rule, message, fix.
+		tb := &fakeTB{}
+		report.AssertNoViolations(tb, []core.Violation{
+			{
+				File:              "internal/order/app/service.go",
+				Line:              42,
+				Rule:              "test.rule",
+				Message:           "domain leak",
+				Fix:               "move to orchestration",
+				EffectiveSeverity: core.Error,
+			},
+			{
+				Rule:              "meta.no-matching-packages",
+				Message:           "module mismatch",
+				EffectiveSeverity: core.Warning,
+			},
+		})
+		if len(tb.logs) != 2 {
+			t.Fatalf("expected 2 log lines (one per violation), got %d: %v", len(tb.logs), tb.logs)
+		}
+		first := tb.logs[0]
+		for _, frag := range []string{"ERROR", "internal/order/app/service.go", "42", "test.rule", "domain leak", "move to orchestration"} {
+			if !strings.Contains(first, frag) {
+				t.Errorf("log[0] missing %q\n%s", frag, first)
+			}
+		}
+		// meta violation: severity, rule, message must be present even with empty file.
+		second := tb.logs[1]
+		for _, frag := range []string{"WARNING", "meta.no-matching-packages", "module mismatch"} {
+			if !strings.Contains(second, frag) {
+				t.Errorf("log[1] missing %q\n%s", frag, second)
+			}
 		}
 	})
 }


### PR DESCRIPTION
Codex review of the \`report\` package flagged stability issues at the public JSON boundary. This PR addresses warnings + regression-guard gaps. The codex-cited \"v1 vs v2 schema mismatch\" was in a gitignored local memo (\`docs/automation.md\`), not a shipped doc, so it has no public-API impact and is noted in the commit message.

## Changes

- \`BuildJSONReport\` now sorts on a defensive copy of input by \`(File, Line, Rule, Message)\`. Caller's slice is not mutated. Matches the sort \`core.Run\` already does, so direct callers (custom runners, third-party rule pipelines) get byte-stable JSON regardless of input order.
- Dropped \`omitempty\` from \`file\`, \`line\`, \`fix\` in \`JSONViolation\`. Meta violations without a source location now emit \`\"file\": \"\"\` and \`\"line\": 0\` rather than dropping keys entirely. Consumers see one stable object shape per violation.
- \`fakeTB.Log\` was discarding logged violations; the human/bot debugging contract on \`AssertNoViolations\` had no regression guard. \`fakeTB\` now records logs; new test asserts every relevant field surfaces.
- New tests:
  - \`TestBuildJSONReport_MetaViolationStableShape\` — meta violation JSON keeps every field
  - \`TestBuildJSONReport_SortsRegardlessOfInputOrder\` — same violations in different orders → byte-identical JSON
  - \`TestBuildJSONReport_DoesNotMutateInput\` — caller's slice is left alone
  - new sub-case in \`TestAssertNoViolations\` — log line contains severity, file, line, rule, message, fix
- Updated \`TestBuildJSONReport\` for the new sort order and \`ExampleMarshalJSONReport\` for the always-emitted fields.

## Public API impact

- **Behavior change** (intentional): JSON consumers that branched on the absence of \`file\`/\`line\`/\`fix\` keys now see them as zero values. This is the stability win — parsers no longer need two code paths.
- **Source-compatible**: \`BuildJSONReport\`, \`MarshalJSONReport\`, \`WriteJSONReport\`, and \`AssertNoViolations\` signatures unchanged.
- Schema marker remains \`go-arch-guard.report.v2\`; this is not a v3 because the field set on \`JSONViolation\` did not change, only the always-emitted policy.

## Test plan

- [x] \`go test ./...\` — 16/16 packages green
- [x] \`make lint\` — 0 issues
- [x] codex review (this PR is the response) — addresses every must-fix and warning that has user-facing impact

Closes #78.