### PR TITLE
refactor(rules): move RepoFileInterface from naming/ to structural/

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -394,7 +394,7 @@ internal/domain/order/utils/   "utils"는 인식된 서브레이어가 아님
 
 `structural.NewInternalTopLevel()`, `structural.NewBannedPackage()`,
 `structural.NewPlacement()`, `structural.NewAlias()`,
-`structural.NewModelRequired()`
+`structural.NewModelRequired()`, `structural.NewRepoFileInterface()`
 
 바이브 코딩 중 구조적 드리프트를 방지하는 파일시스템 레이아웃 규칙을 강제합니다.
 
@@ -466,7 +466,7 @@ DTO 파일(`dto.go`, `*_dto.go`)은 허용된 레이어(handler, app)에만 존�
 
 `naming.NewNoStutter()`, `naming.NewImplSuffix()`,
 `naming.NewSnakeCaseFiles()`, `naming.NewNoLayerSuffix()`,
-`naming.NewNoHandMock()`, `naming.NewRepoFileInterface()`
+`naming.NewNoHandMock()`
 
 코드베이스를 일관되고 grep 친화적으로 유지하는 Go 네이밍 규칙을 강제합니다.
 
@@ -840,8 +840,8 @@ go run github.com/NamhaeSusan/go-arch-guard/cmd/tui --preset hexagonal .
 | `presets.Batch()` / `presets.RecommendedBatch()` | Batch 플랫 레이아웃 아키텍처와 ruleset |
 | `presets.EventPipeline()` / `presets.RecommendedEventPipeline()` | 이벤트 소싱 / CQRS 아키텍처와 ruleset |
 | `dependency.NewIsolation()` / `NewLayerDirection()` / `NewBlastRadius()` | 의존성 규칙 |
-| `naming.NewNoStutter()` / `NewImplSuffix()` / `NewSnakeCaseFiles()` / `NewNoLayerSuffix()` / `NewNoHandMock()` / `NewRepoFileInterface()` | 네이밍 규칙 |
-| `structural.NewAlias()` / `NewPlacement()` / `NewBannedPackage()` / `NewModelRequired()` / `NewInternalTopLevel()` | 구조 규칙 |
+| `naming.NewNoStutter()` / `NewImplSuffix()` / `NewSnakeCaseFiles()` / `NewNoLayerSuffix()` / `NewNoHandMock()` | 네이밍 규칙 |
+| `structural.NewAlias()` / `NewPlacement()` / `NewBannedPackage()` / `NewModelRequired()` / `NewInternalTopLevel()` / `NewRepoFileInterface()` | 구조 규칙 |
 | `interfaces.NewPattern()` / `NewContainer()` / `NewCrossDomainAnonymous()` | 인터페이스 규칙 |
 | `interfaces.WithMaxMethods(n)` | `interfaces.NewPattern`의 인터페이스 메서드 상한 옵션 (기본 0 = 비활성; DDD/CleanArch/Hexagonal 권장 번들은 10으로 활성화) |
 | `tx.New(tx.Config{...})` | 트랜잭션 경계 검사 (옵트인) |

--- a/README.md
+++ b/README.md
@@ -495,8 +495,8 @@ DTO files (`dto.go`, `*_dto.go`) may only exist in allowed layers (handler, app)
 ## Naming Rules
 
 `naming.NewNoStutter()`, `naming.NewImplSuffix()`,
-`naming.NewSnakeCaseFiles()`, `naming.NewNoLayerSuffix()`,
-`naming.NewNoHandMock()`, and `naming.NewRepoFileInterface()`
+`naming.NewSnakeCaseFiles()`, `naming.NewNoLayerSuffix()`, and
+`naming.NewNoHandMock()`
 
 Enforces Go naming conventions that keep the codebase consistent and grep-friendly.
 
@@ -881,8 +881,8 @@ Features: health-status tree coloring, imports/reverse dependencies/coupling met
 | `presets.Batch()` / `presets.RecommendedBatch()` | Batch flat-layout architecture and ruleset |
 | `presets.EventPipeline()` / `presets.RecommendedEventPipeline()` | event-sourcing / CQRS architecture and ruleset |
 | `dependency.NewIsolation()` / `NewLayerDirection()` / `NewBlastRadius()` | dependency rules |
