### PR TITLE
refactor(rules): make repo-port suffix configurable; document layer-placement vocabulary

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -853,6 +853,7 @@ go run github.com/NamhaeSusan/go-arch-guard/cmd/tui --preset hexagonal .
 | `naming.NewNoStutter()` / `NewImplSuffix()` / `NewSnakeCaseFiles()` / `NewNoLayerSuffix()` / `NewTypePattern()` | 네이밍 규칙 |
 | `testpolicy.NewNoHandMock()` | 테스트 정책 규칙 |
 | `structural.NewAlias()` / `NewLayerPlacement()` / `NewBannedPackage()` / `NewModelRequired()` / `NewInternalTopLevel()` / `NewRepoFileInterface()` | 구조 규칙 |
+| `structural.WithRepoPortSuffixes(...)` | `structural.NewRepoFileInterface`의 repository-port 인터페이스 이름 suffix 옵션. 기본값은 `Repository`, `Repo`; 빈 suffix는 무시 |
 | `interfaces.NewPattern()` / `NewContainer()` / `NewCrossDomainAnonymous()` / `NewTooManyMethods()` | 인터페이스 규칙 |
 | `interfaces.WithMaxMethods(n)` | `interfaces.NewTooManyMethods`의 인터페이스 메서드 상한 옵션. 옵션 미지정 시 기본 10; n ≤ 0이면 fallback 10. 다른 interfaces.New*() 룰에 넘기면 silently 무시 |
 | `tx.New(tx.Config{...})` | 트랜잭션 경계 검사 (옵트인) |

--- a/README.ko.md
+++ b/README.ko.md
@@ -546,14 +546,17 @@ order.go          올바름
 
 ### `structural.interface-placement` (DDD만)
 
-Repository 포트 인터페이스(이름이 `Repository` 또는 `Repo`로 끝나는 것)는
-`core/repo/`에만 정의해야 합니다. Consumer-defined interface(사용처에서
-작은 인터페이스를 선언하는 Go 관례)는 `handler/`, `app/`, `svc/` 등
-사용처 어디든 허용됩니다.
+Repository 포트 인터페이스(기본값: 이름이 `Repository` 또는 `Repo`로
+끝나는 것)는 `core/repo/`에만 정의해야 합니다. Consumer-defined
+interface(사용처에서 작은 인터페이스를 선언하는 Go 관례)는 `handler/`,
+`app/`, `svc/` 등 사용처 어디든 허용됩니다.
 
 `type X = otherdomain.Repo` 처럼 다른 도메인의 repository 인터페이스를
 재노출하는 alias도 함께 감지합니다 — 이런 cross-domain 경계 코드는
 `orchestration/`에 두어야 합니다.
+
+다른 어휘를 쓰려면 `structural.WithRepoPortSuffixes("Gateway", "Adapter", ...)`
+옵션으로 suffix를 지정할 수 있습니다 (기본값: `["Repository", "Repo"]`).
 
 ### `naming.type-pattern-mismatch` (flat 프리셋)
 

--- a/README.md
+++ b/README.md
@@ -895,6 +895,7 @@ Features: health-status tree coloring, imports/reverse dependencies/coupling met
 | `dependency.NewIsolation()` / `NewLayerDirection()` / `NewBlastRadius()` | dependency rules |
 | `naming.NewNoStutter()` / `NewImplSuffix()` / `NewSnakeCaseFiles()` / `NewNoLayerSuffix()` / `NewTypePattern()` | naming rules |
 | `structural.NewAlias()` / `NewLayerPlacement()` / `NewBannedPackage()` / `NewModelRequired()` / `NewInternalTopLevel()` / `NewRepoFileInterface()` | structure rules |
+| `structural.WithRepoPortSuffixes(...)` | option for `structural.NewRepoFileInterface` setting repository-port interface name suffixes. Default is `Repository`, `Repo`; blank suffixes are ignored. |
 | `interfaces.NewPattern()` / `NewContainer()` / `NewCrossDomainAnonymous()` / `NewTooManyMethods()` | interface rules |
 | `testpolicy.NewNoHandMock()` | test policy rules |
 | `interfaces.WithMaxMethods(n)` | option for `interfaces.NewTooManyMethods` setting the per-interface method cap. Default 10 when the option is omitted; n ≤ 0 also falls back to 10. Silently ignored if passed to other interfaces.New*() rules. |

