### PR TITLE
Fix empty-context structural check fallback

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -66,7 +66,7 @@ violations := core.Run(ctx, presets.RecommendedDDD())
 report.AssertNoViolations(t, violations)
 ```
 
-`module`과 `root`에 빈 문자열을 넘기면 로드된 패키지에서 자동 추출합니다. 모듈을 확인할 수 없으면 `meta.no-matching-packages` Warning을 냅니다. rule이 panic을 내면 `core.Run`은 `meta.rule-panic` Error violation을 내고 나머지 rule 실행을 계속합니다.
+`module`과 `root`에 빈 문자열을 넘기면 `core.NewContext`가 로드된 패키지의 module metadata에서 두 값을 자동 추출합니다. 패키지 metadata가 없으면 추측하지 않고 빈 값으로 남기며, layout-dependent rule은 프로젝트 root를 임의로 추정하는 대신 `meta.layout-not-supported`를 낼 수 있습니다. rule이 panic을 내면 `core.Run`은 `meta.rule-panic` Error violation을 내고 나머지 rule 실행을 계속합니다.
 
 다른 프리셋은 `presets.Hexagonal()`과 `presets.RecommendedHexagonal()`처럼
 아키텍처와 권장 ruleset을 같은 프리셋으로 맞춰 사용합니다.
@@ -135,7 +135,7 @@ if err := arch.Validate(); err != nil {
 go test -run TestArchitecture -v
 ```
 
-`module`과 `root`에 빈 문자열을 전달하면 로드된 패키지에서 자동 추출합니다.
+`module`과 `root`에 빈 문자열을 전달하면 로드된 패키지의 module metadata에서 추출합니다. metadata가 없으면 값을 추측하지 않고 빈 값으로 남기며, layout-dependent rule은 `meta.layout-not-supported`를 낼 수 있습니다.
 
 ## 프리셋
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ report.AssertNoViolations(t, violations)
 Use the matching architecture and recommended ruleset for other presets, for example
 `presets.Hexagonal()` with `presets.RecommendedHexagonal()`.
 
+Passing empty strings for `module` and `root` asks `core.NewContext` to derive
+both values from loaded package module metadata. If package metadata is not
+available, the values stay empty and layout-dependent rules may report
+`meta.layout-not-supported` instead of guessing a project root.
+
 ### Per-rule control (DDD example)
 
 For finer control over individual checks, compose a `core.RuleSet` manually:
@@ -146,7 +151,7 @@ Sample output when violations exist:
 --- FAIL: TestArchitecture/domain_isolation
 ```
 
-Pass empty strings for `module` and `root` to auto-extract from loaded packages. If the module cannot be determined, a `meta.no-matching-packages` warning is emitted. If a rule panics, `core.Run` emits `meta.rule-panic` with Error severity and continues running the remaining rules.
+Pass empty strings for `module` and `root` to derive them from loaded package module metadata. If metadata is unavailable, the values remain empty rather than being guessed; layout-dependent rules may emit `meta.layout-not-supported`. If a rule panics, `core.Run` emits `meta.rule-panic` with Error severity and continues running the remaining rules.
 
 ## Presets
 

--- a/core/context.go
+++ b/core/context.go
@@ -25,6 +25,8 @@ type Context struct {
 // clone, but cloning here closes the construction-time window where a
 // caller could otherwise mutate shared state before the first Arch() read.
 func NewContext(pkgs []*packages.Package, module, root string, arch Architecture, exclude []string) *Context {
+	module, root = resolveContextDefaults(pkgs, module, root)
+
 	norm := make([]string, len(exclude))
 	for i, p := range exclude {
 		norm[i] = normalizeMatchPath(p)
@@ -36,6 +38,27 @@ func NewContext(pkgs []*packages.Package, module, root string, arch Architecture
 		arch:    cloneArchitecture(arch),
 		exclude: norm,
 	}
+}
+
+func resolveContextDefaults(pkgs []*packages.Package, module, root string) (string, string) {
+	if module != "" && root != "" {
+		return module, root
+	}
+	for _, pkg := range pkgs {
+		if pkg == nil || pkg.Module == nil {
+			continue
+		}
+		if module == "" && pkg.Module.Path != "" {
+			module = pkg.Module.Path
+		}
+		if root == "" && pkg.Module.Dir != "" {
+			root = pkg.Module.Dir
+		}
+		if module != "" && root != "" {
+			return module, root
+		}
+	}
+	return module, root
 }
 
 // Pkgs returns the loaded packages. Treat the returned *packages.Package

--- a/core/context_test.go
+++ b/core/context_test.go
@@ -24,6 +24,39 @@ func TestNewContextStoresInputs(t *testing.T) {
 	}
 }
 
+func TestNewContextDerivesModuleAndRootFromPackageModuleMetadata(t *testing.T) {
+	pkgs := []*packages.Package{
+		nil,
+		{},
+		{Module: &packages.Module{}},
+		{Module: &packages.Module{Path: "example.com/app", Dir: "/repo/app"}},
+	}
+
+	c := NewContext(pkgs, "", "", validArchitecture(), nil)
+
+	if c.Module() != "example.com/app" {
+		t.Errorf("Module() = %q, want %q", c.Module(), "example.com/app")
+	}
+	if c.Root() != "/repo/app" {
+		t.Errorf("Root() = %q, want %q", c.Root(), "/repo/app")
+	}
+}
+
+func TestNewContextPreservesExplicitModuleAndRoot(t *testing.T) {
+	pkgs := []*packages.Package{
+		{Module: &packages.Module{Path: "example.com/derived", Dir: "/repo/derived"}},
+	}
+
+	c := NewContext(pkgs, "example.com/explicit", "/repo/explicit", validArchitecture(), nil)
+
+	if c.Module() != "example.com/explicit" {
+		t.Errorf("Module() = %q, want explicit value", c.Module())
+	}
+	if c.Root() != "/repo/explicit" {
+		t.Errorf("Root() = %q, want explicit value", c.Root())
+	}
+}
+
 func TestContextIsExcludedExactMatch(t *testing.T) {
 	c := NewContext(nil, "", "", Architecture{}, []string{"internal/handler/foo.go"})
 	if !c.IsExcluded("internal/handler/foo.go") {

--- a/docs/model-concepts.md
+++ b/docs/model-concepts.md
@@ -26,6 +26,11 @@ ctx := core.NewContext(pkgs, "", "", arch, nil)
 violations := core.Run(ctx, presets.RecommendedDDD())
 ```
 