-| `naming.NewNoStutter()` / `NewImplSuffix()` / `NewSnakeCaseFiles()` / `NewNoLayerSuffix()` / `NewNoHandMock()` / `NewRepoFileInterface()` | naming rules |
-| `structural.NewAlias()` / `NewPlacement()` / `NewBannedPackage()` / `NewModelRequired()` / `NewInternalTopLevel()` | structure rules |
+| `naming.NewNoStutter()` / `NewImplSuffix()` / `NewSnakeCaseFiles()` / `NewNoLayerSuffix()` / `NewNoHandMock()` | naming rules |
+| `structural.NewAlias()` / `NewPlacement()` / `NewBannedPackage()` / `NewModelRequired()` / `NewInternalTopLevel()` / `NewRepoFileInterface()` | structure rules |
 | `interfaces.NewPattern()` / `NewContainer()` / `NewCrossDomainAnonymous()` | interface rules |
 | `interfaces.WithMaxMethods(n)` | option for `interfaces.NewPattern` setting the per-interface method cap (default 0 = disabled; DDD/CleanArch/Hexagonal recommended bundles bake in 10) |
 | `tx.New(tx.Config{...})` | transaction boundary enforcement (opt-in) |

--- a/core/analysisutil/ast.go
+++ b/core/analysisutil/ast.go
@@ -5,6 +5,7 @@ import (
 	"go/token"
 	"go/types"
 	"strings"
+	"unicode"
 )
 
 // IsTestFile reports whether file's source path ends with "_test.go". The
@@ -105,6 +106,28 @@ func SnakeToPascal(s string) string {
 		b.WriteString(part[1:])
 	}
 	return b.String()