--- a/README.md
+++ b/README.md
@@ -576,13 +576,16 @@ order.go          correct
 
 ### `structural.interface-placement` (DDD only)
 
-Repository-port interfaces — names ending in `Repository` or `Repo` — must be
-defined in `core/repo/`, not scattered across layers. Consumer-defined
+Repository-port interfaces — names ending in `Repository` or `Repo` by default
+— must be defined in `core/repo/`, not scattered across layers. Consumer-defined
 interfaces (the Go idiom where a package declares the small interface it
 consumes) are allowed anywhere they are used: `handler/`, `app/`, `svc/`, etc.
 
 Also flags `type X = otherdomain.Repo` aliases that re-export a repository
 interface across domain boundaries — those belong in `orchestration/`.
+
+Pass `structural.WithRepoPortSuffixes("Gateway", "Adapter", ...)` to match a
+different vocabulary; default is `["Repository", "Repo"]`.
 
 ### `naming.type-pattern-mismatch` (flat presets)
 

--- a/plugins/go-arch-guard/skills/go-arch-guard/SKILL.md
+++ b/plugins/go-arch-guard/skills/go-arch-guard/SKILL.md
@@ -376,7 +376,7 @@ fmt.Println(string(data))
 
 ## DDD 전용: Cross-Domain Interface 금지
 
-Repository 포트 interface(이름이 `Repository`/`Repo`로 끝나는 것)는 **`core/repo/`에만** 정의 가능. Consumer-defined interface(사용처에서 선언하는 Go 관례)는 `handler/`, `app/`, `svc/` 어디든 허용. cross-domain 데이터 필요 시 → `orchestration/handler/`로 이동.
+Repository 포트 interface(기본값: 이름이 `Repository`/`Repo`로 끝나는 것)는 **`core/repo/`에만** 정의 가능. Consumer-defined interface(사용처에서 선언하는 Go 관례)는 `handler/`, `app/`, `svc/` 어디든 허용. cross-domain 데이터 필요 시 → `orchestration/handler/`로 이동. 다른 어휘(`Gateway`, `Adapter` 등) 쓰는 팀은 `structural.WithRepoPortSuffixes(...)`로 매칭 suffix 지정 가능.
 
 | 우회 시도 | 잡는 규칙 |
 |----------|----------|

--- a/rules/structural/layer_placement.go
+++ b/rules/structural/layer_placement.go
@@ -13,10 +13,26 @@ const (
 	misplacedLayer     = "structural.misplaced-layer"
 )
 
-// LayerPlacement flags layer-named directories (currently "app", "infra",
-// "handler") that appear outside their configured slice. The rule still
-// hard-codes these three names; full configurability via LayerDirNames is
-// tracked in #93.
+// LayerPlacement flags layer-named directories that appear outside their
+// allowed slice. It enforces a fixed vocabulary of three layer names —
+// "app", "infra", "handler" — each with its own ad-hoc placement logic:
+//
+//   - "app": allowed at internal/<Layout.AppDir> or per-domain
+//     internal/<DomainDir>/<X>/app/
+//   - "infra": allowed only as per-domain
+//     internal/<DomainDir>/<X>/infra/. Global internal/infra/ is rejected
+//     by design (the library opts the team into per-domain infra).
+//   - "handler": allowed under internal/<ServerDir>/, in
+//     internal/<OrchestrationDir>/handler/, or as per-domain
+//     internal/<DomainDir>/<X>/handler/.
+//
+// LayerDirNames can narrow the active set (only names present in the map
+// are checked) but cannot add new names — directory names other than the
+// three above silently pass. Teams using a different vocabulary
+// (e.g. "controller", "usecase", "port") get no protection from this rule.
+//
+// Generalizing to fully data-driven placement (LayerLocations on
+// LayerModel) is tracked in issue #104.
 type LayerPlacement struct {
 	severity core.Severity
 }

--- a/rules/structural/option.go
+++ b/rules/structural/option.go
@@ -1,16 +1,35 @@
 package structural
 
