### PR TITLE
fix(rules): emit meta.rule-disabled-by-config when config silently disables a rule

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -802,6 +802,7 @@ Exclude 패턴은 정규화 후 매칭됩니다: `/internal/foo`, `internal/foo`
 |---|---|---|
 | `meta.no-matching-packages` | Warning | 설정한 모듈 path가 로드된 패키지와 매칭 안 됨 |
 | `meta.layout-not-supported` | Warning | 레이아웃 의존 룰을 `<root>/<InternalRoot>/` 디렉토리 없는 프로젝트에 실행 |
+| `meta.rule-disabled-by-config` | Warning | 룰(또는 sub-check)이 RuleSet에 등록됐으나 Architecture 설정으로 인해 동작 안 함 — 예: `structural.alias`인데 `Structure.RequireAlias=false`, `dependency.isolation`인데 `Layout.DomainDir=""`, `interfaces.NewPattern`에 `WithMaxMethods` 미지정, `tx.boundary`인데 `tx.Config`가 비어있음 |
 | `meta.rule-panic` | Error | 룰의 `Check`가 panic; panic은 캡처되고 다른 룰은 계속 실행됨 |
 | `meta.unknown-violation-id` | per rule | 룰이 `Spec().Violations`에 선언하지 않은 violation ID emit |
 

--- a/README.md
+++ b/README.md
@@ -843,6 +843,7 @@ diagnostics survive even when multiple rules emit the same ID.
 |---|---|---|
 | `meta.no-matching-packages` | Warning | the configured project module does not match any loaded package |
 | `meta.layout-not-supported` | Warning | a layout-dependent rule is run against a project without a recognized package root (`<root>/<InternalRoot>/`) |
+| `meta.rule-disabled-by-config` | Warning | a rule (or one of its sub-checks) is registered in the ruleset but Architecture config disables it — e.g. `Structure.RequireAlias=false` for `structural.alias`, `Layout.DomainDir=""` for `dependency.isolation`, `WithMaxMethods` not provided to `interfaces.NewPattern`, empty `tx.Config` for `tx.boundary` |
 | `meta.rule-panic` | Error | a rule's `Check` panicked; the panic is captured and other rules continue to run |
 | `meta.unknown-violation-id` | per rule | a rule emits a violation ID it didn't declare in `Spec().Violations` |
 

