### PR TITLE
Enable Hexagonal repo-port enforcement explicitly

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -190,7 +190,7 @@ arch := core.Architecture{
 |------|------|
 | `LayerModel.Sublayers` | authoritative 서브레이어 경로 목록 (`"core/repo"`); direction/port/contract 룰의 권위 |
 | `LayerModel.Direction` | 허용 import 방향 매트릭스 (key는 `Sublayers`에 있어야 함) |
-| `LayerModel.PortLayers` | repo/gateway 같은 순수 인터페이스 레이어 (`Sublayers`에 있어야 함) |
+| `LayerModel.PortLayers` | repo, gateway, Hexagonal port 같은 순수 인터페이스 레이어 (`Sublayers`에 있어야 함; `port`는 명시적으로 listed되지 않으면 추론하지 않음) |
 | `LayerModel.ContractLayers` | 계약 레이어; `PortLayers`의 superset이어야 함 |
 | `LayerModel.PkgRestricted` | 공유 패키지 import 금지 서브레이어 |
 | `LayerModel.InternalTopLevel` | 패키지 루트 아래 허용 최상위 디렉토리 |
@@ -489,19 +489,21 @@ order_service.go  올바름
 
 ### `structural.repo-file-interface-missing`
 
-`repo/` (또는 `core/repo/`) 파일은 파일명과 일치하는 인터페이스를 포함해야 합니다.
+설정된 port layer(`core/repo/`, `gateway/`, Hexagonal `port/` 등)의 파일은
+파일명에 대응하는 인터페이스를 포함해야 합니다.
 
 ```go
-// repo/order.go는 다음을 정의해야:
-type Order interface { ... }  // 파일명과 일치
+// port layer의 order.go는 다음 인터페이스를 정의해야 함:
+type Order interface { ... } // 파일명과 일치
 ```
 
 ### `structural.repo-file-extra-interface`
 
-`repo/` 파일에는 인터페이스가 정확히 1개만 있어야 합니다. 추가 인터페이스는 별도 파일로 분리하세요.
+설정된 port layer의 각 파일에는 인터페이스가 정확히 1개만 있어야 합니다.
+추가 인터페이스는 별도 파일로 분리하세요.
 
 ```go
-// repo/review.go
+// core/repo/review.go 또는 port/review.go
 type Review interface { Find() }   // 올바름
 type Helper interface { Assist() } // 위반: helper.go로 이동
 ```
@@ -544,14 +546,16 @@ order_service.go  "_service" 접미사 불필요
 order.go          올바름
 ```
 
-### `structural.interface-placement` (DDD만)
+### `structural.interface-placement`
 
-Repository 포트 인터페이스(기본값: 이름이 `Repository` 또는 `Repo`로
-끝나는 것)는 `core/repo/`에만 정의해야 합니다. Consumer-defined
-interface(사용처에서 작은 인터페이스를 선언하는 Go 관례)는 `handler/`,
-`app/`, `svc/` 등 사용처 어디든 허용됩니다.
+Repository-port 인터페이스(기본값: 이름이 `Repository` 또는 `Repo`로
+끝나는 것)는 아키텍처가 설정한 port layer(DDD는 `core/repo/`, Clean
+Architecture는 `gateway/`, Hexagonal은 `port/`)에 정의해야 하며, 다른
+레이어에 흩어져 있으면 안 됩니다. Consumer-defined interface(사용처에서
+작은 인터페이스를 선언하는 Go 관례)는 `handler/`, `app/`, `usecase/`,
+`svc/` 등 사용처 어디든 허용됩니다.
 
-`type X = otherdomain.Repo` 처럼 다른 도메인의 repository 인터페이스를
+`type X = otherdomain.Repo`처럼 port layer의 repository 인터페이스를
 재노출하는 alias도 함께 감지합니다 — 이런 cross-domain 경계 코드는
 `orchestration/`에 두어야 합니다.
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Architecture fields:
 |-------|-------------|
 | `LayerModel.Sublayers` | authoritative layer-path vocabulary (`"core/repo"`); referenced by direction, port, and contract rules |
 | `LayerModel.Direction` | allowed import direction matrix (keys must be in `Sublayers`) |
-| `LayerModel.PortLayers` | pure interface layers such as repo or gateway (must be in `Sublayers`) |
+| `LayerModel.PortLayers` | pure interface layers such as repo, gateway, or Hexagonal port (must be in `Sublayers`; `port` is not inferred unless listed) |
 | `LayerModel.ContractLayers` | contract layers; must be a superset of `PortLayers` |
 | `LayerModel.PkgRestricted` | sublayers that must not import shared packages |
 | `LayerModel.InternalTopLevel` | allowed top-level directories under the package root |
@@ -519,19 +519,21 @@ order_service.go  correct
 
 ### `structural.repo-file-interface-missing`
 
-Files in `repo/` (or `core/repo/`) must contain an interface matching the filename.
+Files in a configured port layer (`core/repo/`, `gateway/`, Hexagonal `port/`,
+etc.) must contain an interface matching the filename.
 
 ```go
-// order.go in repo/ must define:
+// order.go in a port layer must define:
 type Order interface { ... }  // matches filename
 ```
 
 ### `structural.repo-file-extra-interface`
 
-Each file in `repo/` must define exactly one interface. Extra interfaces should be split into their own files.
+Each file in a configured port layer must define exactly one interface. Extra
+interfaces should be split into their own files.
 
 ```go
-// repo/review.go
+// core/repo/review.go or port/review.go
 type Review interface { Find() }   // correct
 type Helper interface { Assist() } // violation: move to helper.go
 ```
@@ -574,15 +576,18 @@ order_service.go  "_service" suffix is redundant
 order.go          correct
 ```
 
-### `structural.interface-placement` (DDD only)
+### `structural.interface-placement`
 
 Repository-port interfaces — names ending in `Repository` or `Repo` by default
-— must be defined in `core/repo/`, not scattered across layers. Consumer-defined
-interfaces (the Go idiom where a package declares the small interface it
-consumes) are allowed anywhere they are used: `handler/`, `app/`, `svc/`, etc.
+— must be defined in the architecture's configured port layer (`core/repo/` for
+DDD, `gateway/` for Clean Architecture, `port/` for Hexagonal), not scattered
+across layers. Consumer-defined interfaces (the Go idiom where a package
+declares the small interface it consumes) are allowed anywhere they are used:
+`handler/`, `app/`, `usecase/`, `svc/`, etc.
 
 Also flags `type X = otherdomain.Repo` aliases that re-export a repository