-import "github.com/NamhaeSusan/go-arch-guard/core"
+import (
+	"slices"
+
+	"github.com/NamhaeSusan/go-arch-guard/core"
+)
 
 type Option func(*ruleConfig)
 
 type ruleConfig struct {
-	severity core.Severity
+	severity         core.Severity
+	repoPortSuffixes []string
 }
 
 func WithSeverity(severity core.Severity) Option {
 	return func(cfg *ruleConfig) {
 		cfg.severity = severity
+	}
+}
+
+// WithRepoPortSuffixes sets the suffix list used by
+// structural.NewRepoFileInterface to detect repository-port interface names.
+// Default is ["Repository", "Repo"]; pass alternates such as "Gateway",
+// "Adapter", or "Port" to match a different vocabulary.
+//
+// Other structural.New*() rules silently ignore this option to keep the
+// option API uniform across the package. Empty/nil suffixes are treated as
+// "use the default".
+func WithRepoPortSuffixes(suffixes ...string) Option {
+	return func(cfg *ruleConfig) {
+		cfg.repoPortSuffixes = slices.Clone(suffixes)
 	}
 }
 

--- a/rules/structural/option.go
+++ b/rules/structural/option.go
@@ -29,8 +29,18 @@ func WithSeverity(severity core.Severity) Option {
 // "use the default".
 func WithRepoPortSuffixes(suffixes ...string) Option {
 	return func(cfg *ruleConfig) {
-		cfg.repoPortSuffixes = slices.Clone(suffixes)
+		cfg.repoPortSuffixes = nonBlankStrings(suffixes)
 	}
+}
+
+func nonBlankStrings(in []string) []string {
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if s != "" {
+			out = append(out, s)
+		}
+	}
+	return slices.Clip(out)
 }
 
 func newConfig(opts []Option, severity core.Severity) ruleConfig {

--- a/rules/structural/repo_file_interface.go
+++ b/rules/structural/repo_file_interface.go
@@ -13,12 +13,34 @@ import (
 )
 
 type RepoFileInterface struct {
-	severity core.Severity
+	severity     core.Severity
+	portSuffixes []string
 }
+
+var defaultRepoPortSuffixes = []string{"Repository", "Repo"}
 
 func NewRepoFileInterface(opts ...Option) *RepoFileInterface {
 	cfg := newConfig(opts, core.Error)
-	return &RepoFileInterface{severity: cfg.severity}
+	return &RepoFileInterface{
+		severity:     cfg.severity,
+		portSuffixes: cfg.repoPortSuffixes,
+	}
+}
+
+func (r *RepoFileInterface) suffixes() []string {
+	if len(r.portSuffixes) == 0 {
+		return defaultRepoPortSuffixes
+	}
+	return r.portSuffixes
+}
+
+func (r *RepoFileInterface) isRepoPortName(name string) bool {
+	for _, suf := range r.suffixes() {
+		if strings.HasSuffix(name, suf) {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *RepoFileInterface) Spec() core.RuleSpec {
@@ -109,7 +131,7 @@ func (r *RepoFileInterface) checkInterfacePlacement(ctx *core.Context, pkg *pack
 			continue
 		}
 		for _, info := range analysisutil.InspectTypeSpecs(file, pkg.Fset) {
-			if info.IsInterface && isRepoPortName(info.Name) {
+			if info.IsInterface && r.isRepoPortName(info.Name) {
 				violations = append(violations, r.violation(
 					filePath,
 					info.Line,
@@ -166,10 +188,6 @@ func collectInterfacesFromFile(file *ast.File) map[string]*ast.InterfaceType {
 
 func isDomainPackage(arch core.Architecture, pkgPath string) bool {
 	return arch.Layout.DomainDir != "" && strings.Contains(pkgPath, "/"+arch.Layout.InternalRoot+"/"+arch.Layout.DomainDir+"/")
-}
-
-func isRepoPortName(name string) bool {
-	return strings.HasSuffix(name, "Repository") || strings.HasSuffix(name, "Repo")
 }
 
 var _ core.Rule = (*RepoFileInterface)(nil)

--- a/rules/structural/repo_file_interface_test.go
+++ b/rules/structural/repo_file_interface_test.go
@@ -143,6 +143,55 @@ func TestRepoFileInterfaceNoPortSublayerEmitsMetaDisabledByConfig(t *testing.T) 
 	}
 }
 
+func TestRepoFileInterfaceWithRepoPortSuffixesOverrideMatchesAlternateVocabulary(t *testing.T) {
+	// Default suffixes are ["Repository", "Repo"]. With WithRepoPortSuffixes,
+	// the rule should match a project that names its ports *Gateway instead.
+	ctx := tempContextForRepoIface(t, map[string]string{
+		"internal/domain/order/core/svc/svc.go": `package svc
+
+type OrderGateway interface {
+	Find() string
+}
+`,
+	}, dddArch())
+
+	got := structural.NewRepoFileInterface(structural.WithRepoPortSuffixes("Gateway")).Check(ctx)
+
+	var found bool
+	for _, v := range got {
+		if v.Rule == "structural.interface-placement" && strings.Contains(v.Message, `"OrderGateway"`) {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected interface-placement violation for OrderGateway, got %+v", got)
+	}
+}
+
+func TestRepoFileInterfaceWithRepoPortSuffixesEmptyFallsBackToDefault(t *testing.T) {
+	// Empty suffix slice should fall back to the default ["Repository", "Repo"].
+	ctx := tempContextForRepoIface(t, map[string]string{
+		"internal/domain/order/core/svc/svc.go": `package svc
+
+type OrderRepository interface {
+	Find() string
+}
+`,
+	}, dddArch())
+
+	got := structural.NewRepoFileInterface(structural.WithRepoPortSuffixes()).Check(ctx)
+
+	var found bool
+	for _, v := range got {
+		if v.Rule == "structural.interface-placement" && strings.Contains(v.Message, `"OrderRepository"`) {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected interface-placement violation for OrderRepository (default suffixes), got %+v", got)
+	}
+}
+
 func TestRepoFileInterfaceFlagsRepositoryPortOutsidePortLayer(t *testing.T) {
 	got := structural.NewRepoFileInterface().Check(invalidContextForRepoIface(t))
 

--- a/rules/structural/repo_file_interface_test.go
+++ b/rules/structural/repo_file_interface_test.go
@@ -192,6 +192,45 @@ type OrderRepository interface {
 	}
 }
 
+func TestRepoFileInterfaceWithRepoPortSuffixesBlankIgnored(t *testing.T) {
+	// Blank suffixes must not make every interface name match via
+	// strings.HasSuffix(name, ""). The remaining non-blank suffix should
+	// still apply.
+	ctx := tempContextForRepoIface(t, map[string]string{
+		"internal/domain/order/core/svc/svc.go": `package svc
+
+type LocalReader interface {
+	Read() string
+}
+
+type OrderGateway interface {
+	Find() string
+}
+`,
+	}, dddArch())
+
+	got := structural.NewRepoFileInterface(structural.WithRepoPortSuffixes("", "Gateway")).Check(ctx)
+
+	var localReader, orderGateway bool
+	for _, v := range got {
+		if v.Rule != "structural.interface-placement" {
+			continue
+		}
+		if strings.Contains(v.Message, `"LocalReader"`) {
+			localReader = true
+		}
+		if strings.Contains(v.Message, `"OrderGateway"`) {
+			orderGateway = true
+		}
+	}
+	if localReader {
+		t.Fatalf("blank suffix must not match LocalReader; got %+v", got)
+	}
+	if !orderGateway {
+		t.Fatalf("expected interface-placement violation for OrderGateway, got %+v", got)
+	}
+}
+
 func TestRepoFileInterfaceFlagsRepositoryPortOutsidePortLayer(t *testing.T) {
 	got := structural.NewRepoFileInterface().Check(invalidContextForRepoIface(t))
 


### PR DESCRIPTION
Resolves #93.

## Summary
- `structural.NewRepoFileInterface` gains `WithRepoPortSuffixes(...)` so teams using a different vocabulary (`*Gateway`, `*Adapter`, `*Port`, ...) can match their port interface names. Default stays `["Repository", "Repo"]`; empty/nil falls back to default; other `structural.New*()` rules silently ignore the option (existing package convention, mirroring `interfaces.WithMaxMethods`).
- `LayerPlacement` godoc now states the supported vocabulary (`app`, `infra`, `handler`) and the stealth opinion that global `internal/infra/` is rejected by design — making implicit behavior explicit instead of leaving it for users to discover via violations.

## Why this scope (and not the full #93 inventory)
- Items 2 & 3: not actually hardcodes (rule definition / message already generic).
- Item 5: already resolved in #101.
- Item 4 (tx default `"app"`): split out to #103. Cosmetic; `tx.boundary` is opt-in and most projects use `Layout.AppDir = "app"`.
- Item 6 (full generalization to `LayerLocations`): split out to #104. Primary consumer (drb-server) uses exactly the hardcoded vocabulary, so cost/benefit isn't there yet — godoc is updated for honesty in the meantime.

## Test plan
- [x] go test ./... — all pass
- [x] make lint — 0 issues
- [x] New tests cover: default suffixes still work; custom suffix matches *Gateway; empty WithRepoPortSuffixes() falls back to default