+When `module` and `root` are empty, `core.NewContext` derives them from the
+loaded packages' module metadata (`packages.Package.Module.Path` and `Dir`).
+Explicit non-empty arguments always win. If metadata is unavailable, context
+keeps the empty value instead of guessing from import or file paths.
+
 ## LayerModel
 
 `LayerModel` owns the layer vocabulary. `Sublayers` is the single source of

--- a/rules/structural/layout_meta_test.go
+++ b/rules/structural/layout_meta_test.go
@@ -1,9 +1,12 @@
 package structural_test
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/NamhaeSusan/go-arch-guard/analyzer"
 	"github.com/NamhaeSusan/go-arch-guard/core"
 	"github.com/NamhaeSusan/go-arch-guard/rules/structural"
 )
@@ -53,5 +56,39 @@ func TestStructuralRulesNoMetaOnDDDLayout(t *testing.T) {
 				t.Fatalf("internal/-based project must not emit meta.layout-not-supported: %s", v.String())
 			}
 		}
+	}
+}
+
+func TestStructuralRuleUsesRootDerivedByContext(t *testing.T) {
+	root := t.TempDir()
+	module := "example.com/derive-root"
+	writeLayoutMetaFile(t, filepath.Join(root, "go.mod"), "module "+module+"\n\ngo 1.25.0\n")
+	writeLayoutMetaFile(t, filepath.Join(root, "internal", "domain", "order", "alias.go"), "package order\n")
+	writeLayoutMetaFile(t, filepath.Join(root, "internal", "domain", "order", "core", "model", "order.go"), "package model\n")
+	writeLayoutMetaFile(t, filepath.Join(root, "internal", "config", "config.go"), "package config\n")
+
+	pkgs, err := analyzer.Load(root, "internal/...")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := core.NewContext(pkgs, "", "", dddArch(), nil)
+	violations := core.Run(ctx, core.NewRuleSet(structural.NewInternalTopLevel()))
+
+	for _, v := range violations {
+		if v.Rule == "meta.layout-not-supported" {
+			t.Fatalf("expected derived root to enable structural checks, got meta violation: %s", v.String())
+		}
+	}
+	assertViolation(t, violations, "structural.internal-top-level", "internal/config/")
+}
+
+func writeLayoutMetaFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
## Summary
- Derive `core.Context` module/root from loaded package module metadata when callers pass empty values
- Preserve explicit module/root overrides
- Add regression coverage proving structural checks no longer collapse into `meta.layout-not-supported`

Closes #106

## Verification
- `go test ./core ./rules/structural`
- `go test -count=1 ./...`
- Architect verification: APPROVED
- Deslop pass: scoped to changed files; no broad refactor needed