--- a/presets/batch.go
+++ b/presets/batch.go
@@ -64,7 +64,7 @@ func RecommendedBatch() core.RuleSet {
 		structural.NewPlacement(),
 		structural.NewBannedPackage(),
 		structural.NewInternalTopLevel(),
-		interfaces.NewPattern(),
+		interfaces.NewPattern(interfaces.WithMaxMethods(10)),
 		interfaces.NewContainer(),
 		naming.NewTypePattern(),
 		types.NewNoSetter(),

--- a/presets/consumer_worker.go
+++ b/presets/consumer_worker.go
@@ -64,7 +64,7 @@ func RecommendedConsumerWorker() core.RuleSet {
 		structural.NewPlacement(),
 		structural.NewBannedPackage(),
 		structural.NewInternalTopLevel(),
-		interfaces.NewPattern(),
+		interfaces.NewPattern(interfaces.WithMaxMethods(10)),
 		interfaces.NewContainer(),
 		naming.NewTypePattern(),
 		types.NewNoSetter(),

--- a/presets/event_pipeline.go
+++ b/presets/event_pipeline.go
@@ -74,7 +74,7 @@ func RecommendedEventPipeline() core.RuleSet {
 		structural.NewPlacement(),
 		structural.NewBannedPackage(),
 		structural.NewInternalTopLevel(),
-		interfaces.NewPattern(),
+		interfaces.NewPattern(interfaces.WithMaxMethods(10)),
 		interfaces.NewContainer(),
 		naming.NewTypePattern(),
 		types.NewNoSetter(),

--- a/presets/layered.go
+++ b/presets/layered.go
@@ -67,7 +67,7 @@ func RecommendedLayered() core.RuleSet {
 		structural.NewPlacement(),
 		structural.NewBannedPackage(),
 		structural.NewInternalTopLevel(),
-		interfaces.NewPattern(),
+		interfaces.NewPattern(interfaces.WithMaxMethods(10)),
 		interfaces.NewContainer(),
 		interfaces.NewCrossDomainAnonymous(),
 		naming.NewTypePattern(),

--- a/presets/modular_monolith.go
+++ b/presets/modular_monolith.go
@@ -68,7 +68,7 @@ func RecommendedModularMonolith() core.RuleSet {
 		structural.NewPlacement(),
 		structural.NewBannedPackage(),
 		structural.NewInternalTopLevel(),
-		interfaces.NewPattern(),
+		interfaces.NewPattern(interfaces.WithMaxMethods(10)),
 		interfaces.NewContainer(),
 		interfaces.NewCrossDomainAnonymous(),
 		naming.NewTypePattern(),

--- a/rules/dependency/isolation.go
+++ b/rules/dependency/isolation.go
@@ -42,7 +42,9 @@ func (r *Isolation) Check(ctx *core.Context) []core.Violation {
 	arch := ctx.Arch()
 	layout := arch.Layout
 	if layout.DomainDir == "" {
-		return nil
+		return []core.Violation{metaRuleDisabledByConfig("dependency.isolation",
+			"Layout.DomainDir is empty (flat layout); cross-domain isolation requires a domain directory",
+			"set Layout.DomainDir to your domain root, or remove dependency.NewIsolation() from your RuleSet")}
 	}
 
 	projectModule := analysisutil.ResolveModuleFromContext(ctx, "")
@@ -58,6 +60,11 @@ func (r *Isolation) Check(ctx *core.Context) []core.Violation {
 	internalPrefix := projectModule + "/" + layout.InternalRoot + "/"
 	cmdPrefix := projectModule + "/cmd"
 	var violations []core.Violation
+	if !arch.Structure.RequireAlias {
+		violations = append(violations, metaRuleDisabledByConfig("dependency.isolation",
+			"Structure.RequireAlias is false; dependency.cmd-deep-import and dependency.orchestration-deep-import sub-checks will not fire",
+			"set Structure.RequireAlias = true to enforce alias-only imports from cmd/ and orchestration/"))
+	}
 
 	for _, pkg := range pkgs {
 		if isExcludedPackage(ctx, pkg.PkgPath, projectModule) {
@@ -404,6 +411,20 @@ func metaNoMatchingPackages(message string) core.Violation {
 		Rule:              "meta.no-matching-packages",
 		Message:           message,
 		Fix:               "verify the module argument matches go.mod",
+		DefaultSeverity:   core.Warning,
+		EffectiveSeverity: core.Warning,
+	}
+}
+
+// metaRuleDisabledByConfig signals that a rule is registered in the RuleSet
+// but the supplied core.Architecture configuration prevents it from running
+// (whole rule) or makes a sub-check inert (partial). Severity defaults to
+// Warning via the runner's meta.* prefix handling.
+func metaRuleDisabledByConfig(ruleID, reason, fix string) core.Violation {
+	return core.Violation{
+		Rule:              "meta.rule-disabled-by-config",
+		Message:           fmt.Sprintf("%s: %s", ruleID, reason),
+		Fix:               fix,
 		DefaultSeverity:   core.Warning,
 		EffectiveSeverity: core.Warning,
 	}

--- a/rules/dependency/isolation_test.go
+++ b/rules/dependency/isolation_test.go
@@ -85,6 +85,35 @@ func TestIsolationFlatLayoutEmitsMetaWarning(t *testing.T) {
 	assertExactlyOneMetaLayoutNotSupported(t, violations, "dependency.isolation")
 }
 
+func TestIsolationDomainDirEmptyEmitsMetaDisabledByConfig(t *testing.T) {
+	arch := dddArchitecture()
+	arch.Layout.DomainDir = ""
+	ctx := loadContext(t, "../../testdata/valid", "github.com/kimtaeyun/testproject-dc", arch, "internal/...")
+	got := dependency.NewIsolation().Check(ctx)
+	if len(got) != 1 || got[0].Rule != "meta.rule-disabled-by-config" {
+		t.Fatalf("expected exactly 1 meta.rule-disabled-by-config violation, got %+v", got)
+	}
+	if !strings.Contains(got[0].Message, "Layout.DomainDir is empty") {
+		t.Fatalf("meta message should mention DomainDir, got %q", got[0].Message)
+	}
+}
+
+func TestIsolationRequireAliasFalseEmitsMetaForPartialDisable(t *testing.T) {
+	arch := dddArchitecture()
+	arch.Structure.RequireAlias = false
+	ctx := loadContext(t, "../../testdata/valid", "github.com/kimtaeyun/testproject-dc", arch, "internal/...")
+	got := dependency.NewIsolation().Check(ctx)
+	var sawMeta bool
+	for _, v := range got {
+		if v.Rule == "meta.rule-disabled-by-config" && strings.Contains(v.Message, "RequireAlias is false") {
+			sawMeta = true
+		}
+	}
+	if !sawMeta {
+		t.Fatalf("expected meta.rule-disabled-by-config when RequireAlias=false, got %+v", got)
+	}
+}
+
 func TestIsolationDDDProjectHasNoMetaLayoutWarning(t *testing.T) {
 	ctx := loadContext(t, "../../testdata/valid", "github.com/kimtaeyun/testproject-dc", dddArchitecture(), "internal/...")
 	for _, v := range dependency.NewIsolation().Check(ctx) {

--- a/rules/interfaces/cross_domain.go
+++ b/rules/interfaces/cross_domain.go
@@ -41,7 +41,9 @@ func (r *CrossDomainAnonymous) Check(ctx *core.Context) []core.Violation {
 		return []core.Violation{metaLayoutNotSupported("interfaces.cross-domain-anonymous", projectModule)}
 	}
 	if arch.Layout.DomainDir == "" {
-		return nil
+		return []core.Violation{metaRuleDisabledByConfig("interfaces.cross-domain-anonymous",
+			"Layout.DomainDir is empty (flat layout); cross-domain anonymous interface detection requires a domain directory",
+			"set Layout.DomainDir to your domain root, or remove interfaces.NewCrossDomainAnonymous() from your RuleSet")}
 	}
 
 	var violations []core.Violation

--- a/rules/interfaces/cross_domain_test.go
+++ b/rules/interfaces/cross_domain_test.go
@@ -1,11 +1,32 @@
 package interfaces_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/NamhaeSusan/go-arch-guard/core"
 	"github.com/NamhaeSusan/go-arch-guard/rules/interfaces"
 )
+
+func TestCrossDomainAnonymousDomainDirEmptyEmitsMetaDisabledByConfig(t *testing.T) {
+	root := writeFixture(t, "example.com/flat-layout", map[string]string{
+		"internal/svc/svc.go": "package svc\n",
+	})
+	arch := flatArchitecture()
+	arch.Layout.DomainDir = ""
+	ctx := loadContext(t, root, arch, "example.com/flat-layout")
+
+	got := interfaces.NewCrossDomainAnonymous().Check(ctx)
+	var sawMeta bool
+	for _, v := range got {
+		if v.Rule == "meta.rule-disabled-by-config" && strings.Contains(v.Message, "Layout.DomainDir is empty") {
+			sawMeta = true
+		}
+	}
+	if !sawMeta {
+		t.Fatalf("expected meta.rule-disabled-by-config when DomainDir is empty, got %+v", got)
+	}
+}
 
 func TestCrossDomainAnonymousDetectsAnonymousInterfaceOutsideDomain(t *testing.T) {
 	root := writeFixture(t, "example.com/cross-domain-anon", map[string]string{

--- a/rules/interfaces/layout_meta.go
+++ b/rules/interfaces/layout_meta.go
@@ -35,3 +35,17 @@ func metaLayoutNotSupported(ruleID, projectModule string) core.Violation {
 		EffectiveSeverity: core.Warning,
 	}
 }
+
+// metaRuleDisabledByConfig signals that a rule is registered in the RuleSet
+// but the supplied core.Architecture configuration prevents it from running
+// (whole rule) or makes a sub-check inert (partial). Severity defaults to
+// Warning via the runner's meta.* prefix handling.
+func metaRuleDisabledByConfig(ruleID, reason, fix string) core.Violation {
+	return core.Violation{
+		Rule:              "meta.rule-disabled-by-config",
+		Message:           fmt.Sprintf("%s: %s", ruleID, reason),
+		Fix:               fix,
+		DefaultSeverity:   core.Warning,
+		EffectiveSeverity: core.Warning,
+	}
+}

--- a/rules/interfaces/pattern.go
+++ b/rules/interfaces/pattern.go
@@ -47,6 +47,11 @@ func (r *Pattern) Check(ctx *core.Context) []core.Violation {
 	}
 
 	var violations []core.Violation
+	if r.cfg.maxMethods <= 0 {
+		violations = append(violations, metaRuleDisabledByConfig("interfaces.pattern",
+			"WithMaxMethods option not provided; interfaces.too-many-methods sub-check will not fire",
+			"pass interfaces.WithMaxMethods(n) to NewPattern to enable the method-count cap"))
+	}
 	for _, pkg := range pkgs {
 		if isExcludedInterfacePatternPkg(arch, pkg) {
 			continue

--- a/rules/interfaces/pattern_test.go
+++ b/rules/interfaces/pattern_test.go
@@ -12,6 +12,60 @@ import (
 	"github.com/NamhaeSusan/go-arch-guard/rules/interfaces"
 )
 
+func TestPatternWithoutMaxMethodsEmitsMetaDisabledByConfig(t *testing.T) {
+	root := writeFixture(t, "example.com/no-max-methods", map[string]string{
+		"internal/store/store.go": `package store
+
+type Store interface {
+	Get(id string) string
+}
+
+type StoreImpl struct{}
+
+func (s *StoreImpl) Get(id string) string { return "" }
+
+func New() Store { return &StoreImpl{} }
+`,
+	})
+	arch := flatArchitecture()
+	got := interfaces.NewPattern().Check(loadContext(t, root, arch, "example.com/no-max-methods"))
+
+	var sawMeta bool
+	for _, v := range got {
+		if v.Rule == "meta.rule-disabled-by-config" && strings.Contains(v.Message, "WithMaxMethods option not provided") {
+			sawMeta = true
+		}
+	}
+	if !sawMeta {
+		t.Fatalf("expected meta.rule-disabled-by-config when WithMaxMethods is omitted, got %+v", got)
+	}
+}
+
+func TestPatternWithMaxMethodsDoesNotEmitMeta(t *testing.T) {
+	root := writeFixture(t, "example.com/with-max-methods", map[string]string{
+		"internal/store/store.go": `package store
+
+type Store interface {
+	Get(id string) string
+}
+
+type StoreImpl struct{}
+
+func (s *StoreImpl) Get(id string) string { return "" }
+
+func New() Store { return &StoreImpl{} }
+`,
+	})
+	arch := flatArchitecture()
+	got := interfaces.NewPattern(interfaces.WithMaxMethods(10)).Check(loadContext(t, root, arch, "example.com/with-max-methods"))
+
+	for _, v := range got {
+		if v.Rule == "meta.rule-disabled-by-config" {
+			t.Fatalf("unexpected meta.rule-disabled-by-config when WithMaxMethods is set: %v", v)
+		}
+	}
+}
+
 func TestPatternDetectsCoreViolations(t *testing.T) {
 	root := writeFixture(t, "example.com/pattern-core", map[string]string{
 		"internal/store/store.go": `package store
@@ -111,8 +165,13 @@ func NewModel() Model { return &ModelImpl{} }
 
 	violations := interfaces.NewPattern().Check(loadContext(t, root, arch, "example.com/pattern-exclude"))
 
-	if len(violations) != 0 {
-		t.Fatalf("violations = %v, want none", violations)
+	// NewPattern() without WithMaxMethods emits meta.rule-disabled-by-config
+	// to signal that the too-many-methods sub-check is inactive. Filter that
+	// out — the test is asserting no actual interfaces.* violations.
+	for _, v := range violations {
+		if v.Rule != "meta.rule-disabled-by-config" {
+			t.Fatalf("unexpected non-meta violation: %v", v)
+		}
 	}
 }
 

--- a/rules/structural/alias.go
+++ b/rules/structural/alias.go
@@ -52,8 +52,15 @@ func (r *Alias) Check(ctx *core.Context) []core.Violation {
 	if !hasInternalDir(ctx.Root(), arch.Layout.InternalRoot) {
 		return []core.Violation{metaLayoutNotSupported(ruleAlias)}
 	}
-	if arch.Layout.DomainDir == "" || !arch.Structure.RequireAlias {
-		return nil
+	if arch.Layout.DomainDir == "" {
+		return []core.Violation{metaRuleDisabledByConfig(ruleAlias,
+			"Layout.DomainDir is empty (flat layout); alias enforcement requires a domain directory",
+			"set Layout.DomainDir to your domain root, or remove structural.NewAlias() from your RuleSet")}
+	}
+	if !arch.Structure.RequireAlias {
+		return []core.Violation{metaRuleDisabledByConfig(ruleAlias,
+			"Structure.RequireAlias is false; alias enforcement skipped",
+			"set Structure.RequireAlias = true, or remove structural.NewAlias() from your RuleSet")}
 	}
 
 	domainDir := filepath.Join(ctx.Root(), arch.Layout.InternalRoot, filepath.FromSlash(arch.Layout.DomainDir))

--- a/rules/structural/alias_test.go
+++ b/rules/structural/alias_test.go
@@ -48,13 +48,31 @@ type AdminOps = svc.AdminOps
 		assertMessageContains(t, violations, "structural.domain-alias-contract-reexport", "AdminOps")
 	})
 
-	t.Run("skips non-DDD architecture", func(t *testing.T) {
+	t.Run("emits meta.rule-disabled-by-config when DomainDir is empty (flat layout)", func(t *testing.T) {
 		arch := dddArch()
 		arch.Layout.DomainDir = ""
 		ctx := core.NewContext(nil, "github.com/example/app", "../../testdata/invalid", arch, nil)
 
-		if got := structural.NewAlias().Check(ctx); len(got) != 0 {
-			t.Fatalf("len = %d, want 0 for non-DDD architecture", len(got))
+		got := structural.NewAlias().Check(ctx)
+		if len(got) != 1 || got[0].Rule != "meta.rule-disabled-by-config" {
+			t.Fatalf("expected exactly 1 meta.rule-disabled-by-config violation, got %+v", got)
+		}
+		if !strings.Contains(got[0].Message, "Layout.DomainDir is empty") {
+			t.Fatalf("meta message should mention DomainDir, got %q", got[0].Message)
+		}
+	})
+
+	t.Run("emits meta.rule-disabled-by-config when RequireAlias is false", func(t *testing.T) {
+		arch := dddArch()
+		arch.Structure.RequireAlias = false
+		ctx := core.NewContext(nil, "github.com/example/app", "../../testdata/invalid", arch, nil)
+
+		got := structural.NewAlias().Check(ctx)
+		if len(got) != 1 || got[0].Rule != "meta.rule-disabled-by-config" {
+			t.Fatalf("expected exactly 1 meta.rule-disabled-by-config violation, got %+v", got)
+		}
+		if !strings.Contains(got[0].Message, "RequireAlias is false") {
+			t.Fatalf("meta message should mention RequireAlias, got %q", got[0].Message)
 		}
 	})
 }

--- a/rules/structural/layout_meta.go
+++ b/rules/structural/layout_meta.go
@@ -29,3 +29,17 @@ func metaLayoutNotSupported(ruleID string) core.Violation {
 		EffectiveSeverity: core.Warning,
 	}
 }
+
+// metaRuleDisabledByConfig signals that a rule is registered in the RuleSet
+// but the supplied core.Architecture configuration prevents it from running
+// (whole rule) or makes a sub-check inert (partial). Severity defaults to
+// Warning via the runner's meta.* prefix handling.
+func metaRuleDisabledByConfig(ruleID, reason, fix string) core.Violation {
+	return core.Violation{
+		Rule:              "meta.rule-disabled-by-config",
+		Message:           fmt.Sprintf("%s: %s", ruleID, reason),
+		Fix:               fix,
+		DefaultSeverity:   core.Warning,
+		EffectiveSeverity: core.Warning,
+	}
+}

--- a/rules/structural/model_required.go
+++ b/rules/structural/model_required.go
@@ -40,8 +40,15 @@ func (r *ModelRequired) Check(ctx *core.Context) []core.Violation {
 	if !hasInternalDir(ctx.Root(), arch.Layout.InternalRoot) {
 		return []core.Violation{metaLayoutNotSupported(ruleModelRequired)}
 	}
-	if arch.Layout.DomainDir == "" || !arch.Structure.RequireModel {
-		return nil
+	if arch.Layout.DomainDir == "" {
+		return []core.Violation{metaRuleDisabledByConfig(ruleModelRequired,
+			"Layout.DomainDir is empty (flat layout); model enforcement requires a domain directory",
+			"set Layout.DomainDir to your domain root, or remove structural.NewModelRequired() from your RuleSet")}
+	}
+	if !arch.Structure.RequireModel {
+		return []core.Violation{metaRuleDisabledByConfig(ruleModelRequired,
+			"Structure.RequireModel is false; model enforcement skipped",
+			"set Structure.RequireModel = true, or remove structural.NewModelRequired() from your RuleSet")}
 	}
 
 	domainDir := filepath.Join(ctx.Root(), arch.Layout.InternalRoot, filepath.FromSlash(arch.Layout.DomainDir))

--- a/rules/structural/model_required_test.go
+++ b/rules/structural/model_required_test.go
@@ -1,6 +1,7 @@
 package structural_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/NamhaeSusan/go-arch-guard/core"
@@ -18,13 +19,31 @@ func TestModelRequired(t *testing.T) {
 		assertViolation(t, violations, "structural.domain-model-required", "internal/domain/ghost/")
 	})
 
-	t.Run("skips non-DDD architecture", func(t *testing.T) {
+	t.Run("emits meta.rule-disabled-by-config when DomainDir is empty (flat layout)", func(t *testing.T) {
 		arch := dddArch()
 		arch.Layout.DomainDir = ""
 		ctx := core.NewContext(nil, "github.com/example/app", "../../testdata/invalid", arch, nil)
 
-		if got := structural.NewModelRequired().Check(ctx); len(got) != 0 {
-			t.Fatalf("len = %d, want 0 for non-DDD architecture", len(got))
+		got := structural.NewModelRequired().Check(ctx)
+		if len(got) != 1 || got[0].Rule != "meta.rule-disabled-by-config" {
+			t.Fatalf("expected exactly 1 meta.rule-disabled-by-config violation, got %+v", got)
+		}
+		if !strings.Contains(got[0].Message, "Layout.DomainDir is empty") {
+			t.Fatalf("meta message should mention DomainDir, got %q", got[0].Message)
+		}
+	})
+
+	t.Run("emits meta.rule-disabled-by-config when RequireModel is false", func(t *testing.T) {
+		arch := dddArch()
+		arch.Structure.RequireModel = false
+		ctx := core.NewContext(nil, "github.com/example/app", "../../testdata/invalid", arch, nil)
+
+		got := structural.NewModelRequired().Check(ctx)
+		if len(got) != 1 || got[0].Rule != "meta.rule-disabled-by-config" {
+			t.Fatalf("expected exactly 1 meta.rule-disabled-by-config violation, got %+v", got)
+		}
+		if !strings.Contains(got[0].Message, "RequireModel is false") {
+			t.Fatalf("meta message should mention RequireModel, got %q", got[0].Message)
 		}
 	})
 }

--- a/rules/structural/repo_file_interface.go
+++ b/rules/structural/repo_file_interface.go
@@ -37,7 +37,9 @@ func (r *RepoFileInterface) Spec() core.RuleSpec {
 func (r *RepoFileInterface) Check(ctx *core.Context) []core.Violation {
 	layers := ctx.Arch().Layers
 	if !analysisutil.HasPortSublayer(layers) {
-		return nil
+		return []core.Violation{metaRuleDisabledByConfig("structural.repo-file-interface",
+			"LayerModel.PortLayers is empty; repo-file interface enforcement requires at least one port sublayer",
+			"declare PortLayers in your LayerModel (e.g. []string{\"core/repo\"}), or remove structural.NewRepoFileInterface() from your RuleSet")}
 	}
 	var violations []core.Violation
 	for _, pkg := range ctx.Pkgs() {

--- a/rules/structural/repo_file_interface_test.go
+++ b/rules/structural/repo_file_interface_test.go
@@ -126,6 +126,23 @@ func TestRepoFileInterfaceExtraInterfaceFixUsesSnakeCase(t *testing.T) {
 	}
 }
 
+func TestRepoFileInterfaceNoPortSublayerEmitsMetaDisabledByConfig(t *testing.T) {
+	arch := dddArch()
+	// Strip every port-shaped sublayer (named "repo"/"gateway" or listed in PortLayers)
+	// so analysisutil.HasPortSublayer returns false.
+	arch.Layers.PortLayers = nil
+	arch.Layers.Sublayers = []string{"handler", "app", "core", "core/model", "core/svc", "event", "infra"}
+	ctx := core.NewContext(nil, "github.com/example/app", "../../testdata/valid", arch, nil)
+
+	got := structural.NewRepoFileInterface().Check(ctx)
+	if len(got) != 1 || got[0].Rule != "meta.rule-disabled-by-config" {
+		t.Fatalf("expected exactly 1 meta.rule-disabled-by-config violation, got %+v", got)
+	}
+	if !strings.Contains(got[0].Message, "PortLayers is empty") {
+		t.Fatalf("meta message should mention PortLayers, got %q", got[0].Message)
+	}
+}
+
 func TestRepoFileInterfaceFlagsRepositoryPortOutsidePortLayer(t *testing.T) {
 	got := structural.NewRepoFileInterface().Check(invalidContextForRepoIface(t))
 

--- a/rules/tx/boundary.go
+++ b/rules/tx/boundary.go
@@ -74,8 +74,13 @@ func (r *Boundary) Spec() core.RuleSpec {
 }
 
 func (r *Boundary) Check(ctx *core.Context) []core.Violation {
-	if ctx == nil || (len(r.cfg.StartSymbols) == 0 && len(r.cfg.Types) == 0) {
+	if ctx == nil {
 		return nil
+	}
+	if len(r.cfg.StartSymbols) == 0 && len(r.cfg.Types) == 0 {
+		return []core.Violation{metaRuleDisabledByConfig(ruleID,
+			"tx.Config.StartSymbols and tx.Config.Types are both empty; boundary enforcement skipped",
+			"populate tx.Config with at least one start symbol (e.g. \"database/sql.(*DB).BeginTx\") or one tx type, or remove tx.New() from your RuleSet")}
 	}
 
 	allowed := r.allowedLayers()
@@ -205,6 +210,19 @@ func (r *Boundary) violation(rule, file string, line int, message, fix string) c
 		Fix:               fix,
 		DefaultSeverity:   r.severity,
 		EffectiveSeverity: r.severity,
+	}
+}
+
+// metaRuleDisabledByConfig signals that the rule is registered in the RuleSet
+// but the supplied core.Architecture configuration prevents it from running.
+// Severity defaults to Warning via the runner's meta.* prefix handling.
+func metaRuleDisabledByConfig(ruleID, reason, fix string) core.Violation {
+	return core.Violation{
+		Rule:              "meta.rule-disabled-by-config",
+		Message:           fmt.Sprintf("%s: %s", ruleID, reason),
+		Fix:               fix,
+		DefaultSeverity:   core.Warning,
+		EffectiveSeverity: core.Warning,
 	}
 }
 

--- a/rules/tx/boundary_test.go
+++ b/rules/tx/boundary_test.go
@@ -32,11 +32,12 @@ func TestBoundarySpec(t *testing.T) {
 	}
 }
 
-func TestBoundaryEmptyConfigNoop(t *testing.T) {
+func TestBoundaryEmptyConfigEmitsMeta(t *testing.T) {
 	rule := tx.New(tx.Config{})
 
-	if got := rule.Check(txBoundaryContext(t, nil)); len(got) != 0 {
-		t.Fatalf("Check() with empty config returned %d violations: %+v", len(got), got)
+	got := rule.Check(txBoundaryContext(t, nil))
+	if len(got) != 1 || got[0].Rule != "meta.rule-disabled-by-config" {
+		t.Fatalf("Check() with empty config: expected 1 meta.rule-disabled-by-config violation, got %+v", got)
 	}
 }
 


### PR DESCRIPTION
Closes #92.

## The bug

Several rules silently returned zero violations when an Architecture config flag or LayerModel field made their preconditions unmet. A user adding the rule to their RuleSet, seeing no output, would assume their codebase passes the check — when in fact **the rule never executed**.

> CI green = false peace.

This audit re-scanned every \`Check()\` body and found **9 silent-disable points** across 7 rules, three of which weren't documented in #92's original write-up:

### Newly discovered (not in original issue body)
- \`dependency.Isolation\` with \`Layout.DomainDir == ""\` (flat layout) → entire rule silent
- \`interfaces.CrossDomainAnonymous\` with \`Layout.DomainDir == ""\` → entire rule silent
- \`structural.RepoFileInterface\` with no port sublayer → entire rule silent

### Already in #92
- \`structural.Alias\` with \`!RequireAlias\` or \`DomainDir == ""\`
- \`structural.ModelRequired\` with \`!RequireModel\` or \`DomainDir == ""\`
- \`dependency.Isolation\` with \`!RequireAlias\` (sub-check: cmd-deep-import / orchestration-deep-import)
- \`interfaces.Pattern\` with \`maxMethods <= 0\` (sub-check: too-many-methods)
- \`tx.Boundary\` with empty \`tx.Config\`

## The fix

New meta violation ID **\`meta.rule-disabled-by-config\`** (Warning by default via the runner's meta.* prefix handling). Each silent-disable point now emits this meta with a precise message naming the offending config field plus a fix suggestion.

Example output before/after:

```
# Before
$ go test -run TestArchitecture
PASS  ✓  (silent — rule never ran)

# After
[WARNING] structural.alias: Structure.RequireAlias is false; alias enforcement skipped
fix: set Structure.RequireAlias = true, or remove structural.NewAlias() from your RuleSet
```

## Per-package helper

Added \`metaRuleDisabledByConfig(ruleID, reason, fix)\` to four packages (mirrors the existing \`metaLayoutNotSupported\` helper):

- \`rules/dependency/isolation.go\`
- \`rules/interfaces/layout_meta.go\`
- \`rules/structural/layout_meta.go\`
- \`rules/tx/boundary.go\`

Runner already dedupes meta by \`(Rule, Message)\`, so per-package sub-checks don't multiply noise.

## Preset cleanup (related)

5 presets called \`interfaces.NewPattern()\` without \`interfaces.WithMaxMethods(10)\` — that would now trigger the new meta for every consumer. Aligned all 8 presets to use \`interfaces.NewPattern(interfaces.WithMaxMethods(10))\` for consistency with DDD/CleanArch/Hexagonal.

## Test plan

- [x] 6 new regression tests covering each new emit point (Isolation flat / Isolation RequireAlias / CrossDomainAnonymous flat / RepoFileInterface no-port / Pattern WithMaxMethods missing / Pattern WithMaxMethods present)
- [x] 4 existing tests adapted (TestAlias/skips_non-DDD_architecture, TestModelRequired/skips_non-DDD_architecture, TestBoundaryEmptyConfigNoop → renamed *EmitsMeta, TestPatternHonorsInterfacePatternExclude — filter the new meta)
- [x] \`go test ./...\` green
- [x] \`make lint\` 0 issues

## Out of scope (intentionally NOT emitting meta)

| Case | Why |
|---|---|
| \`BlastRadius < 5 internal packages\` | Statistical analysis legitimately needs sample size; not a misconfiguration |
| \`TypePattern\` empty \`Structure.TypePatterns\` | Rule is fundamentally opt-in via TypePatterns config; empty means "nothing to enforce", not misconfig. Adding meta here would noise every domain preset that bundles the rule without patterns. |
| \`os.ReadDir\` errors | Environmental, not the rule's responsibility |
| \`ctx == nil\` defensive checks | Shouldn't occur in practice; defensive only |

## Breaking change

**No breaking change.** New meta IDs are additive. Consumers seeing new warnings should fix their configuration (the message names exactly what to change). Anyone wanting to silence: \`core.WithSeverityOverride("meta.rule-disabled-by-config", ...)\` or \`RuleSet.Without("meta.rule-disabled-by-config")\`.