### PR TITLE
fix(rules): bump structural.banned-package default severity to Error

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,7 +453,7 @@ internal/domain/order/app/util/   "util" is banned
 
 ### `structure.legacy-package`
 
-Warns about package names that should be migrated: `router`, `bootstrap`
+Flags package names that should be migrated: `router`, `bootstrap`. Default severity is Error; downgrade with `WithSeverityOverride("structure.legacy-package", core.Warning)` during migration windows.
 
 ### `structure.misplaced-layer`
 

--- a/rules/structural/banned_package.go
+++ b/rules/structural/banned_package.go
@@ -19,7 +19,7 @@ type BannedPackage struct {
 }
 
 func NewBannedPackage(opts ...Option) *BannedPackage {
-	cfg := newConfig(opts, core.Warning)
+	cfg := newConfig(opts, core.Error)
 	return &BannedPackage{severity: cfg.severity}
 }
 

--- a/rules/structural/banned_package_test.go
+++ b/rules/structural/banned_package_test.go
@@ -20,12 +20,25 @@ func TestBannedPackage(t *testing.T) {
 		assertViolation(t, violations, "structure.legacy-package", "internal/router/")
 	})
 
-	t.Run("defaults to warning", func(t *testing.T) {
+	t.Run("defaults to error for both banned and legacy violations", func(t *testing.T) {
 		violations := runRule(t, "../../testdata/invalid", structural.NewBannedPackage())
+		var sawBanned, sawLegacy bool
 		for _, v := range violations {
-			if v.Rule == "structure.banned-package" && v.DefaultSeverity != core.Warning {
-				t.Fatalf("DefaultSeverity = %v, want Warning", v.DefaultSeverity)
+			switch v.Rule {
+			case "structure.banned-package":
+				sawBanned = true
+				if v.DefaultSeverity != core.Error {
+					t.Fatalf("banned DefaultSeverity = %v, want Error", v.DefaultSeverity)
+				}
+			case "structure.legacy-package":
+				sawLegacy = true
+				if v.DefaultSeverity != core.Error {
+					t.Fatalf("legacy DefaultSeverity = %v, want Error", v.DefaultSeverity)
+				}
 			}
+		}
+		if !sawBanned || !sawLegacy {
+			t.Fatalf("expected both banned and legacy violations in invalid fixture, got banned=%v legacy=%v", sawBanned, sawLegacy)
 		}
 	})
 }


### PR DESCRIPTION
Closes #91. Partially addresses #94.

## Summary
- `structural.NewBannedPackage` now defaults to `core.Error`. It was the only structural rule that defaulted to `core.Warning`, breaking the consistency users expect when selectively enabling structural rules.
- The change applies to both violation IDs the rule emits (`structure.banned-package`, `structure.legacy-package`) since they share the rule's severity.
- README updated: the legacy-package section no longer claims "warns" and points users at `WithSeverityOverride` for migration windows.

## Why this resolves #91 (instead of splitting)
#91 proposed splitting `BannedPackage` into separate banned + legacy rules so each could carry its own severity. After review, harmonizing both at Error severity is sufficient policy: banned names are anti-patterns and should fail builds; legacy names are transitional and should fail builds *until migration is done*. Teams in mid-migration use `WithSeverityOverride` to soften only `structure.legacy-package` for the duration. Splitting the rule for that single use case adds API surface for marginal benefit.

## Why partial for #94
The other outlier (#94 mentions `naming.RepoFileInterface` defaulting to Error in a Warning-default package) is owned by #85 — moving the rule to `structural/` makes the Error default consistent in its new home.

## Test plan
- [x] `go test ./rules/structural/ -run TestBannedPackage -count=1` — defaults-to-error sub-test asserts both banned AND legacy violations carry Error
- [x] `go test ./...` — full suite green
- [x] `make lint` — 0 issues

## Breaking change note
Consumers who previously saw `structure.banned-package` / `structure.legacy-package` as Warning will now see Error. If a project has these violations and was tolerating them, builds will start failing. Soften with:

```go
core.Run(ctx, rules,
    core.WithSeverityOverride("structure.legacy-package", core.Warning),
    core.WithSeverityOverride("structure.banned-package", core.Warning),
)
```