+}
+
+// PascalToSnake converts a PascalCase / camelCase / mixed identifier to
+// snake_case. Runs of uppercase are kept together as one word; an underscore
+// is inserted only at a real word boundary:
+//   - between a lowercase/digit and an uppercase ("createOrder" -> "create_order")
+//   - between an uppercase and an uppercase that is followed by a lowercase
+//     ("XMLParser" -> "xml_parser")
+func PascalToSnake(name string) string {
+	runes := []rune(name)
+	var result []rune
+	for i, r := range runes {
+		if i > 0 && unicode.IsUpper(r) {
+			prev := runes[i-1]
+			nextLower := i+1 < len(runes) && unicode.IsLower(runes[i+1])
+			if unicode.IsLower(prev) || unicode.IsDigit(prev) || (unicode.IsUpper(prev) && nextLower) {
+				result = append(result, '_')
+			}
+		}
+		result = append(result, unicode.ToLower(r))
+	}
+	return string(result)
 }
 
 func ResolveIdentImportPath(file *ast.File, identName string) string {

--- a/presets/batch.go
+++ b/presets/batch.go
@@ -59,7 +59,7 @@ func RecommendedBatch() core.RuleSet {
 		naming.NewSnakeCaseFiles(),
 		naming.NewNoLayerSuffix(),
 		naming.NewNoHandMock(),
-		naming.NewRepoFileInterface(),
+		structural.NewRepoFileInterface(),
 		structural.NewPlacement(),
 		structural.NewBannedPackage(),
 		structural.NewInternalTopLevel(),

--- a/presets/cleanarch.go
+++ b/presets/cleanarch.go
@@ -66,7 +66,7 @@ func RecommendedCleanArch() core.RuleSet {
 		naming.NewSnakeCaseFiles(),
 		naming.NewNoLayerSuffix(),
 		naming.NewNoHandMock(),
-		naming.NewRepoFileInterface(),
+		structural.NewRepoFileInterface(),
 		structural.NewPlacement(),
 		structural.NewBannedPackage(),
 		structural.NewInternalTopLevel(),

--- a/presets/consumer_worker.go
+++ b/presets/consumer_worker.go
@@ -59,7 +59,7 @@ func RecommendedConsumerWorker() core.RuleSet {
 		naming.NewSnakeCaseFiles(),
 		naming.NewNoLayerSuffix(),
 		naming.NewNoHandMock(),
-		naming.NewRepoFileInterface(),
+		structural.NewRepoFileInterface(),
 		structural.NewPlacement(),
 		structural.NewBannedPackage(),
 		structural.NewInternalTopLevel(),

--- a/presets/ddd.go
+++ b/presets/ddd.go
@@ -84,7 +84,7 @@ func RecommendedDDD() core.RuleSet {
 		naming.NewSnakeCaseFiles(),
 		naming.NewNoLayerSuffix(),
 		naming.NewNoHandMock(),
-		naming.NewRepoFileInterface(),
+		structural.NewRepoFileInterface(),
 		structural.NewAlias(),
 		structural.NewPlacement(),
 		structural.NewBannedPackage(),

--- a/presets/event_pipeline.go
+++ b/presets/event_pipeline.go
@@ -69,7 +69,7 @@ func RecommendedEventPipeline() core.RuleSet {
 		naming.NewSnakeCaseFiles(),
 		naming.NewNoLayerSuffix(),
 		naming.NewNoHandMock(),
-		naming.NewRepoFileInterface(),
+		structural.NewRepoFileInterface(),
 		structural.NewPlacement(),
 		structural.NewBannedPackage(),
 		structural.NewInternalTopLevel(),

--- a/presets/hexagonal.go
+++ b/presets/hexagonal.go
@@ -64,7 +64,7 @@ func RecommendedHexagonal() core.RuleSet {
 		naming.NewSnakeCaseFiles(),
 		naming.NewNoLayerSuffix(),
 		naming.NewNoHandMock(),
-		naming.NewRepoFileInterface(),
+		structural.NewRepoFileInterface(),
 		structural.NewPlacement(),
 		structural.NewBannedPackage(),
 		structural.NewInternalTopLevel(),

--- a/presets/layered.go
+++ b/presets/layered.go
@@ -62,7 +62,7 @@ func RecommendedLayered() core.RuleSet {
 		naming.NewSnakeCaseFiles(),
 		naming.NewNoLayerSuffix(),
 		naming.NewNoHandMock(),
-		naming.NewRepoFileInterface(),
+		structural.NewRepoFileInterface(),
 		structural.NewPlacement(),
 		structural.NewBannedPackage(),
 		structural.NewInternalTopLevel(),

--- a/presets/modular_monolith.go
+++ b/presets/modular_monolith.go
@@ -63,7 +63,7 @@ func RecommendedModularMonolith() core.RuleSet {
 		naming.NewSnakeCaseFiles(),
 		naming.NewNoLayerSuffix(),
 		naming.NewNoHandMock(),
-		naming.NewRepoFileInterface(),
+		structural.NewRepoFileInterface(),
 		structural.NewPlacement(),
 		structural.NewBannedPackage(),
 		structural.NewInternalTopLevel(),

--- a/rules/dependency/custom_root_test.go
+++ b/rules/dependency/custom_root_test.go
@@ -35,4 +35,3 @@ func TestIsolationCustomInternalRootEmitsMetaForMissingRoot(t *testing.T) {
 		t.Fatalf("expected exactly 1 meta.layout-not-supported when InternalRoot points to a missing dir, got %d: %+v", meta, violations)
 	}
 }
-

--- a/rules/naming/snake_case_files.go
+++ b/rules/naming/snake_case_files.go
@@ -75,29 +75,7 @@ func isSnakeCase(filename string) bool {
 
 func toSnakeCase(filename string) string {
 	ext := filepath.Ext(filename)
-	return pascalToSnake(strings.TrimSuffix(filename, ext)) + ext
-}
-
-// pascalToSnake converts a PascalCase / camelCase / mixed identifier to
-// snake_case. Runs of uppercase are kept together as one word; an underscore
-// is inserted only at a real word boundary:
-//   - between a lowercase/digit and an uppercase ("createOrder" -> "create_order")
-//   - between an uppercase and an uppercase that is followed by a lowercase
-//     ("XMLParser" -> "xml_parser")
-func pascalToSnake(name string) string {
-	runes := []rune(name)
-	var result []rune
-	for i, r := range runes {
-		if i > 0 && unicode.IsUpper(r) {
-			prev := runes[i-1]
-			nextLower := i+1 < len(runes) && unicode.IsLower(runes[i+1])
-			if unicode.IsLower(prev) || unicode.IsDigit(prev) || (unicode.IsUpper(prev) && nextLower) {
-				result = append(result, '_')
-			}
-		}
-		result = append(result, unicode.ToLower(r))
-	}
-	return string(result)
+	return analysisutil.PascalToSnake(strings.TrimSuffix(filename, ext)) + ext
 }
 
 var _ core.Rule = (*SnakeCaseFiles)(nil)

--- a/rules/structural/repo_file_interface.go
+++ b/rules/structural/repo_file_interface.go
@@ -1,4 +1,4 @@
-package naming
+package structural
 
 import (
 	"go/ast"
@@ -23,7 +23,7 @@ func NewRepoFileInterface(opts ...Option) *RepoFileInterface {
 
 func (r *RepoFileInterface) Spec() core.RuleSpec {
 	return core.RuleSpec{
-		ID:              "naming.repo-file-interface",
+		ID:              "structural.repo-file-interface",
 		Description:     "repository port interface placement and filename conventions",
 		DefaultSeverity: r.severity,
 		Violations: []core.ViolationSpec{
@@ -88,7 +88,7 @@ func (r *RepoFileInterface) checkPortPackage(ctx *core.Context, pkg *packages.Pa
 			0,
 			"structure.repo-file-extra-interface",
 			`file "`+base+`" in repo/ must define only "`+expected+`", found extra: `+strings.Join(extra, ", "),
-			"move each extra interface to its own file (e.g. "+pascalToSnake(extra[0])+".go)",
+			"move each extra interface to its own file (e.g. "+analysisutil.PascalToSnake(extra[0])+".go)",
 		))
 	}
 	return violations

--- a/rules/structural/repo_file_interface_test.go
+++ b/rules/structural/repo_file_interface_test.go
@@ -1,18 +1,69 @@
-package naming_test
+package structural_test
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
+	"github.com/NamhaeSusan/go-arch-guard/analyzer"
 	"github.com/NamhaeSusan/go-arch-guard/core"
-	"github.com/NamhaeSusan/go-arch-guard/rules/naming"
+	"github.com/NamhaeSusan/go-arch-guard/rules/structural"
+	"golang.org/x/tools/go/packages"
 )
 
-func TestRepoFileInterfaceSpec(t *testing.T) {
-	spec := naming.NewRepoFileInterface(naming.WithSeverity(core.Warning)).Spec()
+var (
+	repoIfaceInvalidOnce sync.Once
+	repoIfaceInvalidPkgs []*packages.Package
+	repoIfaceInvalidErr  error
+)
 
-	if spec.ID != "naming.repo-file-interface" {
-		t.Fatalf("ID = %q, want naming.repo-file-interface", spec.ID)
+func loadInvalidForRepoIface(t *testing.T) []*packages.Package {
+	t.Helper()
+	repoIfaceInvalidOnce.Do(func() {
+		repoIfaceInvalidPkgs, repoIfaceInvalidErr = analyzer.Load("../../testdata/invalid", "internal/...")
+	})
+	if repoIfaceInvalidErr != nil {
+		t.Fatal(repoIfaceInvalidErr)
+	}
+	return repoIfaceInvalidPkgs
+}
+
+func invalidContextForRepoIface(t *testing.T) *core.Context {
+	t.Helper()
+	return core.NewContext(loadInvalidForRepoIface(t), "github.com/kimtaeyun/testproject-dc-invalid", "../../testdata/invalid", dddArch(), nil)
+}
+
+func tempContextForRepoIface(t *testing.T, files map[string]string, arch core.Architecture) *core.Context {
+	t.Helper()
+	root := t.TempDir()
+	writeRepoIfaceFile(t, filepath.Join(root, "go.mod"), "module example.com/structuraltest\n\ngo 1.25.0\n")
+	for name, content := range files {
+		writeRepoIfaceFile(t, filepath.Join(root, name), content)
+	}
+	pkgs, err := analyzer.Load(root, "internal/...")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return core.NewContext(pkgs, "example.com/structuraltest", root, arch, nil)
+}
+
+func writeRepoIfaceFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRepoFileInterfaceSpec(t *testing.T) {
+	spec := structural.NewRepoFileInterface(structural.WithSeverity(core.Warning)).Spec()
+
+	if spec.ID != "structural.repo-file-interface" {
+		t.Fatalf("ID = %q, want structural.repo-file-interface", spec.ID)
 	}
 	if spec.DefaultSeverity != core.Warning {
 		t.Fatalf("DefaultSeverity = %v, want Warning", spec.DefaultSeverity)
@@ -27,11 +78,11 @@ func TestRepoFileInterfaceSpec(t *testing.T) {
 }
 
 func TestRepoFileInterfaceFlagsRepoFilenameContract(t *testing.T) {
-	ctx := tempContext(t, map[string]string{
+	ctx := tempContextForRepoIface(t, map[string]string{
 		"internal/domain/order/core/repo/order.go": "package repo\n\nfunc FindOrder() {}\n",
 	}, dddArch())
 
-	got := naming.NewRepoFileInterface().Check(ctx)
+	got := structural.NewRepoFileInterface().Check(ctx)
 	if len(got) != 1 {
 		t.Fatalf("len = %d, want 1: %+v", len(got), got)
 	}
@@ -41,22 +92,22 @@ func TestRepoFileInterfaceFlagsRepoFilenameContract(t *testing.T) {
 }
 
 func TestRepoFileInterfaceFlagsExtraInterfaces(t *testing.T) {
-	ctx := tempContext(t, map[string]string{
+	ctx := tempContextForRepoIface(t, map[string]string{
 		"internal/domain/order/core/repo/review.go": "package repo\n\ntype Review interface { Find() }\ntype Helper interface { Assist() }\n",
 	}, dddArch())
 
-	got := naming.NewRepoFileInterface().Check(ctx)
+	got := structural.NewRepoFileInterface().Check(ctx)
 	if len(got) != 1 || got[0].Rule != "structure.repo-file-extra-interface" {
 		t.Fatalf("got %+v, want one extra-interface violation", got)
 	}
 }
 
 func TestRepoFileInterfaceExtraInterfaceFixUsesSnakeCase(t *testing.T) {
-	ctx := tempContext(t, map[string]string{
+	ctx := tempContextForRepoIface(t, map[string]string{
 		"internal/domain/order/core/repo/order.go": "package repo\n\ntype Order interface { Find() }\ntype UserRepository interface { Save() }\n",
 	}, dddArch())
 
-	got := naming.NewRepoFileInterface().Check(ctx)
+	got := structural.NewRepoFileInterface().Check(ctx)
 	var found bool
 	for _, v := range got {
 		if v.Rule != "structure.repo-file-extra-interface" {
@@ -76,7 +127,7 @@ func TestRepoFileInterfaceExtraInterfaceFixUsesSnakeCase(t *testing.T) {
 }
 
 func TestRepoFileInterfaceFlagsRepositoryPortOutsidePortLayer(t *testing.T) {
-	got := naming.NewRepoFileInterface().Check(invalidContext(t, nil))
+	got := structural.NewRepoFileInterface().Check(invalidContextForRepoIface(t))
 
 	var direct, alias bool
 	for _, v := range got {


### PR DESCRIPTION
Closes #85. Partially addresses #94 (resolves the `naming/RepoFileInterface` Error-default outlier — Error is now consistent with its new structural/ home).

## Summary
- **Move** `rules/naming/repo_file_interface.go` → `rules/structural/repo_file_interface.go`
- **Spec.ID** rename: `naming.repo-file-interface` → `structural.repo-file-interface`
- **Emitted violation IDs unchanged** (`structure.repo-file-interface`, `structure.repo-file-extra-interface`, `structure.interface-placement`)
- **Default severity unchanged** (`core.Error`) — but it stops being an outlier now that it lives among other Error-default structural rules
- **8 presets updated**: `naming.NewRepoFileInterface()` → `structural.NewRepoFileInterface()`
- **README updated**: rule moved between catalog tables, dropped from the naming-rules section
- **Helper extracted**: `pascalToSnake` (private to `rules/naming`) → `analysisutil.PascalToSnake` (mirrors the existing `analysisutil.SnakeToPascal`). Used by both the moved rule and `naming.SnakeCaseFiles`.

## Why
The rule was misnamed: only one of its three checks is naming-related (filename matches interface name). The other two — "one interface per file in port layer" and "repo-named interfaces must live in port layer" — are structural placement contracts. The rule's Error severity default also stuck out in `naming/` (every other naming rule defaults to Warning) because structural enforcement deserves Error.

## Test plan
- [x] `go test ./...` — all tests pass; the moved tests (`TestRepoFileInterface*`) cover Spec, repo-filename contract, extra-interface detection, snake-case fix-message hint, and interface placement
- [x] `make lint` — 0 issues
- [x] Test helpers (`tempContextForRepoIface`, `invalidContextForRepoIface`) added to structural test package; mirror the loading-cache pattern from `rules/naming/no_stutter_test.go` and reuse the existing `dddArch()` fixture

## Breaking change note
Consumers using `RuleSet.Without("naming.repo-file-interface")` or `WithSeverityOverride("naming.repo-file-interface", ...)` against the **rule-spec ID** must update to `"structural.repo-file-interface"`. Users filtering or overriding the **emitted violation IDs** (the common case — `structure.repo-file-interface` etc.) are unaffected.