-interface across domain boundaries — those belong in `orchestration/`.
+interface from a port layer — cross-domain coordination belongs in
+`orchestration/`.
 
 Pass `structural.WithRepoPortSuffixes("Gateway", "Adapter", ...)` to match a
 different vocabulary; default is `["Repository", "Repo"]`.

--- a/core/analysisutil/sublayer_test.go
+++ b/core/analysisutil/sublayer_test.go
@@ -29,11 +29,14 @@ func TestPortAndContractSublayers(t *testing.T) {
 
 func TestFallbackSublayerMatching(t *testing.T) {
 	layers := core.LayerModel{
-		Sublayers: []string{"core/repo", "core/svc", "core/model"},
+		Sublayers: []string{"core/repo", "core/svc", "core/model", "port"},
 	}
 
 	if !IsPortSublayer(layers, "core/repo") {
 		t.Fatal("fallback port layer not detected")
+	}
+	if IsPortSublayer(layers, "port") {
+		t.Fatal("fallback port layer must not treat a literal port/ sublayer as a port unless PortLayers opts in")
 	}
 	if !IsContractSublayer(layers, "core/svc") {
 		t.Fatal("fallback contract layer not detected")
@@ -46,6 +49,24 @@ func TestFallbackSublayerMatching(t *testing.T) {
 	}
 	if got := PortSublayerName(layers); got != "core/repo" {
 		t.Fatalf("PortSublayerName() = %q", got)
+	}
+}
+
+func TestExplicitPortSublayerMatching(t *testing.T) {
+	layers := core.LayerModel{
+		Sublayers:      []string{"handler", "usecase", "port", "domain", "adapter"},
+		PortLayers:     []string{"port"},
+		ContractLayers: []string{"port"},
+	}
+
+	if !IsPortSublayer(layers, "port") {
+		t.Fatal("explicit PortLayers entry should mark port as a port sublayer")
+	}
+	if got := MatchPortSublayer(layers, "example.com/app/internal/domain/order/port"); got != "port" {
+		t.Fatalf("MatchPortSublayer() = %q, want port", got)
+	}
+	if got := PortSublayerName(layers); got != "port" {
+		t.Fatalf("PortSublayerName() = %q, want port", got)
 	}
 }
 

--- a/docs/model-concepts.md
+++ b/docs/model-concepts.md
@@ -35,7 +35,7 @@ truth: every field that names a layer must refer to a value in `Sublayers`.
 |-------|---------|
 | `Sublayers` | Authoritative list of layer names. Domain presets classify paths under each domain using this list; flat presets classify top-level `internal/` directories. |
 | `Direction` | Allowed import matrix. Every sublayer must have a key, even if the allowed target list is empty. |
-| `PortLayers` | Pure interface layers such as `core/repo`, `gateway`, or `port`. |
+| `PortLayers` | Pure interface layers such as `core/repo`, `gateway`, or explicitly configured `port`. The basename `port` is not inferred unless listed here. |
 | `ContractLayers` | Layers that expose contracts. Must include every entry in `PortLayers`. |
 | `PkgRestricted` | Layers that must not import the shared package tree. |
 | `InternalTopLevel` | Top-level directories allowed under `internal/`. Structure rules use this to catch accidental directories. |

--- a/docs/presets.md
+++ b/docs/presets.md
@@ -124,6 +124,15 @@ Hexagonal direction:
 | `domain` | nothing |
 | `adapter` | `port`, `domain` |
 
+`port` is explicitly configured as both `PortLayers` and `ContractLayers` for
+Hexagonal presets. This keeps repository-port interface checks active for
+`presets.RecommendedHexagonal()` while leaving `Structure.RequireAlias` false:
+Hexagonal projects do not have to expose domain-root `alias.go` packages.
+Repository-like interfaces (`*Repository`, `*Repo`, or custom suffixes) belong
+in `internal/domain/<domain>/port/`; consumer-defined interfaces in `usecase/`
+or adapter packages are not treated as repository ports unless their names
+match that configured vocabulary.
+
 ## Modular Monolith Layout
 
 ```text

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -689,7 +689,7 @@ func TestIntegration_RealWorldHexagonal(t *testing.T) {
 	writeIntegrationFile(t, filepath.Join(root, "internal", "domain", "order", "usecase", "create_order.go"),
 		"package usecase\n\nimport (\n\t_ \""+module+"/internal/domain/order/port\"\n\t_ \""+module+"/internal/domain/order/domain\"\n)\n")
 	writeIntegrationFile(t, filepath.Join(root, "internal", "domain", "order", "port", "repository.go"),
-		"package port\n\nimport _ \""+module+"/internal/domain/order/domain\"\n\ntype OrderRepo interface{ Save(id string) error }\n")
+		"package port\n\nimport _ \""+module+"/internal/domain/order/domain\"\n\ntype Repository interface{ Save(id string) error }\n")
 	writeIntegrationFile(t, filepath.Join(root, "internal", "domain", "order", "domain", "order.go"),
 		"package domain\n\ntype Order struct{ ID string }\n")
 	writeIntegrationFile(t, filepath.Join(root, "internal", "domain", "order", "adapter", "pg_order.go"),

--- a/presets/hexagonal.go
+++ b/presets/hexagonal.go
@@ -30,6 +30,8 @@ func Hexagonal() core.Architecture {
 				"controller": true, "service": true, "entity": true,
 				"store": true, "persistence": true,
 			},
+			PortLayers:     []string{"port"},
+			ContractLayers: []string{"port"},
 		},
 		Layout: core.LayoutModel{
 			DomainDir:        domainDir,

--- a/presets/presets_test.go
+++ b/presets/presets_test.go
@@ -50,6 +50,32 @@ func TestRecommendedRuleSetsAreNonEmpty(t *testing.T) {
 	}
 }
 
+func TestHexagonalDeclaresPortLayerWithoutAliasRequirement(t *testing.T) {
+	arch := presets.Hexagonal()
+
+	if arch.Structure.RequireAlias {
+		t.Fatal("Hexagonal().Structure.RequireAlias must remain false")
+	}
+	if got, want := arch.Layers.PortLayers, []string{"port"}; !sameStringSlice(got, want) {
+		t.Fatalf("Hexagonal().Layers.PortLayers = %v, want %v", got, want)
+	}
+	if got, want := arch.Layers.ContractLayers, []string{"port"}; !sameStringSlice(got, want) {
+		t.Fatalf("Hexagonal().Layers.ContractLayers = %v, want %v", got, want)
+	}
+}
+
+func sameStringSlice(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
 // TestRecommendedRuleSetsContainCoreRules pins the membership of each
 // recommended bundle so a silent rule deletion (e.g. dropping
 // dependency.NewLayerDirection from RecommendedDDD) breaks this test.

--- a/rules/structural/repo_file_interface.go
+++ b/rules/structural/repo_file_interface.go
@@ -2,7 +2,6 @@ package structural
 
 import (
 	"go/ast"
-	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -65,8 +64,8 @@ func (r *RepoFileInterface) Check(ctx *core.Context) []core.Violation {
 	}
 	var violations []core.Violation
 	for _, pkg := range ctx.Pkgs() {
-		if analysisutil.MatchPortSublayer(layers, pkg.PkgPath) != "" {
-			violations = append(violations, r.checkPortPackage(ctx, pkg)...)
+		if portLayer := analysisutil.MatchPortSublayer(layers, pkg.PkgPath); portLayer != "" {
+			violations = append(violations, r.checkPortPackage(ctx, pkg, portLayer)...)
 			continue
 		}
 		violations = append(violations, r.checkInterfacePlacement(ctx, pkg)...)
@@ -74,8 +73,9 @@ func (r *RepoFileInterface) Check(ctx *core.Context) []core.Violation {
 	return violations
 }
 
-func (r *RepoFileInterface) checkPortPackage(ctx *core.Context, pkg *packages.Package) []core.Violation {
+func (r *RepoFileInterface) checkPortPackage(ctx *core.Context, pkg *packages.Package, portLayer string) []core.Violation {
 	var violations []core.Violation
+	portDisplay := layerDisplay(portLayer)
 	for _, file := range pkg.Syntax {
 		filename := pkg.Fset.Position(file.Pos()).Filename
 		base := filepath.Base(filename)
@@ -93,7 +93,7 @@ func (r *RepoFileInterface) checkPortPackage(ctx *core.Context, pkg *packages.Pa
 				relPath,
 				0,
 				"structural.repo-file-interface-missing",
-				`file "`+base+`" in repo/ must contain interface "`+expected+`"`,
+				`file "`+base+`" in `+portDisplay+`/ must contain interface "`+expected+`"`,
 				`add "type `+expected+` interface { ... }" or rename the file`,
 			))
 		}
@@ -111,7 +111,7 @@ func (r *RepoFileInterface) checkPortPackage(ctx *core.Context, pkg *packages.Pa
 			relPath,
 			0,
 			"structural.repo-file-extra-interface",
-			`file "`+base+`" in repo/ must define only "`+expected+`", found extra: `+strings.Join(extra, ", "),
+			`file "`+base+`" in `+portDisplay+`/ must define only "`+expected+`", found extra: `+strings.Join(extra, ", "),
 			"move each extra interface to its own file (e.g. "+analysisutil.PascalToSnake(extra[0])+".go)",
 		))
 	}
@@ -120,10 +120,13 @@ func (r *RepoFileInterface) checkPortPackage(ctx *core.Context, pkg *packages.Pa
 
 func (r *RepoFileInterface) checkInterfacePlacement(ctx *core.Context, pkg *packages.Package) []core.Violation {
 	arch := ctx.Arch()
-	if !arch.Structure.RequireAlias || !isDomainPackage(arch, pkg.PkgPath) {
+	sublayer, ok := domainSublayerForPackage(ctx.Module(), arch, pkg.PkgPath)
+	if !ok || analysisutil.IsPortSublayer(arch.Layers, sublayer) {
 		return nil
 	}
 	repoName := analysisutil.PortSublayerName(arch.Layers)
+	repoDisplay := layerDisplay(repoName)
+	currentDisplay := layerDisplay(sublayer)
 	var violations []core.Violation
 	for _, file := range pkg.Syntax {
 		filePath := analysisutil.RelativePathForPackage(pkg, pkg.Fset.Position(file.Pos()).Filename)
@@ -136,16 +139,16 @@ func (r *RepoFileInterface) checkInterfacePlacement(ctx *core.Context, pkg *pack
 					filePath,
 					info.Line,
 					"structural.interface-placement",
-					`interface "`+info.Name+`" matches repository-port naming and must be defined in `+repoName+`/, not in `+path.Base(path.Dir(pkg.PkgPath))+`/`,
-					"move to "+repoName+"/, or rename if it's a consumer-defined interface",
+					`interface "`+info.Name+`" matches repository-port naming and must be defined in `+repoDisplay+`/, not in `+currentDisplay+`/`,
+					"move to "+repoDisplay+"/, or rename if it's a consumer-defined interface",
 				))
 			}
-			if info.AliasFrom != "" && analysisutil.MatchPortSublayer(arch.Layers, info.AliasFrom) != "" {
+			if info.AliasFrom != "" && isPortPackage(ctx.Module(), arch, info.AliasFrom) {
 				violations = append(violations, r.violation(
 					filePath,
 					info.Line,
 					"structural.interface-placement",
-					`type alias "`+info.Name+`" re-exports interface from `+repoName+` - suspected cross-domain dependency; use `+arch.Layout.OrchestrationDir+`/ instead`,
+					`type alias "`+info.Name+`" re-exports interface from `+repoDisplay+`/ - repository-port contracts must stay in `+repoDisplay+`/`,
 					"remove alias and move cross-domain coordination to "+arch.Layout.OrchestrationDir+"/",
 				))
 			}
@@ -186,8 +189,50 @@ func collectInterfacesFromFile(file *ast.File) map[string]*ast.InterfaceType {
 	return result
 }
 
-func isDomainPackage(arch core.Architecture, pkgPath string) bool {
-	return arch.Layout.DomainDir != "" && strings.Contains(pkgPath, "/"+arch.Layout.InternalRoot+"/"+arch.Layout.DomainDir+"/")
+func isPortPackage(module string, arch core.Architecture, pkgPath string) bool {
+	sublayer, ok := domainSublayerForPackage(module, arch, pkgPath)
+	return ok && analysisutil.IsPortSublayer(arch.Layers, sublayer)
+}
+
+func domainSublayerForPackage(module string, arch core.Architecture, pkgPath string) (string, bool) {
+	module = strings.TrimSuffix(module, "/")
+	if module == "" || arch.Layout.InternalRoot == "" || arch.Layout.DomainDir == "" {
+		return "", false
+	}
+	internalPrefix := module + "/" + arch.Layout.InternalRoot + "/"
+	rel, ok := strings.CutPrefix(pkgPath, internalPrefix)
+	if !ok {
+		return "", false
+	}
+	domainPrefix := arch.Layout.DomainDir + "/"
+	domainRel, ok := strings.CutPrefix(rel, domainPrefix)
+	if !ok {
+		return "", false
+	}
+	_, layerRel, ok := strings.Cut(domainRel, "/")
+	if !ok || layerRel == "" {
+		return "", false
+	}
+	if sublayer, ok := knownSublayerForRel(arch.Layers.Sublayers, layerRel); ok {
+		return sublayer, true
+	}
+	return "", false
+}
+
+func knownSublayerForRel(sublayers []string, layerRel string) (string, bool) {
+	var best string
+	for _, sublayer := range sublayers {
+		if layerRel == sublayer || strings.HasPrefix(layerRel, sublayer+"/") {
+			if len(sublayer) > len(best) {
+				best = sublayer
+			}
+		}
+	}
+	return best, best != ""
+}
+
+func layerDisplay(sublayer string) string {
+	return strings.TrimSuffix(sublayer, "/")
 }
 
 var _ core.Rule = (*RepoFileInterface)(nil)

--- a/rules/structural/repo_file_interface_test.go
+++ b/rules/structural/repo_file_interface_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/NamhaeSusan/go-arch-guard/analyzer"
 	"github.com/NamhaeSusan/go-arch-guard/core"
+	"github.com/NamhaeSusan/go-arch-guard/presets"
 	"github.com/NamhaeSusan/go-arch-guard/rules/structural"
 	"golang.org/x/tools/go/packages"
 )
@@ -251,5 +252,130 @@ func TestRepoFileInterfaceFlagsRepositoryPortOutsidePortLayer(t *testing.T) {
 	}
 	if !direct || !alias {
 		t.Fatalf("direct=%v alias=%v, want both true; got %+v", direct, alias, got)
+	}
+}
+
+func TestRepoFileInterfaceHexagonalFlagsRepositoryPortOutsidePortWithoutRequireAlias(t *testing.T) {
+	arch := presets.Hexagonal()
+	if arch.Structure.RequireAlias {
+		t.Fatal("Hexagonal RequireAlias must stay false")
+	}
+	ctx := tempContextForRepoIface(t, map[string]string{
+		"internal/domain/order/port/repository.go": "package port\n\ntype Repository interface { Save() error }\n",
+		"internal/domain/order/usecase/order_repository.go": `package usecase
+
+type OrderRepository interface {
+	Find(id string) error
+}
+`,
+	}, arch)
+
+	got := structural.NewRepoFileInterface().Check(ctx)
+
+	var found bool
+	for _, v := range got {
+		if v.Rule == "meta.rule-disabled-by-config" {
+			t.Fatalf("hexagonal repo-file-interface must be active, got disabled meta: %+v", got)
+		}
+		if v.Rule == "structural.interface-placement" && strings.Contains(v.Message, `"OrderRepository"`) {
+			found = true
+			if !strings.Contains(v.Message, "port/") || strings.Contains(v.Message, "repo/") {
+				t.Fatalf("hexagonal placement message must point to port/, got %q", v.Message)
+			}
+			if !strings.Contains(v.Fix, "port/") {
+				t.Fatalf("hexagonal placement fix must point to port/, got %q", v.Fix)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected interface-placement violation for OrderRepository outside port/, got %+v", got)
+	}
+}
+
+func TestRepoFileInterfaceHexagonalValidPortPackageIsActiveAndClean(t *testing.T) {
+	ctx := tempContextForRepoIface(t, map[string]string{
+		"internal/domain/order/port/repository.go": "package port\n\ntype Repository interface { Save() error }\n",
+	}, presets.Hexagonal())
+
+	got := structural.NewRepoFileInterface().Check(ctx)
+	if len(got) != 0 {
+		t.Fatalf("valid hexagonal port package should be clean and not disabled, got %+v", got)
+	}
+}
+
+func TestRepoFileInterfaceHexagonalDoesNotFlagNonRepoOrNonDomainInterfaces(t *testing.T) {
+	ctx := tempContextForRepoIface(t, map[string]string{
+		"internal/domain/order/port/repository.go": "package port\n\ntype Repository interface { Save() error }\n",
+		"internal/domain/order/usecase/service.go": `package usecase
+
+type Service interface {
+	DoSomething() error
+}
+`,
+		"internal/orchestration/repository.go": `package orchestration
+
+type OrderRepository interface {
+	Coordinate() error
+}
+`,
+		"internal/pkg/repository.go": `package pkg
+
+type AuditRepository interface {
+	Write() error
+}
+`,
+		"internal/domain/order/policy/repository.go": `package policy
+
+type PolicyRepository interface {
+	Load() error
+}
+`,
+	}, presets.Hexagonal())
+
+	got := structural.NewRepoFileInterface().Check(ctx)
+	for _, v := range got {
+		if v.Rule == "structural.interface-placement" {
+			t.Fatalf("non-repo, non-domain, and unknown-domain-sublayer interfaces must not be flagged, got %+v", got)
+		}
+		if v.Rule == "meta.rule-disabled-by-config" {
+			t.Fatalf("hexagonal repo-file-interface must be active, got disabled meta: %+v", got)
+		}
+	}
+}
+
+func TestRepoFileInterfaceDoesNotTreatPortNameAsGlobalFallback(t *testing.T) {
+	arch := presets.Hexagonal()
+	arch.Layers.PortLayers = nil
+	arch.Layers.ContractLayers = nil
+	ctx := tempContextForRepoIface(t, map[string]string{
+		"internal/domain/order/port/repository.go": "package port\n\ntype Repository interface { Save() error }\n",
+		"internal/domain/order/usecase/order_repository.go": `package usecase
+
+type OrderRepository interface {
+	Find(id string) error
+}
+`,
+	}, arch)
+
+	got := structural.NewRepoFileInterface().Check(ctx)
+	if len(got) != 1 || got[0].Rule != "meta.rule-disabled-by-config" {
+		t.Fatalf("custom port sublayer without explicit PortLayers must not be activated by fallback, got %+v", got)
+	}
+}
+
+func TestRepoFileInterfaceHexagonalPortDiagnosticsUseMatchedLayer(t *testing.T) {
+	ctx := tempContextForRepoIface(t, map[string]string{
+		"internal/domain/order/port/order_repository.go": "package port\n\nfunc NotAnInterface() {}\n",
+	}, presets.Hexagonal())
+
+	got := structural.NewRepoFileInterface().Check(ctx)
+	if len(got) != 1 || got[0].Rule != "structural.repo-file-interface-missing" {
+		t.Fatalf("expected one missing-interface violation, got %+v", got)
+	}
+	if !strings.Contains(got[0].Message, "port/") {
+		t.Fatalf("hexagonal port diagnostic should name port/, got %q", got[0].Message)
+	}
+	if strings.Contains(got[0].Message, "repo/") {
+		t.Fatalf("hexagonal port diagnostic must not use hard-coded repo/, got %q", got[0].Message)
 	}
 }


### PR DESCRIPTION
## Summary
- Configure Hexagonal `port` as an explicit `PortLayer` and `ContractLayer` while keeping `RequireAlias` false
- Decouple repo-port placement enforcement from alias policy using module/internal/domain sublayer classification
- Preserve no-global-port-fallback behavior and update Hexagonal docs/tests

Closes #107

## Verification
- `go test ./core ./core/analysisutil ./rules/structural ./presets ./integration`
- `go vet ./...`
- `go test -count=1 ./...`
- Architect verification: APPROVED (initial + post-deslop adjustment)
- Deslop pass: scoped to changed files; removed plan drift in port package dispatch
