### PR TITLE
feat(rules): banned-package exempts top-level SharedDir path

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,11 @@ Banned by default: `util`, `common`, `misc`, `helper`, `shared`, `services`
 internal/domain/order/app/util/   "util" is banned
 ```
 
+The configured `Layout.SharedDir` is exempt at its top-level path only. If
+`SharedDir = "shared"`, then `internal/shared/` is allowed but
+`internal/domain/<x>/shared/` is still flagged — the dumping-ground
+anti-pattern stays blocked inside layers.
+
 ### `structure.legacy-package`
 
 Warns about package names that should be migrated: `router`, `bootstrap`

--- a/docs/model-concepts.md
+++ b/docs/model-concepts.md
@@ -106,7 +106,7 @@ names; layer-aware rules read from `LayerModel.Sublayers`.
 
 | Field | Meaning |
 |-------|---------|
-| `BannedPkgNames` | Package names that should not appear under `internal/`, such as `util` or `common`. |
+| `BannedPkgNames` | Package names that should not appear under `internal/`, such as `util` or `common`. The exact `internal/<SharedDir>/` path is exempt so a banned-listed name (e.g. `shared`) can still be used as the configured cross-cutting bucket; nested occurrences remain flagged. |
 | `LegacyPkgNames` | Package names that produce migration warnings, such as `router` or `bootstrap`. |
 | `AliasFileName` | Filename for domain root alias files, usually `alias.go`. |
 

--- a/rules/structural/banned_package.go
+++ b/rules/structural/banned_package.go
@@ -64,12 +64,24 @@ func (r *BannedPackage) Check(ctx *core.Context) []core.Violation {
 			return nil
 		}
 		name := entry.Name()
+		// SharedDir is the architectural cross-cutting bucket. When its
+		// configured name happens to be in BannedPkgNames (e.g. SharedDir
+		// = "shared"), the rule exempts ONLY the exact top-level path
+		// internal/<SharedDir>/ — nested directories with the same name
+		// are still flagged so the dumping-ground anti-pattern cannot
+		// return inside domains or other layers.
+		topLevelSharedRel := arch.Layout.InternalRoot + "/" + arch.Layout.SharedDir
+		isTopLevelShared := arch.Layout.SharedDir != "" && rel == topLevelSharedRel
 		for _, banned := range arch.Naming.BannedPkgNames {
-			if name == banned {
-				violations = append(violations, violation(r.severity, bannedPackage, rel+"/",
-					`package "`+name+`" is banned`,
-					fmt.Sprintf("move to specific domain or %s/", arch.Layout.SharedDir)))
+			if name != banned {
+				continue
 			}
+			if isTopLevelShared {
+				continue
+			}
+			violations = append(violations, violation(r.severity, bannedPackage, rel+"/",
+				`package "`+name+`" is banned`,
+				fmt.Sprintf("move to specific domain or %s/", arch.Layout.SharedDir)))
 		}
 		for _, legacy := range arch.Naming.LegacyPkgNames {
 			if name == legacy {

--- a/rules/structural/banned_package_test.go
+++ b/rules/structural/banned_package_test.go
@@ -1,6 +1,7 @@
 package structural_test
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/NamhaeSusan/go-arch-guard/core"
@@ -27,5 +28,49 @@ func TestBannedPackage(t *testing.T) {
 				t.Fatalf("DefaultSeverity = %v, want Warning", v.DefaultSeverity)
 			}
 		}
+	})
+
+	// Path-aware exemption: when the configured SharedDir name happens to
+	// match an entry in BannedPkgNames (e.g. SharedDir="shared"), the rule
+	// must exempt internal/<SharedDir>/ at the top level only. Nested
+	// directories with the same name are still flagged so the dumping-ground
+	// anti-pattern cannot return inside domains.
+	t.Run("top-level SharedDir exempt even when its name is banned", func(t *testing.T) {
+		root := t.TempDir()
+		writeTestFile(t, filepath.Join(root, "internal/shared/foo.go"), "package shared\n")
+		writeTestFile(t, filepath.Join(root, "internal/domain/order/shared/bar.go"), "package shared\n")
+		writeTestFile(t, filepath.Join(root, "internal/domain/order/util/baz.go"), "package util\n")
+
+		arch := dddArch()
+		arch.Layout.SharedDir = "shared"
+
+		ctx := core.NewContext(nil, "github.com/example/app", root, arch, nil)
+		violations := core.Run(ctx, core.NewRuleSet(structural.NewBannedPackage()))
+
+		for _, v := range violations {
+			if v.Rule == "structure.banned-package" && v.File == "internal/shared/" {
+				t.Fatalf("top-level SharedDir must be exempt, got: %+v", v)
+			}
+		}
+		assertViolation(t, violations, "structure.banned-package", "internal/domain/order/shared/")
+		assertViolation(t, violations, "structure.banned-package", "internal/domain/order/util/")
+	})
+
+	t.Run("when SharedDir is not banned the rule behaves as before", func(t *testing.T) {
+		root := t.TempDir()
+		writeTestFile(t, filepath.Join(root, "internal/pkg/foo.go"), "package pkg\n")
+		writeTestFile(t, filepath.Join(root, "internal/domain/order/shared/bar.go"), "package shared\n")
+
+		arch := dddArch() // SharedDir="pkg" (not in banned list)
+
+		ctx := core.NewContext(nil, "github.com/example/app", root, arch, nil)
+		violations := core.Run(ctx, core.NewRuleSet(structural.NewBannedPackage()))
+
+		for _, v := range violations {
+			if v.Rule == "structure.banned-package" && v.File == "internal/pkg/" {
+				t.Fatalf("internal/pkg/ must not be flagged, got: %+v", v)
+			}
+		}
+		assertViolation(t, violations, "structure.banned-package", "internal/domain/order/shared/")
 	})
 }


### PR DESCRIPTION
## Summary
- `structural.NewBannedPackage` now exempts the exact `internal/<SharedDir>/` path from BannedPkgNames matching, so `Layout.SharedDir` can be any name — including one that appears in `BannedPkgNames` (e.g. `"shared"`).
- Nested directories with the same name (e.g. `internal/domain/order/shared/`) are still flagged so the dumping-ground anti-pattern stays blocked inside layers.
- Removes a hidden coupling between `Layout.SharedDir` and `Naming.BannedPkgNames` that previously made `SharedDir = "shared"` self-contradictory at the rule level.

## Why
Without this exemption, the rule matched purely on directory name, which meant any SharedDir whose name also appeared in BannedPkgNames was unusable — and the rule's own fix hint (`"move to <SharedDir>/"`) became self-contradictory in that case. Path-aware matching codifies the architectural intent that the SharedDir is a single blessed top-level bucket, not a name to be allowed everywhere.

## Test plan
- [x] `go test ./rules/structural/ -run TestBannedPackage -count=1` — new sub-tests added:
  - top-level `internal/<SharedDir>/` exempt when SharedDir name is banned
  - nested `internal/domain/<x>/<SharedDir>/` still flagged
  - `internal/domain/<x>/util/` still flagged (regression: other banned names unaffected)
  - rule behavior unchanged when SharedDir is not in BannedPkgNames
- [x] `go test ./...` — full suite green
- [x] `make lint` — 0 issues

## Notes
This is a non-breaking change. Default presets keep `SharedDir = "pkg"` (which was never in BannedPkgNames), so existing consumers see identical behavior. Teams that prefer `SharedDir = "shared"` can now do so without hand-editing `BannedPkgNames`.