### PR TITLE
Resolve non-tx open architecture issues

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -71,6 +71,10 @@ report.AssertNoViolations(t, violations)
 다른 프리셋은 `presets.Hexagonal()`과 `presets.RecommendedHexagonal()`처럼
 아키텍처와 권장 ruleset을 같은 프리셋으로 맞춰 사용합니다.
 
+`analyzer.Load`는 프로젝트 상대 filesystem 패턴(`"internal/..."`), 명시적
+상대 패턴(`"./internal/..."`), 모듈 경로 패턴
+(`"github.com/acme/project/internal/..."`), 절대 filesystem 패턴을 지원합니다.
+
 ### 개별 rule 제어 (DDD 예시)
 
 각 체크를 세밀하게 제어하려면 `core.RuleSet`을 직접 조합합니다:
@@ -195,6 +199,7 @@ arch := core.Architecture{
 | `LayerModel.PkgRestricted` | 공유 패키지 import 금지 서브레이어 |
 | `LayerModel.InternalTopLevel` | 패키지 루트 아래 허용 최상위 디렉토리 |
 | `LayerModel.LayerDirNames` | 파일/디렉토리 배치 룰이 인식하는 레이어 **basename** (`"repo"`); 의도적으로 `Sublayers`에 있을 필요 없음 |
+| `LayerModel.LayerLocations` | `structural.layer-placement`용 basename → 허용 경로 템플릿; `{InternalRoot}`, `{DomainDir}`, `{AppDir}`, `{ServerDir}`, `*`, `**` 지원 |
 | `LayoutModel.InternalRoot` | 프로젝트 상대 패키지 루트 디렉토리; 빈 값은 `"internal"`로 정규화됨 (`"packages"`, `"src"` 등 비표준 레이아웃 지원) |
 | `LayoutModel.DomainDir` | 도메인 최상위 디렉토리명. 플랫 레이아웃은 빈 값 |
 | `LayoutModel.OrchestrationDir` | 오케스트레이션 최상위 디렉토리명 |
@@ -760,6 +765,28 @@ ruleset := presets.RecommendedDDD().With(tx.New(tx.Config{
 
 발생 가능한 규칙 ID: `tx.start-outside-allowed-layer`, `tx.type-in-signature`.
 
+### `tx.NewForbiddenCalls` / `tx.NewMandatoryWrapper` (옵트인)
+
+프리셋 번들에 포함하지 않고 SDK/client 직접 호출을 거칠게 막고 싶을 때 사용합니다.
+`AllowedLayers`에는 아키텍처 레이어명(`"infra"`, `"app"`) 또는 프로젝트 상대
+패키지 prefix(`"pkg/httpclient"`)를 넣을 수 있습니다.
+
+```go
+ruleset = ruleset.With(
+    tx.NewForbiddenCalls([]tx.ForbiddenCall{{
+        Symbols:       []string{"database/sql.Open"},
+        AllowedLayers: []string{"infra"},
+    }}),
+    tx.NewMandatoryWrapper([]tx.MandatoryWrapper{{
+        Symbols:       []string{"net/http.(*Client).Do"},
+        AllowedLayers: []string{"pkg/httpclient"},
+        ReplaceWith:   "pkg/httpclient.Do",
+    }}),
+)
+```
+
+발생 가능한 규칙 ID: `tx.forbidden-call`, `tx.mandatory-wrapper`.
+
 ## 세터 패턴
 
 ### `types.NewNoSetter`
@@ -860,7 +887,7 @@ go run github.com/NamhaeSusan/go-arch-guard/cmd/tui --preset hexagonal .
 | `structural.WithRepoPortSuffixes(...)` | `structural.NewRepoFileInterface`의 repository-port 인터페이스 이름 suffix 옵션. 기본값은 `Repository`, `Repo`; 빈 suffix는 무시 |
 | `interfaces.NewPattern()` / `NewContainer()` / `NewCrossDomainAnonymous()` / `NewTooManyMethods()` | 인터페이스 규칙 |
 | `interfaces.WithMaxMethods(n)` | `interfaces.NewTooManyMethods`의 인터페이스 메서드 상한 옵션. 옵션 미지정 시 기본 10; n ≤ 0이면 fallback 10. 다른 interfaces.New*() 룰에 넘기면 silently 무시 |
-| `tx.New(tx.Config{...})` | 트랜잭션 경계 검사 (옵트인) |
+| `tx.New(tx.Config{...})` / `tx.NewForbiddenCalls(...)` / `tx.NewMandatoryWrapper(...)` | 트랜잭션 및 symbol-call 검사 (옵트인) |
 | `types.NewNoSetter()` | setter 규칙 (값 타입의 불변성 강제) |
 
 ## 기계 친화적인 JSON 출력

--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ both values from loaded package module metadata. If package metadata is not
 available, the values stay empty and layout-dependent rules may report
 `meta.layout-not-supported` instead of guessing a project root.
 
+`analyzer.Load` accepts project-relative filesystem patterns (`"internal/..."`),
+explicit relative patterns (`"./internal/..."`), module-path patterns
+(`"github.com/acme/project/internal/..."`), and absolute filesystem patterns.
+
 ### Per-rule control (DDD example)
 
 For finer control over individual checks, compose a `core.RuleSet` manually:
@@ -212,6 +216,7 @@ Architecture fields:
 | `LayerModel.PkgRestricted` | sublayers that must not import shared packages |
 | `LayerModel.InternalTopLevel` | allowed top-level directories under the package root |
 | `LayerModel.LayerDirNames` | layer **basenames** (`"repo"`) recognized by file/directory placement rules; intentionally NOT required to appear in `Sublayers` |
+| `LayerModel.LayerLocations` | optional basename → allowed path templates for `structural.layer-placement`; supports `{InternalRoot}`, `{DomainDir}`, `{AppDir}`, `{ServerDir}`, `*`, and `**` |
 | `LayoutModel.InternalRoot` | project-relative package-root directory; defaults to `"internal"` when empty (set to `"packages"`, `"src"`, etc. for non-default layouts) |
 | `LayoutModel.DomainDir` | top-level directory name for domains; empty for flat layouts |
 | `LayoutModel.OrchestrationDir` | top-level directory name for orchestration |
@@ -804,6 +809,28 @@ ruleset := presets.RecommendedDDD().With(tx.New(tx.Config{
 
 Emitted rule IDs: `tx.start-outside-allowed-layer`, `tx.type-in-signature`.
 
+### `tx.NewForbiddenCalls` / `tx.NewMandatoryWrapper` (opt-in)
+
+Use these for coarse SDK/client call guards without adding them to preset
+bundles. `AllowedLayers` accepts architecture layer names (`"infra"`, `"app"`)
+and project-relative package prefixes (`"pkg/httpclient"`).
+
+```go
+ruleset = ruleset.With(
+    tx.NewForbiddenCalls([]tx.ForbiddenCall{{
+        Symbols:       []string{"database/sql.Open"},
+        AllowedLayers: []string{"infra"},
+    }}),
+    tx.NewMandatoryWrapper([]tx.MandatoryWrapper{{
+        Symbols:       []string{"net/http.(*Client).Do"},
+        AllowedLayers: []string{"pkg/httpclient"},
+        ReplaceWith:   "pkg/httpclient.Do",
+    }}),
+)
+```
+
+Emitted rule IDs: `tx.forbidden-call`, `tx.mandatory-wrapper`.
+
 ## Setter Pattern
 
 ### `types.NewNoSetter`
@@ -909,7 +936,7 @@ Features: health-status tree coloring, imports/reverse dependencies/coupling met
 | `interfaces.NewPattern()` / `NewContainer()` / `NewCrossDomainAnonymous()` / `NewTooManyMethods()` | interface rules |
 | `testpolicy.NewNoHandMock()` | test policy rules |
 | `interfaces.WithMaxMethods(n)` | option for `interfaces.NewTooManyMethods` setting the per-interface method cap. Default 10 when the option is omitted; n ≤ 0 also falls back to 10. Silently ignored if passed to other interfaces.New*() rules. |
-| `tx.New(tx.Config{...})` | transaction boundary enforcement (opt-in) |
+| `tx.New(tx.Config{...})` / `tx.NewForbiddenCalls(...)` / `tx.NewMandatoryWrapper(...)` | transaction and symbol-call guards (opt-in) |
 | `types.NewNoSetter()` | setter rule (immutability for value types) |
 
 ## Machine-readable JSON Output

--- a/analyzer/loader.go
+++ b/analyzer/loader.go
@@ -9,7 +9,11 @@ import (
 	"golang.org/x/tools/go/packages"
 )
 
-// Load parses Go packages matching the given patterns under dir.
+// Load parses Go packages matching the given patterns under dir. Relative
+// directory patterns such as "internal/..." are resolved under dir, patterns
+// beginning with "./" are passed through, module-path patterns such as
+// "github.com/acme/project/..." are passed through, and absolute filesystem
+// patterns are passed through unchanged.
 // When some packages contain errors (e.g. type-check failures), they are
 // skipped and the successfully loaded packages are returned alongside a
 // non-nil error describing what was skipped. Callers that want partial
@@ -38,6 +42,8 @@ func Load(dir string, patterns ...string) ([]*packages.Package, error) {
 	for i, p := range patterns {
 		switch {
 		case strings.HasPrefix(p, "./"):
+			prefixed[i] = p
+		case filepath.IsAbs(p):
 			prefixed[i] = p
 		case looksLikeModulePath(p):
 			prefixed[i] = p

--- a/analyzer/loader_test.go
+++ b/analyzer/loader_test.go
@@ -1,6 +1,7 @@
 package analyzer_test
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -133,6 +134,26 @@ func TestLoad(t *testing.T) {
 			// be from pattern handling, not classification
 			if strings.Contains(err.Error(), "./github.com/") {
 				t.Fatalf("loader double-prefixed an absolute module pattern: %v", err)
+			}
+		}
+	})
+
+	t.Run("absolute filesystem patterns are passed through unchanged", func(t *testing.T) {
+		root, err := filepath.Abs("../testdata/load_type_error")
+		if err != nil {
+			t.Fatal(err)
+		}
+		pattern := filepath.Join(root, "internal", "...")
+		pkgs, err := analyzer.Load(root, pattern)
+		if err != nil {
+			t.Fatalf("expected absolute filesystem pattern to load, got %v", err)
+		}
+		if len(pkgs) == 0 {
+			t.Fatal("expected packages to be loaded from absolute filesystem pattern")
+		}
+		for _, pkg := range pkgs {
+			if !strings.HasPrefix(pkg.PkgPath, "github.com/kimtaeyun/testproject-load-type-error/internal/") {
+				t.Fatalf("loaded unexpected package %q from absolute filesystem pattern", pkg.PkgPath)
 			}
 		}
 	})

--- a/cmd/tui/main.go
+++ b/cmd/tui/main.go
@@ -60,7 +60,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	pkgs, err := analyzer.Load(dir, "internal/...", "cmd/...")
+	arch := entry.arch()
+	pkgs, err := analyzer.Load(dir, loadPatterns(arch)...)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "warning: %v\n", err)
 	}
@@ -81,8 +82,16 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := tui.Run(pkgs, module, absDir, entry.arch(), entry.ruleset()); err != nil {
+	if err := tui.Run(pkgs, module, absDir, arch, entry.ruleset()); err != nil {
 		fmt.Fprintf(os.Stderr, "tui error: %v\n", err)
 		os.Exit(1)
 	}
+}
+
+func loadPatterns(arch core.Architecture) []string {
+	internalRoot := strings.Trim(strings.TrimSpace(arch.Layout.InternalRoot), "/")
+	if internalRoot == "" {
+		internalRoot = "internal"
+	}
+	return []string{internalRoot + "/...", "cmd/..."}
 }

--- a/cmd/tui/main_test.go
+++ b/cmd/tui/main_test.go
@@ -4,11 +4,24 @@ import (
 	"sort"
 	"strings"
 	"testing"
+
+	"github.com/NamhaeSusan/go-arch-guard/core"
 )
 
 func TestPresetNamesAreSorted(t *testing.T) {
 	got := strings.Split(presetNames(), ", ")
 	if !sort.StringsAreSorted(got) {
 		t.Fatalf("presetNames() = %q, want sorted names", presetNames())
+	}
+}
+
+func TestLoadPatternsRespectInternalRoot(t *testing.T) {
+	arch := core.Architecture{}
+	arch.Layout.InternalRoot = "packages"
+
+	got := loadPatterns(arch)
+	want := []string{"packages/...", "cmd/..."}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("loadPatterns() = %#v, want %#v", got, want)
 	}
 }

--- a/core/analysisutil/ast.go
+++ b/core/analysisutil/ast.go
@@ -28,12 +28,11 @@ type TypeSpecInfo struct {
 	AliasFrom   string // import path of `type X = pkg.Y`; empty if not an alias
 }
 
-// InspectTypeSpecs walks the top-level type decls in file and returns one
-// entry per interface declaration or per type alias whose RHS is
-// `<ident>.<Name>`. Other type decls are skipped. Callers usually want to
-// detect interfaces or detect re-exports of types from other packages.
-func InspectTypeSpecs(file *ast.File, fset *token.FileSet) []TypeSpecInfo {
-	var result []TypeSpecInfo
+// WalkTypeSpecs visits top-level type declarations in source order.
+func WalkTypeSpecs(file *ast.File, fset *token.FileSet, visit func(*ast.TypeSpec, token.Position)) {
+	if file == nil || visit == nil {
+		return
+	}
 	for _, decl := range file.Decls {
 		gd, ok := decl.(*ast.GenDecl)
 		if !ok {
@@ -44,25 +43,53 @@ func InspectTypeSpecs(file *ast.File, fset *token.FileSet) []TypeSpecInfo {
 			if !ok {
 				continue
 			}
-			info := TypeSpecInfo{
-				Name: ts.Name.Name,
-				Line: fset.Position(ts.Name.Pos()).Line,
+			var pos token.Position
+			if fset != nil {
+				pos = fset.Position(ts.Name.Pos())
 			}
-			if _, ok := ts.Type.(*ast.InterfaceType); ok {
-				info.IsInterface = true
-			}
-			if ts.Assign != 0 {
-				if sel, ok := ts.Type.(*ast.SelectorExpr); ok {
-					if ident, ok := sel.X.(*ast.Ident); ok {
-						info.AliasFrom = ResolveIdentImportPath(file, ident.Name)
-					}
-				}
-			}
-			if info.IsInterface || info.AliasFrom != "" {
-				result = append(result, info)
-			}
+			visit(ts, pos)
 		}
 	}
+}
+
+// WalkFuncDecls visits top-level function declarations in source order.
+func WalkFuncDecls(file *ast.File, visit func(*ast.FuncDecl)) {
+	if file == nil || visit == nil {
+		return
+	}
+	for _, decl := range file.Decls {
+		fd, ok := decl.(*ast.FuncDecl)
+		if ok {
+			visit(fd)
+		}
+	}
+}
+
+// InspectTypeSpecs walks the top-level type decls in file and returns one
+// entry per interface declaration or per type alias whose RHS is
+// `<ident>.<Name>`. Other type decls are skipped. Callers usually want to
+// detect interfaces or detect re-exports of types from other packages.
+func InspectTypeSpecs(file *ast.File, fset *token.FileSet) []TypeSpecInfo {
+	var result []TypeSpecInfo
+	WalkTypeSpecs(file, fset, func(ts *ast.TypeSpec, pos token.Position) {
+		info := TypeSpecInfo{
+			Name: ts.Name.Name,
+			Line: pos.Line,
+		}
+		if _, ok := ts.Type.(*ast.InterfaceType); ok {
+			info.IsInterface = true
+		}
+		if ts.Assign != 0 {
+			if sel, ok := ts.Type.(*ast.SelectorExpr); ok {
+				if ident, ok := sel.X.(*ast.Ident); ok {
+					info.AliasFrom = ResolveIdentImportPath(file, ident.Name)
+				}
+			}
+		}
+		if info.IsInterface || info.AliasFrom != "" {
+			result = append(result, info)
+		}
+	})
 	return result
 }
 
@@ -151,14 +178,13 @@ func WalkFuncSignatureTypes(info *types.Info, file *ast.File, visit func(*ast.Fu
 	if info == nil || file == nil || visit == nil {
 		return
 	}
-	for _, decl := range file.Decls {
-		fd, ok := decl.(*ast.FuncDecl)
-		if !ok || fd.Type == nil {
-			continue
+	WalkFuncDecls(file, func(fd *ast.FuncDecl) {
+		if fd.Type == nil {
+			return
 		}
 		walkFieldListTypes(info, fd, fd.Type.Params, visit)
 		walkFieldListTypes(info, fd, fd.Type.Results, visit)
-	}
+	})
 }
 
 func StripWrappers(t types.Type) types.Type {

--- a/core/analysisutil/ast_test.go
+++ b/core/analysisutil/ast_test.go
@@ -6,6 +6,7 @@ import (
 	"go/parser"
 	"go/token"
 	"go/types"
+	"strings"
 	"testing"
 )
 
@@ -135,6 +136,38 @@ func Process(items []Item, err error) (*Item, error) { return nil, nil }
 		if got[i] != want[i] {
 			t.Fatalf("WalkFuncSignatureTypes()[%d] = %q, want %q", i, got[i], want[i])
 		}
+	}
+}
+
+func TestWalkTypeSpecsAndFuncDecls(t *testing.T) {
+	src := `package p
+
+type A struct{}
+type B = A
+func one() {}
+var ignored = 1
+func two() {}
+`
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "sample.go", src, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var types []string
+	WalkTypeSpecs(file, fset, func(ts *ast.TypeSpec, _ token.Position) {
+		types = append(types, ts.Name.Name)
+	})
+	if got, want := strings.Join(types, ","), "A,B"; got != want {
+		t.Fatalf("WalkTypeSpecs() = %q, want %q", got, want)
+	}
+
+	var funcs []string
+	WalkFuncDecls(file, func(fd *ast.FuncDecl) {
+		funcs = append(funcs, fd.Name.Name)
+	})
+	if got, want := strings.Join(funcs, ","), "one,two"; got != want {
+		t.Fatalf("WalkFuncDecls() = %q, want %q", got, want)
 	}
 }
 

--- a/core/analysisutil/path.go
+++ b/core/analysisutil/path.go
@@ -5,16 +5,12 @@ import (
 	"strings"
 
 	"github.com/NamhaeSusan/go-arch-guard/core"
+	"github.com/NamhaeSusan/go-arch-guard/internal/pathmatch"
 	"golang.org/x/tools/go/packages"
 )
 
 func NormalizeMatchPath(path string) string {
-	path = strings.ReplaceAll(path, `\`, `/`)
-	path = filepath.ToSlash(path)
-	for strings.HasPrefix(path, "./") {
-		path = strings.TrimPrefix(path, "./")
-	}
-	return path
+	return pathmatch.Normalize(path)
 }
 
 func RelPathFromRoot(projectRoot, filename string) string {

--- a/core/analysisutil/path_test.go
+++ b/core/analysisutil/path_test.go
@@ -89,9 +89,22 @@ func TestProjectRelativePackagePath(t *testing.T) {
 }
 
 func TestNormalizeMatchPath(t *testing.T) {
-	got := NormalizeMatchPath("./internal\\domain/order")
-	want := "internal/domain/order"
-	if got != want {
-		t.Fatalf("NormalizeMatchPath() = %q, want %q", got, want)
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{name: "dot slash and backslash", path: "./internal\\domain/order", want: "internal/domain/order"},
+		{name: "leading slash", path: "/internal/domain/order", want: "internal/domain/order"},
+		{name: "trailing slash", path: "internal/domain/order/", want: "internal/domain/order"},
+		{name: "recursive suffix", path: "internal/domain/...", want: "internal/domain/..."},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := NormalizeMatchPath(tc.path); got != tc.want {
+				t.Fatalf("NormalizeMatchPath() = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }

--- a/core/analysisutil/sublayer.go
+++ b/core/analysisutil/sublayer.go
@@ -44,11 +44,15 @@ func HasPortSublayer(layers core.LayerModel) bool {
 }
 
 func MatchPortSublayer(layers core.LayerModel, pkgPath string) string {
+	return MatchPortSublayerInLayout(layers, core.LayoutModel{InternalRoot: "internal", DomainDir: "domain"}, pkgPath)
+}
+
+func MatchPortSublayerInLayout(layers core.LayerModel, layout core.LayoutModel, pkgPath string) string {
 	for _, sl := range layers.Sublayers {
 		if !IsPortSublayer(layers, sl) {
 			continue
 		}
-		if strings.HasSuffix(pkgPath, "/"+sl) || strings.Contains(pkgPath, "/"+sl+"/") {
+		if matchesSublayerBoundary(layout, pkgPath, sl) {
 			return sl
 		}
 	}
@@ -56,15 +60,52 @@ func MatchPortSublayer(layers core.LayerModel, pkgPath string) string {
 }
 
 func MatchContractSublayer(layers core.LayerModel, pkgPath string) string {
+	return MatchContractSublayerInLayout(layers, core.LayoutModel{InternalRoot: "internal", DomainDir: "domain"}, pkgPath)
+}
+
+func MatchContractSublayerInLayout(layers core.LayerModel, layout core.LayoutModel, pkgPath string) string {
 	for _, sl := range layers.Sublayers {
 		if !IsContractSublayer(layers, sl) {
 			continue
 		}
-		if strings.HasSuffix(pkgPath, "/"+sl) || strings.Contains(pkgPath, "/"+sl+"/") {
+		if matchesSublayerBoundary(layout, pkgPath, sl) {
 			return sl
 		}
 	}
 	return ""
+}
+
+func matchesSublayerBoundary(layout core.LayoutModel, pkgPath, sublayer string) bool {
+	internalRoot := layout.InternalRoot
+	if internalRoot == "" {
+		internalRoot = "internal"
+	}
+	domainDir := layout.DomainDir
+	if domainDir == "" {
+		domainDir = "domain"
+	}
+	parts := strings.Split(pkgPath, "/")
+	for i := 0; i+2 < len(parts); i++ {
+		if parts[i] == internalRoot && parts[i+1] == domainDir {
+			if matchesSublayerParts(parts[i+2:], sublayer) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func matchesSublayerParts(relParts []string, sublayer string) bool {
+	slParts := strings.Split(sublayer, "/")
+	if len(relParts) < 1+len(slParts) {
+		return false
+	}
+	for i, want := range slParts {
+		if relParts[1+i] != want {
+			return false
+		}
+	}
+	return true
 }
 
 func PortSublayerName(layers core.LayerModel) string {

--- a/core/analysisutil/sublayer_test.go
+++ b/core/analysisutil/sublayer_test.go
@@ -52,6 +52,50 @@ func TestFallbackSublayerMatching(t *testing.T) {
 	}
 }
 
+func TestSublayerMatchingRejectsPathSubstringsOutsideDomainLayer(t *testing.T) {
+	layers := core.LayerModel{
+		Sublayers: []string{"core/repo", "core/svc", "core/model"},
+	}
+
+	if got := MatchPortSublayer(layers, "example.com/app/internal/pkg/core/repo/cache"); got != "" {
+		t.Fatalf("MatchPortSublayer() = %q, want no match outside domain layer", got)
+	}
+	if got := MatchPortSublayer(layers, "example.com/app/internal/pkg/core/repo"); got != "" {
+		t.Fatalf("MatchPortSublayer() = %q, want no exact suffix match outside domain layer", got)
+	}
+	if got := MatchPortSublayer(layers, "example.com/app/internal/pkg/domain/order/core/repo"); got != "" {
+		t.Fatalf("MatchPortSublayer() = %q, want no internal/pkg/domain false match", got)
+	}
+	if got := MatchPortSublayer(layers, "example.com/domain/app/internal/domain/order/core/repo"); got != "core/repo" {
+		t.Fatalf("MatchPortSublayer() = %q, want core/repo with module prefix containing domain", got)
+	}
+	if got := MatchPortSublayer(layers, "example.com/app/internal/domain/order/core/repo/internal/domain/cache"); got != "core/repo" {
+		t.Fatalf("MatchPortSublayer() = %q, want core/repo with nested internal/domain below layer", got)
+	}
+	if got := MatchContractSublayer(layers, "example.com/app/internal/pkg/core/svc/cache"); got != "" {
+		t.Fatalf("MatchContractSublayer() = %q, want no match outside domain layer", got)
+	}
+}
+
+func TestSublayerMatchingUsesConfiguredLayout(t *testing.T) {
+	layers := core.LayerModel{
+		Sublayers: []string{"core/repo", "core/svc", "core/model"},
+	}
+
+	layout := core.LayoutModel{InternalRoot: "packages", DomainDir: "domain"}
+	if got := MatchPortSublayerInLayout(layers, layout, "example.com/app/packages/domain/order/core/repo"); got != "core/repo" {
+		t.Fatalf("MatchPortSublayerInLayout() = %q, want core/repo for custom InternalRoot", got)
+	}
+	if got := MatchPortSublayerInLayout(layers, layout, "example.com/app/internal/domain/order/core/repo"); got != "" {
+		t.Fatalf("MatchPortSublayerInLayout() = %q, want no match for wrong InternalRoot", got)
+	}
+
+	layout = core.LayoutModel{InternalRoot: "internal", DomainDir: "module"}
+	if got := MatchContractSublayerInLayout(layers, layout, "example.com/app/internal/module/order/core/svc"); got != "core/svc" {
+		t.Fatalf("MatchContractSublayerInLayout() = %q, want core/svc for custom DomainDir", got)
+	}
+}
+
 func TestExplicitPortSublayerMatching(t *testing.T) {
 	layers := core.LayerModel{
 		Sublayers:      []string{"handler", "usecase", "port", "domain", "adapter"},

--- a/core/architecture.go
+++ b/core/architecture.go
@@ -54,6 +54,11 @@ type LayerModel struct {
 	// directory placement rules. Keys are basenames, NOT full Sublayer
 	// paths.
 	LayerDirNames map[string]bool
+	// LayerLocations maps a layer basename to allowed project-relative path
+	// templates for structural placement checks. Templates may use layout
+	// placeholders such as {InternalRoot}, {DomainDir}, {AppDir},
+	// {ServerDir}, and glob segments "*" or "**".
+	LayerLocations map[string][]string
 }
 
 // LayoutModel describes the package-root directory topology. Empty fields
@@ -115,6 +120,7 @@ func cloneArchitecture(a Architecture) Architecture {
 			PkgRestricted:    cloneBoolMap(a.Layers.PkgRestricted),
 			InternalTopLevel: cloneBoolMap(a.Layers.InternalTopLevel),
 			LayerDirNames:    cloneBoolMap(a.Layers.LayerDirNames),
+			LayerLocations:   cloneStringSliceMap(a.Layers.LayerLocations),
 		},
 		Layout: a.Layout, // value type with only string fields
 		Naming: NamingPolicy{

--- a/core/architecture_validate.go
+++ b/core/architecture_validate.go
@@ -103,6 +103,19 @@ func (a Architecture) Validate() error {
 			errs = append(errs, "LayerDirNames contains empty-string key")
 		}
 	}
+	for k, locations := range a.Layers.LayerLocations {
+		if k == "" {
+			errs = append(errs, "LayerLocations contains empty-string key")
+		}
+		if len(locations) == 0 {
+			errs = append(errs, fmt.Sprintf("LayerLocations[%q] has no locations", k))
+		}
+		for _, location := range locations {
+			if strings.TrimSpace(location) == "" {
+				errs = append(errs, fmt.Sprintf("LayerLocations[%q] contains empty location", k))
+			}
+		}
+	}
 	// InternalTopLevel keys are top-level dir names; they don't have to map
 	// to Sublayers either, but empty keys are always a typo.
 	for k := range a.Layers.InternalTopLevel {

--- a/core/architecture_validate_test.go
+++ b/core/architecture_validate_test.go
@@ -54,6 +54,25 @@ func TestValidateRejectsEmptyLayerDirNamesKey(t *testing.T) {
 	}
 }
 
+func TestValidateRejectsMalformedLayerLocations(t *testing.T) {
+	a := validArchitecture()
+	a.Layers.LayerLocations = map[string][]string{
+		"":           {"{InternalRoot}/{DomainDir}/*/adapter"},
+		"controller": {""},
+		"adapter":    nil,
+	}
+	err := a.Validate()
+	if err == nil {
+		t.Fatal("expected malformed LayerLocations to be rejected")
+	}
+	msg := err.Error()
+	for _, want := range []string{"LayerLocations contains empty-string key", "LayerLocations[\"controller\"] contains empty location", "LayerLocations[\"adapter\"] has no locations"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("expected %q in %q", want, msg)
+		}
+	}
+}
+
 func TestValidateRejectsEmptyInternalTopLevelKey(t *testing.T) {
 	a := validArchitecture()
 	a.Layers.InternalTopLevel = map[string]bool{"": true}

--- a/core/context.go
+++ b/core/context.go
@@ -1,9 +1,9 @@
 package core
 
 import (
-	"path/filepath"
 	"strings"
 
+	"github.com/NamhaeSusan/go-arch-guard/internal/pathmatch"
 	"golang.org/x/tools/go/packages"
 )
 
@@ -128,14 +128,5 @@ func matchExcludePattern(pattern, path string) bool {
 // As a result "internal/foo", "/internal/foo", "./internal/foo",
 // "internal\\foo", and "internal/foo/" are all the same key.
 func normalizeMatchPath(path string) string {
-	path = strings.ReplaceAll(path, "\\", "/")
-	path = filepath.ToSlash(path)
-	path = strings.TrimPrefix(path, "/")
-	for strings.HasPrefix(path, "./") {
-		path = strings.TrimPrefix(path, "./")
-	}
-	if strings.HasSuffix(path, "/") && !strings.HasSuffix(path, "...") {
-		path = strings.TrimSuffix(path, "/")
-	}
-	return path
+	return pathmatch.Normalize(path)
 }

--- a/core/context_test.go
+++ b/core/context_test.go
@@ -167,11 +167,14 @@ func TestContextPkgsHeaderCopyDoesNotAffectOthers(t *testing.T) {
 func TestNewContextIsolatesCallerArchitectureMutation(t *testing.T) {
 	arch := validArchitecture()
 	arch.Layers.LayerDirNames = map[string]bool{"handler": true, "app": true}
+	arch.Layers.LayerLocations = map[string][]string{"app": {"{InternalRoot}/{AppDir}"}}
 	c := NewContext(nil, "m", "/r", arch, nil)
 
 	// Mutate the original arch maps and slices after NewContext.
 	arch.Layers.Sublayers = append(arch.Layers.Sublayers, "rogue")
 	arch.Layers.LayerDirNames["rogue"] = true
+	arch.Layers.LayerLocations["app"][0] = "mutated"
+	arch.Layers.LayerLocations["rogue"] = []string{"rogue"}
 	arch.Layers.Direction["rogue"] = []string{"handler"}
 
 	got := c.Arch()
@@ -182,6 +185,9 @@ func TestNewContextIsolatesCallerArchitectureMutation(t *testing.T) {
 	}
 	if got.Layers.LayerDirNames["rogue"] {
 		t.Fatalf("caller mutation leaked into Context: LayerDirNames contains rogue")
+	}
+	if got.Layers.LayerLocations["app"][0] == "mutated" || got.Layers.LayerLocations["rogue"] != nil {
+		t.Fatalf("caller mutation leaked into Context: LayerLocations = %#v", got.Layers.LayerLocations)
 	}
 	if _, ok := got.Layers.Direction["rogue"]; ok {
 		t.Fatalf("caller mutation leaked into Context: Direction contains rogue")

--- a/docs/model-concepts.md
+++ b/docs/model-concepts.md
@@ -45,6 +45,7 @@ truth: every field that names a layer must refer to a value in `Sublayers`.
 | `PkgRestricted` | Layers that must not import the shared package tree. |
 | `InternalTopLevel` | Top-level directories allowed under `internal/`. Structure rules use this to catch accidental directories. |
 | `LayerDirNames` | Basename hints used by placement rules to identify layer-like directories. |
+| `LayerLocations` | Optional basename → allowed path templates for layer placement. Templates support layout placeholders such as `{InternalRoot}` and glob segments `*` / `**`. |
 
 Example:
 
@@ -65,6 +66,11 @@ layers := core.LayerModel{
     },
     LayerDirNames: map[string]bool{
         "api": true, "logic": true, "data": true,
+    },
+    LayerLocations: map[string][]string{
+        "api":   {"{InternalRoot}/{DomainDir}/*/api"},
+        "logic": {"{InternalRoot}/{DomainDir}/*/logic"},
+        "data":  {"{InternalRoot}/{DomainDir}/*/data"},
     },
 }
 ```

--- a/docs/presets.md
+++ b/docs/presets.md
@@ -8,6 +8,10 @@ For custom architectures, see [Architecture Concepts](model-concepts.md).
 > Projects that keep packages under a different directory (`packages/`, `src/`, etc.)
 > should set `arch.Layout.InternalRoot` accordingly — the same layout structure applies,
 > just under a different root.
+>
+> Custom layer vocabularies can also set `arch.Layers.LayerLocations` so
+> `structural.layer-placement` checks names beyond the built-in
+> `app`/`infra`/`handler` fallback vocabulary.
 
 ## DDD Layout
 

--- a/internal/pathmatch/path.go
+++ b/internal/pathmatch/path.go
@@ -1,0 +1,21 @@
+package pathmatch
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// Normalize canonicalizes paths used by exclude patterns and rule-level
+// path matching so callers agree on slash, prefix, and trailing-slash shape.
+func Normalize(path string) string {
+	path = strings.ReplaceAll(path, "\\", "/")
+	path = filepath.ToSlash(path)
+	path = strings.TrimPrefix(path, "/")
+	for strings.HasPrefix(path, "./") {
+		path = strings.TrimPrefix(path, "./")
+	}
+	if strings.HasSuffix(path, "/") && !strings.HasSuffix(path, "...") {
+		path = strings.TrimSuffix(path, "/")
+	}
+	return path
+}

--- a/plugins/go-arch-guard/skills/go-arch-guard/SKILL.md
+++ b/plugins/go-arch-guard/skills/go-arch-guard/SKILL.md
@@ -286,8 +286,8 @@ arch := core.Architecture{
 ```
 
 전체 필드: `LayerModel.Sublayers`, `LayerModel.Direction`, `LayerModel.PkgRestricted`,
-`LayerModel.InternalTopLevel`, `LayerModel.LayerDirNames`, `LayerModel.PortLayers`,
-`LayerModel.ContractLayers`, `LayoutModel.InternalRoot` (default `"internal"`,
+`LayerModel.InternalTopLevel`, `LayerModel.LayerDirNames`, `LayerModel.LayerLocations`,
+`LayerModel.PortLayers`, `LayerModel.ContractLayers`, `LayoutModel.InternalRoot` (default `"internal"`,
 `"packages"`/`"src"` 등 비표준 패키지 루트 지원), `LayoutModel.DomainDir`,
 `LayoutModel.OrchestrationDir`, `LayoutModel.SharedDir`, `LayoutModel.AppDir`,
 `LayoutModel.ServerDir`, `NamingPolicy.BannedPkgNames`, `NamingPolicy.LegacyPkgNames`,
@@ -348,6 +348,24 @@ ruleset := presets.RecommendedDDD().With(tx.New(tx.Config{
 ```
 
 위반 규칙 ID: `tx.start-outside-allowed-layer`, `tx.type-in-signature`.
+
+SDK/client 직접 호출을 제한하려면 opt-in symbol-call 룰을 추가한다:
+
+```go
+ruleset = ruleset.With(
+    tx.NewForbiddenCalls([]tx.ForbiddenCall{{
+        Symbols:       []string{"database/sql.Open"},
+        AllowedLayers: []string{"infra"},
+    }}),
+    tx.NewMandatoryWrapper([]tx.MandatoryWrapper{{
+        Symbols:       []string{"net/http.(*Client).Do"},
+        AllowedLayers: []string{"pkg/httpclient"},
+        ReplaceWith:   "pkg/httpclient.Do",
+    }}),
+)
+```
+
+위반 규칙 ID: `tx.forbidden-call`, `tx.mandatory-wrapper`.
 
 ## Machine-readable Output
 

--- a/presets/presets_test.go
+++ b/presets/presets_test.go
@@ -157,8 +157,10 @@ func TestRecommendedRuleSetsContainCoreRules(t *testing.T) {
 					t.Errorf("unexpected rule %q in Recommended%s", id, tc.name)
 				}
 			}
-			if ids["tx.boundary"] {
-				t.Errorf("tx.boundary must remain opt-in; found in Recommended%s", tc.name)
+			for _, optInID := range []string{"tx.boundary", "tx.forbidden-call", "tx.mandatory-wrapper"} {
+				if ids[optInID] {
+					t.Errorf("%s must remain opt-in; found in Recommended%s", optInID, tc.name)
+				}
 			}
 		})
 	}

--- a/rules/dependency/isolation.go
+++ b/rules/dependency/isolation.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/NamhaeSusan/go-arch-guard/core"
 	"github.com/NamhaeSusan/go-arch-guard/core/analysisutil"
+	"github.com/NamhaeSusan/go-arch-guard/rules/internal/rulemeta"
 	"golang.org/x/tools/go/packages"
 )
 
@@ -407,13 +408,7 @@ func validateModule(pkgs []*packages.Package, projectModule string) []core.Viola
 }
 
 func metaNoMatchingPackages(message string) core.Violation {
-	return core.Violation{
-		Rule:              "meta.no-matching-packages",
-		Message:           message,
-		Fix:               "verify the module argument matches go.mod",
-		DefaultSeverity:   core.Warning,
-		EffectiveSeverity: core.Warning,
-	}
+	return rulemeta.NoMatchingPackages(message)
 }
 
 // metaRuleDisabledByConfig signals that a rule is registered in the RuleSet
@@ -421,13 +416,7 @@ func metaNoMatchingPackages(message string) core.Violation {
 // (whole rule) or makes a sub-check inert (partial). Severity defaults to
 // Warning via the runner's meta.* prefix handling.
 func metaRuleDisabledByConfig(ruleID, reason, fix string) core.Violation {
-	return core.Violation{
-		Rule:              "meta.rule-disabled-by-config",
-		Message:           fmt.Sprintf("%s: %s", ruleID, reason),
-		Fix:               fix,
-		DefaultSeverity:   core.Warning,
-		EffectiveSeverity: core.Warning,
-	}
+	return rulemeta.RuleDisabledByConfig(ruleID, reason, fix)
 }
 
 // hasInternalPackages reports whether any loaded package lives under
@@ -445,13 +434,9 @@ func hasInternalPackages(pkgs []*packages.Package, projectModule, internalRoot s
 }
 
 func metaLayoutNotSupported(ruleID, projectModule string) core.Violation {
-	return core.Violation{
-		Rule:              "meta.layout-not-supported",
-		Message:           fmt.Sprintf("%s requires an internal/-based layout; no internal/ packages found in module %q", ruleID, projectModule),
-		Fix:               "use this rule with internal/-based presets (DDD, CleanArch, Hexagonal, ModularMonolith), or remove it from your ruleset for flat layouts",
-		DefaultSeverity:   core.Warning,
-		EffectiveSeverity: core.Warning,
-	}
+	return rulemeta.LayoutNotSupported(
+		fmt.Sprintf("%s requires an internal/-based layout; no internal/ packages found in module %q", ruleID, projectModule),
+		"use this rule with internal/-based presets (DDD, CleanArch, Hexagonal, ModularMonolith), or remove it from your ruleset for flat layouts")
 }
 
 func violationSpecs(severity core.Severity, ids ...string) []core.ViolationSpec {

--- a/rules/interfaces/container.go
+++ b/rules/interfaces/container.go
@@ -172,21 +172,14 @@ func collectNonTestInterfaces(pkg *packages.Package) map[string]token.Position {
 		if analysisutil.IsTestFile(file, pkg.Fset) {
 			continue
 		}
-		for _, decl := range file.Decls {
-			gd, ok := decl.(*ast.GenDecl)
-			if !ok {
-				continue
+		analysisutil.WalkTypeSpecs(file, pkg.Fset, func(ts *ast.TypeSpec, pos token.Position) {
+			if ts.Assign != 0 {
+				return
 			}
-			for _, spec := range gd.Specs {
-				ts, ok := spec.(*ast.TypeSpec)
-				if !ok || ts.Assign != 0 {
-					continue
-				}
-				if _, ok := ts.Type.(*ast.InterfaceType); ok {
-					result[ts.Name.Name] = pkg.Fset.Position(ts.Name.Pos())
-				}
+			if _, ok := ts.Type.(*ast.InterfaceType); ok {
+				result[ts.Name.Name] = pos
 			}
-		}
+		})
 	}
 	return result
 }

--- a/rules/interfaces/cross_domain.go
+++ b/rules/interfaces/cross_domain.go
@@ -3,6 +3,7 @@ package interfaces
 import (
 	"fmt"
 	"go/ast"
+	"go/token"
 	"sort"
 	"strings"
 
@@ -64,27 +65,19 @@ func (r *CrossDomainAnonymous) checkPackage(pkg *packages.Package, arch core.Arc
 		if analysisutil.IsTestFile(file, pkg.Fset) {
 			continue
 		}
-		for _, decl := range file.Decls {
-			switch d := decl.(type) {
-			case *ast.GenDecl:
-				for _, spec := range d.Specs {
-					ts, ok := spec.(*ast.TypeSpec)
-					if !ok {
-						continue
-					}
-					if _, isIface := ts.Type.(*ast.InterfaceType); isIface {
-						continue
-					}
-					violations = append(violations, r.inspectExpr(ts.Type, file, pkg, currentDomain, arch)...)
-				}
-			case *ast.FuncDecl:
-				if d.Type == nil {
-					continue
-				}
-				violations = append(violations, r.inspectFieldList(d.Type.Params, file, pkg, currentDomain, arch)...)
-				violations = append(violations, r.inspectFieldList(d.Type.Results, file, pkg, currentDomain, arch)...)
+		analysisutil.WalkTypeSpecs(file, pkg.Fset, func(ts *ast.TypeSpec, _ token.Position) {
+			if _, isIface := ts.Type.(*ast.InterfaceType); isIface {
+				return
 			}
-		}
+			violations = append(violations, r.inspectExpr(ts.Type, file, pkg, currentDomain, arch)...)
+		})
+		analysisutil.WalkFuncDecls(file, func(fd *ast.FuncDecl) {
+			if fd.Type == nil {
+				return
+			}
+			violations = append(violations, r.inspectFieldList(fd.Type.Params, file, pkg, currentDomain, arch)...)
+			violations = append(violations, r.inspectFieldList(fd.Type.Results, file, pkg, currentDomain, arch)...)
+		})
 	}
 	return violations
 }

--- a/rules/interfaces/layout_meta.go
+++ b/rules/interfaces/layout_meta.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/NamhaeSusan/go-arch-guard/core"
+	"github.com/NamhaeSusan/go-arch-guard/rules/internal/rulemeta"
 	"golang.org/x/tools/go/packages"
 )
 
@@ -27,13 +28,9 @@ func hasInternalPackages(pkgs []*packages.Package, projectModule, internalRoot s
 }
 
 func metaLayoutNotSupported(ruleID, projectModule string) core.Violation {
-	return core.Violation{
-		Rule:              "meta.layout-not-supported",
-		Message:           fmt.Sprintf("%s requires an internal/-based layout; no internal/ packages found in module %q", ruleID, projectModule),
-		Fix:               "use this rule with internal/-based presets (DDD, CleanArch, Hexagonal, ModularMonolith), or remove it from your ruleset for flat layouts",
-		DefaultSeverity:   core.Warning,
-		EffectiveSeverity: core.Warning,
-	}
+	return rulemeta.LayoutNotSupported(
+		fmt.Sprintf("%s requires an internal/-based layout; no internal/ packages found in module %q", ruleID, projectModule),
+		"use this rule with internal/-based presets (DDD, CleanArch, Hexagonal, ModularMonolith), or remove it from your ruleset for flat layouts")
 }
 
 // metaRuleDisabledByConfig signals that a rule is registered in the RuleSet
@@ -41,11 +38,5 @@ func metaLayoutNotSupported(ruleID, projectModule string) core.Violation {
 // (whole rule) or makes a sub-check inert (partial). Severity defaults to
 // Warning via the runner's meta.* prefix handling.
 func metaRuleDisabledByConfig(ruleID, reason, fix string) core.Violation {
-	return core.Violation{
-		Rule:              "meta.rule-disabled-by-config",
-		Message:           fmt.Sprintf("%s: %s", ruleID, reason),
-		Fix:               fix,
-		DefaultSeverity:   core.Warning,
-		EffectiveSeverity: core.Warning,
-	}
+	return rulemeta.RuleDisabledByConfig(ruleID, reason, fix)
 }

--- a/rules/interfaces/pattern.go
+++ b/rules/interfaces/pattern.go
@@ -3,6 +3,7 @@ package interfaces
 import (
 	"fmt"
 	"go/ast"
+	"go/token"
 	"go/types"
 	"sort"
 	"strings"
@@ -196,19 +197,11 @@ func collectExportedStructs(pkg *packages.Package) map[string]bool {
 func collectExportedTypeSpecs(pkg *packages.Package) []*ast.TypeSpec {
 	var result []*ast.TypeSpec
 	for _, file := range pkg.Syntax {
-		for _, decl := range file.Decls {
-			gd, ok := decl.(*ast.GenDecl)
-			if !ok {
-				continue
-			}
-			for _, spec := range gd.Specs {
-				ts, ok := spec.(*ast.TypeSpec)
-				if !ok || !ts.Name.IsExported() {
-					continue
-				}
+		analysisutil.WalkTypeSpecs(file, nil, func(ts *ast.TypeSpec, _ token.Position) {
+			if ts.Name.IsExported() {
 				result = append(result, ts)
 			}
-		}
+		})
 	}
 	return result
 }
@@ -228,10 +221,9 @@ func lookupInterface(scope *types.Scope, name string) *types.Interface {
 func (r *Pattern) checkConstructorName(pkg *packages.Package) []core.Violation {
 	var violations []core.Violation
 	for _, file := range pkg.Syntax {
-		for _, decl := range file.Decls {
-			fd, ok := decl.(*ast.FuncDecl)
-			if !ok || fd.Recv != nil || !fd.Name.IsExported() {
-				continue
+		analysisutil.WalkFuncDecls(file, func(fd *ast.FuncDecl) {
+			if fd.Recv != nil || !fd.Name.IsExported() {
+				return
 			}
 			name := fd.Name.Name
 			if strings.HasPrefix(name, "New") && name != "New" {
@@ -239,7 +231,7 @@ func (r *Pattern) checkConstructorName(pkg *packages.Package) []core.Violation {
 					fmt.Sprintf("constructor %q must be named \"New\"; NewXxx variants are not allowed", name),
 					"rename to \"New\""))
 			}
-		}
+		})
 	}
 	return violations
 }
@@ -247,18 +239,17 @@ func (r *Pattern) checkConstructorName(pkg *packages.Package) []core.Violation {
 func (r *Pattern) checkConstructorReturnsInterface(pkg *packages.Package, ifaces map[string]*ast.InterfaceType) []core.Violation {
 	var violations []core.Violation
 	for _, file := range pkg.Syntax {
-		for _, decl := range file.Decls {
-			fd, ok := decl.(*ast.FuncDecl)
-			if !ok || fd.Recv != nil || fd.Name.Name != "New" {
-				continue
+		analysisutil.WalkFuncDecls(file, func(fd *ast.FuncDecl) {
+			if fd.Recv != nil || fd.Name.Name != "New" {
+				return
 			}
 			if fd.Type.Results == nil || len(fd.Type.Results.List) == 0 {
-				continue
+				return
 			}
 
 			firstRet := fd.Type.Results.List[0].Type
 			if ident, ok := firstRet.(*ast.Ident); ok && ifaces[ident.Name] != nil {
-				continue
+				return
 			}
 
 			fix := "return an interface type"
@@ -270,7 +261,7 @@ func (r *Pattern) checkConstructorReturnsInterface(pkg *packages.Package, ifaces
 			violations = append(violations, r.violation(pkg, 0, "interfaces.constructor-returns-interface",
 				fmt.Sprintf("New() returns %s, should return an interface", formatTypeExpr(firstRet)),
 				fix))
-		}
+		})
 	}
 	return violations
 }

--- a/rules/internal/rulemeta/meta.go
+++ b/rules/internal/rulemeta/meta.go
@@ -1,0 +1,29 @@
+package rulemeta
+
+import (
+	"fmt"
+
+	"github.com/NamhaeSusan/go-arch-guard/core"
+)
+
+func Warning(rule, message, fix string) core.Violation {
+	return core.Violation{
+		Rule:              rule,
+		Message:           message,
+		Fix:               fix,
+		DefaultSeverity:   core.Warning,
+		EffectiveSeverity: core.Warning,
+	}
+}
+
+func RuleDisabledByConfig(ruleID, reason, fix string) core.Violation {
+	return Warning("meta.rule-disabled-by-config", fmt.Sprintf("%s: %s", ruleID, reason), fix)
+}
+
+func LayoutNotSupported(message, fix string) core.Violation {
+	return Warning("meta.layout-not-supported", message, fix)
+}
+
+func NoMatchingPackages(message string) core.Violation {
+	return Warning("meta.no-matching-packages", message, "verify the module argument matches go.mod")
+}

--- a/rules/internal/rulemeta/meta_test.go
+++ b/rules/internal/rulemeta/meta_test.go
@@ -1,0 +1,24 @@
+package rulemeta_test
+
+import (
+	"testing"
+
+	"github.com/NamhaeSusan/go-arch-guard/core"
+	"github.com/NamhaeSusan/go-arch-guard/rules/internal/rulemeta"
+)
+
+func TestRuleDisabledByConfig(t *testing.T) {
+	got := rulemeta.RuleDisabledByConfig("rules.example", "missing config", "set config")
+	if got.Rule != "meta.rule-disabled-by-config" {
+		t.Fatalf("Rule = %q", got.Rule)
+	}
+	if got.Message != "rules.example: missing config" {
+		t.Fatalf("Message = %q", got.Message)
+	}
+	if got.Fix != "set config" {
+		t.Fatalf("Fix = %q", got.Fix)
+	}
+	if got.DefaultSeverity != core.Warning || got.EffectiveSeverity != core.Warning {
+		t.Fatalf("severity = %s/%s, want warning/warning", got.DefaultSeverity, got.EffectiveSeverity)
+	}
+}

--- a/rules/naming/impl_suffix.go
+++ b/rules/naming/impl_suffix.go
@@ -2,6 +2,7 @@ package naming
 
 import (
 	"go/ast"
+	"go/token"
 	"strings"
 
 	"github.com/NamhaeSusan/go-arch-guard/core"
@@ -33,28 +34,20 @@ func (r *ImplSuffix) Check(ctx *core.Context) []core.Violation {
 			if ctx.IsExcluded(filePath) {
 				continue
 			}
-			for _, decl := range file.Decls {
-				gd, ok := decl.(*ast.GenDecl)
-				if !ok {
-					continue
+			analysisutil.WalkTypeSpecs(file, pkg.Fset, func(ts *ast.TypeSpec, pos token.Position) {
+				if !ts.Name.IsExported() || !strings.HasSuffix(ts.Name.Name, "Impl") {
+					return
 				}
-				for _, spec := range gd.Specs {
-					ts, ok := spec.(*ast.TypeSpec)
-					if !ok || !ts.Name.IsExported() || !strings.HasSuffix(ts.Name.Name, "Impl") {
-						continue
-					}
-					pos := pkg.Fset.Position(ts.Name.Pos())
-					violations = append(violations, core.Violation{
-						File:              analysisutil.RelativePathForPackage(pkg, pos.Filename),
-						Line:              pos.Line,
-						Rule:              "naming.no-impl-suffix",
-						Message:           `type "` + ts.Name.Name + `" uses banned suffix "Impl"`,
-						Fix:               "rename without Impl suffix",
-						DefaultSeverity:   r.severity,
-						EffectiveSeverity: r.severity,
-					})
-				}
-			}
+				violations = append(violations, core.Violation{
+					File:              analysisutil.RelativePathForPackage(pkg, pos.Filename),
+					Line:              pos.Line,
+					Rule:              "naming.no-impl-suffix",
+					Message:           `type "` + ts.Name.Name + `" uses banned suffix "Impl"`,
+					Fix:               "rename without Impl suffix",
+					DefaultSeverity:   r.severity,
+					EffectiveSeverity: r.severity,
+				})
+			})
 		}
 	}
 	return violations

--- a/rules/naming/no_stutter.go
+++ b/rules/naming/no_stutter.go
@@ -2,6 +2,7 @@ package naming
 
 import (
 	"go/ast"
+	"go/token"
 	"strings"
 	"unicode"
 
@@ -36,30 +37,22 @@ func (r *NoStutter) Check(ctx *core.Context) []core.Violation {
 			if ctx.IsExcluded(filePath) {
 				continue
 			}
-			for _, decl := range file.Decls {
-				gd, ok := decl.(*ast.GenDecl)
-				if !ok {
-					continue
+			analysisutil.WalkTypeSpecs(file, pkg.Fset, func(ts *ast.TypeSpec, pos token.Position) {
+				if !ts.Name.IsExported() {
+					return
 				}
-				for _, spec := range gd.Specs {
-					ts, ok := spec.(*ast.TypeSpec)
-					if !ok || !ts.Name.IsExported() {
-						continue
-					}
-					name := ts.Name.Name
-					if !stutters(pkgName, name) {
-						continue
-					}
-					suggested := string([]rune(name)[pkgNameLen:])
-					pos := pkg.Fset.Position(ts.Name.Pos())
-					violations = append(violations, r.violation(
-						analysisutil.RelativePathForPackage(pkg, pos.Filename),
-						pos.Line,
-						`type "`+name+`" stutters with package "`+pkgName+`"`,
-						`rename to "`+suggested+`"`,
-					))
+				name := ts.Name.Name
+				if !stutters(pkgName, name) {
+					return
 				}
-			}
+				suggested := string([]rune(name)[pkgNameLen:])
+				violations = append(violations, r.violation(
+					analysisutil.RelativePathForPackage(pkg, pos.Filename),
+					pos.Line,
+					`type "`+name+`" stutters with package "`+pkgName+`"`,
+					`rename to "`+suggested+`"`,
+				))
+			})
 		}
 	}
 	return violations

--- a/rules/naming/type_pattern.go
+++ b/rules/naming/type_pattern.go
@@ -3,6 +3,7 @@ package naming
 import (
 	"fmt"
 	"go/ast"
+	"go/token"
 	"path/filepath"
 	"strings"
 
@@ -120,37 +121,27 @@ func (r *TypePattern) checkPackage(ctx *core.Context, pkg *packages.Package, pat
 }
 
 func hasTypePatternExportedType(file *ast.File, name string) bool {
-	for _, decl := range file.Decls {
-		gd, ok := decl.(*ast.GenDecl)
-		if !ok {
-			continue
+	found := false
+	analysisutil.WalkTypeSpecs(file, nil, func(ts *ast.TypeSpec, _ token.Position) {
+		if ts.Name.Name == name && ts.Name.IsExported() {
+			found = true
 		}
-		for _, spec := range gd.Specs {
-			ts, ok := spec.(*ast.TypeSpec)
-			if !ok {
-				continue
-			}
-			if ts.Name.Name == name && ts.Name.IsExported() {
-				return true
-			}
-		}
-	}
-	return false
+	})
+	return found
 }
 
 func collectTypePatternMethods(pkg *packages.Package) map[string]bool {
 	result := make(map[string]bool)
 	for _, file := range pkg.Syntax {
-		for _, decl := range file.Decls {
-			fd, ok := decl.(*ast.FuncDecl)
-			if !ok || fd.Recv == nil || len(fd.Recv.List) == 0 {
-				continue
+		analysisutil.WalkFuncDecls(file, func(fd *ast.FuncDecl) {
+			if fd.Recv == nil || len(fd.Recv.List) == 0 {
+				return
 			}
 			typeName := analysisutil.ReceiverTypeName(fd.Recv.List[0].Type)
 			if typeName != "" {
 				result[typeName+"."+fd.Name.Name] = true
 			}
-		}
+		})
 	}
 	return result
 }

--- a/rules/structural/alias.go
+++ b/rules/structural/alias.go
@@ -145,7 +145,7 @@ func (r *Alias) checkAliasTypes(aliasPath, aliasRel, aliasName string, arch core
 			v.Line = info.Line
 			violations = append(violations, v)
 		}
-		if src := analysisutil.MatchContractSublayer(arch.Layers, info.AliasFrom); src != "" {
+		if src := analysisutil.MatchContractSublayerInLayout(arch.Layers, arch.Layout, info.AliasFrom); src != "" {
 			v := violation(r.severity, aliasContractExport, aliasRel,
 				aliasName+` re-exports "`+info.Name+`" from `+src+` - suspected cross-domain dependency; use `+arch.Layout.OrchestrationDir+`/ instead`,
 				"move cross-domain coordination to "+arch.Layout.OrchestrationDir+"/handler/ or "+arch.Layout.OrchestrationDir+"/")

--- a/rules/structural/layer_placement.go
+++ b/rules/structural/layer_placement.go
@@ -14,8 +14,9 @@ const (
 )
 
 // LayerPlacement flags layer-named directories that appear outside their
-// allowed slice. It enforces a fixed vocabulary of three layer names —
-// "app", "infra", "handler" — each with its own ad-hoc placement logic:
+// allowed slice. LayerModel.LayerLocations can define custom placement
+// templates for any layer basename. When no explicit template exists for a
+// name, the rule keeps its legacy fallback vocabulary:
 //
 //   - "app": allowed at internal/<Layout.AppDir> or per-domain
 //     internal/<DomainDir>/<X>/app/
@@ -27,12 +28,8 @@ const (
 //     internal/<DomainDir>/<X>/handler/.
 //
 // LayerDirNames can narrow the active set (only names present in the map
-// are checked) but cannot add new names — directory names other than the
-// three above silently pass. Teams using a different vocabulary
-// (e.g. "controller", "usecase", "port") get no protection from this rule.
-//
-// Generalizing to fully data-driven placement (LayerLocations on
-// LayerModel) is tracked in issue #104.
+// are checked). LayerLocations adds protection for additional names such as
+// "controller", "usecase", or "port" without changing the legacy fallback.
 type LayerPlacement struct {
 	severity core.Severity
 }
@@ -97,6 +94,9 @@ func isMisplacedLayerDir(arch core.Architecture, rel, name string) bool {
 	if len(arch.Layers.LayerDirNames) > 0 && !arch.Layers.LayerDirNames[name] {
 		return false
 	}
+	if locations, ok := arch.Layers.LayerLocations[name]; ok {
+		return !matchesAnyLayerLocation(arch, rel, locations)
+	}
 	switch name {
 	case "app", "infra":
 		if name == "app" && arch.Layout.AppDir != "" && rel == filepath.ToSlash(filepath.Join(arch.Layout.InternalRoot, arch.Layout.AppDir)) {
@@ -115,6 +115,47 @@ func isMisplacedLayerDir(arch core.Architecture, rel, name string) bool {
 	default:
 		return false
 	}
+}
+
+func matchesAnyLayerLocation(arch core.Architecture, rel string, locations []string) bool {
+	for _, location := range locations {
+		if matchLayerLocation(arch, rel, location) {
+			return true
+		}
+	}
+	return false
+}
+
+func matchLayerLocation(arch core.Architecture, rel, location string) bool {
+	location = strings.Trim(strings.TrimSpace(location), "/")
+	location = strings.NewReplacer(
+		"{InternalRoot}", arch.Layout.InternalRoot,
+		"{DomainDir}", arch.Layout.DomainDir,
+		"{OrchestrationDir}", arch.Layout.OrchestrationDir,
+		"{SharedDir}", arch.Layout.SharedDir,
+		"{AppDir}", arch.Layout.AppDir,
+		"{ServerDir}", arch.Layout.ServerDir,
+	).Replace(location)
+	patternParts := strings.Split(filepath.ToSlash(location), "/")
+	relParts := strings.Split(strings.Trim(filepath.ToSlash(rel), "/"), "/")
+	return matchLayerLocationParts(patternParts, relParts)
+}
+
+func matchLayerLocationParts(pattern, rel []string) bool {
+	if len(pattern) == 0 {
+		return len(rel) == 0
+	}
+	if pattern[0] == "**" {
+		return len(pattern) == 1 || matchLayerLocationParts(pattern[1:], rel) ||
+			(len(rel) > 0 && matchLayerLocationParts(pattern, rel[1:]))
+	}
+	if len(rel) == 0 {
+		return false
+	}
+	if pattern[0] == "*" {
+		return rel[0] != "" && matchLayerLocationParts(pattern[1:], rel[1:])
+	}
+	return pattern[0] == rel[0] && matchLayerLocationParts(pattern[1:], rel[1:])
 }
 
 func matchesDomainLayer(arch core.Architecture, rel, name string) bool {

--- a/rules/structural/layer_placement_test.go
+++ b/rules/structural/layer_placement_test.go
@@ -1,8 +1,10 @@
 package structural_test
 
 import (
+	"path/filepath"
 	"testing"
 
+	"github.com/NamhaeSusan/go-arch-guard/core"
 	"github.com/NamhaeSusan/go-arch-guard/rules/structural"
 )
 
@@ -16,4 +18,46 @@ func TestLayerPlacement(t *testing.T) {
 		violations := runRule(t, "../../testdata/invalid", structural.NewLayerPlacement())
 		assertViolation(t, violations, "structural.misplaced-layer", "internal/platform/handler/")
 	})
+
+	t.Run("detects custom layer names using configured locations", func(t *testing.T) {
+		root := t.TempDir()
+		writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "controller", "controller.go"), "package controller\n")
+		writeTestFile(t, filepath.Join(root, "internal", "platform", "controller", "controller.go"), "package controller\n")
+
+		arch := dddArch()
+		arch.Layers.LayerDirNames["controller"] = true
+		arch.Layers.LayerLocations = map[string][]string{
+			"controller": {"{InternalRoot}/{DomainDir}/*/controller"},
+		}
+		ctx := core.NewContext(nil, "github.com/example/app", root, arch, nil)
+
+		violations := core.Run(ctx, core.NewRuleSet(structural.NewLayerPlacement()))
+		assertViolation(t, violations, "structural.misplaced-layer", "internal/platform/controller/")
+		assertNoViolationAt(t, violations, "structural.misplaced-layer", "internal/domain/order/controller/")
+	})
+
+	t.Run("keeps built-in fallback checks when custom locations are configured", func(t *testing.T) {
+		root := t.TempDir()
+		writeTestFile(t, filepath.Join(root, "internal", "platform", "handler", "handler.go"), "package handler\n")
+		writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "controller", "controller.go"), "package controller\n")
+
+		arch := dddArch()
+		arch.Layers.LayerDirNames["controller"] = true
+		arch.Layers.LayerLocations = map[string][]string{
+			"controller": {"{InternalRoot}/{DomainDir}/*/controller"},
+		}
+		ctx := core.NewContext(nil, "github.com/example/app", root, arch, nil)
+
+		violations := core.Run(ctx, core.NewRuleSet(structural.NewLayerPlacement()))
+		assertViolation(t, violations, "structural.misplaced-layer", "internal/platform/handler/")
+	})
+}
+
+func assertNoViolationAt(t *testing.T, violations []core.Violation, rule, file string) {
+	t.Helper()
+	for _, v := range violations {
+		if v.Rule == rule && v.File == file {
+			t.Fatalf("unexpected %s at %s in %#v", rule, file, violations)
+		}
+	}
 }

--- a/rules/structural/layout_meta.go
+++ b/rules/structural/layout_meta.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/NamhaeSusan/go-arch-guard/core"
+	"github.com/NamhaeSusan/go-arch-guard/rules/internal/rulemeta"
 )
 
 // hasInternalDir reports whether <root>/<internalRoot> exists as a
@@ -21,13 +22,9 @@ func hasInternalDir(root, internalRoot string) bool {
 }
 
 func metaLayoutNotSupported(ruleID string) core.Violation {
-	return core.Violation{
-		Rule:              "meta.layout-not-supported",
-		Message:           fmt.Sprintf("%s requires an internal/-based layout; internal/ directory not found", ruleID),
-		Fix:               "use this rule with internal/-based presets (DDD, CleanArch, Hexagonal, ModularMonolith), or remove it from your ruleset for flat layouts",
-		DefaultSeverity:   core.Warning,
-		EffectiveSeverity: core.Warning,
-	}
+	return rulemeta.LayoutNotSupported(
+		fmt.Sprintf("%s requires an internal/-based layout; internal/ directory not found", ruleID),
+		"use this rule with internal/-based presets (DDD, CleanArch, Hexagonal, ModularMonolith), or remove it from your ruleset for flat layouts")
 }
 
 // metaRuleDisabledByConfig signals that a rule is registered in the RuleSet
@@ -35,11 +32,5 @@ func metaLayoutNotSupported(ruleID string) core.Violation {
 // (whole rule) or makes a sub-check inert (partial). Severity defaults to
 // Warning via the runner's meta.* prefix handling.
 func metaRuleDisabledByConfig(ruleID, reason, fix string) core.Violation {
-	return core.Violation{
-		Rule:              "meta.rule-disabled-by-config",
-		Message:           fmt.Sprintf("%s: %s", ruleID, reason),
-		Fix:               fix,
-		DefaultSeverity:   core.Warning,
-		EffectiveSeverity: core.Warning,
-	}
+	return rulemeta.RuleDisabledByConfig(ruleID, reason, fix)
 }

--- a/rules/structural/repo_file_interface.go
+++ b/rules/structural/repo_file_interface.go
@@ -56,15 +56,17 @@ func (r *RepoFileInterface) Spec() core.RuleSpec {
 }
 
 func (r *RepoFileInterface) Check(ctx *core.Context) []core.Violation {
-	layers := ctx.Arch().Layers
+	arch := ctx.Arch()
+	layers := arch.Layers
 	if !analysisutil.HasPortSublayer(layers) {
 		return []core.Violation{metaRuleDisabledByConfig("structural.repo-file-interface",
 			"LayerModel.PortLayers is empty; repo-file interface enforcement requires at least one port sublayer",
 			"declare PortLayers in your LayerModel (e.g. []string{\"core/repo\"}), or remove structural.NewRepoFileInterface() from your RuleSet")}
 	}
+	module := analysisutil.ResolveModuleFromContext(ctx, "")
 	var violations []core.Violation
 	for _, pkg := range ctx.Pkgs() {
-		if portLayer := analysisutil.MatchPortSublayer(layers, pkg.PkgPath); portLayer != "" {
+		if portLayer, ok := domainSublayerForPackage(module, arch, pkg.PkgPath); ok && analysisutil.IsPortSublayer(layers, portLayer) {
 			violations = append(violations, r.checkPortPackage(ctx, pkg, portLayer)...)
 			continue
 		}

--- a/rules/tx/boundary.go
+++ b/rules/tx/boundary.go
@@ -3,11 +3,13 @@ package tx
 import (
 	"fmt"
 	"go/ast"
+	"go/types"
 	"slices"
 	"strings"
 
 	"github.com/NamhaeSusan/go-arch-guard/core"
 	"github.com/NamhaeSusan/go-arch-guard/core/analysisutil"
+	"github.com/NamhaeSusan/go-arch-guard/rules/internal/rulemeta"
 	"golang.org/x/tools/go/packages"
 )
 
@@ -105,30 +107,18 @@ func (r *Boundary) checkStartCalls(ctx *core.Context, allowed []string) []core.V
 	allowedSet := stringSet(allowed)
 
 	var violations []core.Violation
-	r.walkInternalPackages(ctx, func(pkg *packages.Package, layer string) {
-		if allowedSet[layer] || pkg.TypesInfo == nil {
+	checkSymbolCalls(ctx, true, func(hit symbolCall) {
+		if allowedSet[hit.layer] || !wanted[hit.symbol] {
 			return
 		}
-		for _, file := range pkg.Syntax {
-			ast.Inspect(file, func(n ast.Node) bool {
-				call, ok := n.(*ast.CallExpr)
-				if !ok {
-					return true
-				}
-				if !wanted[analysisutil.ResolveCalleeID(pkg.TypesInfo, call)] {
-					return true
-				}
-				pos := pkg.Fset.Position(call.Pos())
-				violations = append(violations, r.violation(
-					startOutsideLayerID,
-					analysisutil.RelPathFromRoot(ctx.Root(), pos.Filename),
-					pos.Line,
-					fmt.Sprintf("transaction must not start in layer %q; allowed layers: %v", layer, allowed),
-					fmt.Sprintf("move the transaction-starting call out of %q into an allowed layer: %v", layer, allowed),
-				))
-				return true
-			})
-		}
+		pos := hit.pkg.Fset.Position(hit.call.Pos())
+		violations = append(violations, r.violation(
+			startOutsideLayerID,
+			analysisutil.RelPathFromRoot(ctx.Root(), pos.Filename),
+			pos.Line,
+			fmt.Sprintf("transaction must not start in layer %q; allowed layers: %v", hit.layer, allowed),
+			fmt.Sprintf("move the transaction-starting call out of %q into an allowed layer: %v", hit.layer, allowed),
+		))
 	})
 	return violations
 }
@@ -146,59 +136,31 @@ func (r *Boundary) checkSignatureTypes(ctx *core.Context, allowed []string) []co
 			return
 		}
 		for _, file := range pkg.Syntax {
-			for _, decl := range file.Decls {
-				fd, ok := decl.(*ast.FuncDecl)
-				if !ok || fd.Type == nil {
-					continue
-				}
-				r.checkFields(ctx, pkg, fd.Type.Params, wanted, allowed, &violations)
-				r.checkFields(ctx, pkg, fd.Type.Results, wanted, allowed, &violations)
-			}
+			analysisutil.WalkFuncSignatureTypes(pkg.TypesInfo, file, func(_ *ast.FuncDecl, field *ast.Field, typ types.Type) {
+				r.checkSignatureField(ctx, pkg, field, typ, wanted, allowed, &violations)
+			})
 		}
 	})
 	return violations
 }
 
-func (r *Boundary) checkFields(ctx *core.Context, pkg *packages.Package, fields *ast.FieldList, wanted map[string]bool, allowed []string, out *[]core.Violation) {
-	if fields == nil {
+func (r *Boundary) checkSignatureField(ctx *core.Context, pkg *packages.Package, field *ast.Field, typ types.Type, wanted map[string]bool, allowed []string, out *[]core.Violation) {
+	id := analysisutil.NamedQualifiedName(analysisutil.StripWrappers(typ))
+	if id == "" || !wanted[id] {
 		return
 	}
-	for _, field := range fields.List {
-		typ := pkg.TypesInfo.TypeOf(field.Type)
-		id := analysisutil.NamedQualifiedName(analysisutil.StripWrappers(typ))
-		if id == "" || !wanted[id] {
-			continue
-		}
-		pos := pkg.Fset.Position(field.Pos())
-		*out = append(*out, r.violation(
-			typeInSignatureID,
-			analysisutil.RelPathFromRoot(ctx.Root(), pos.Filename),
-			pos.Line,
-			fmt.Sprintf("tx type %q must not appear in function signature outside allowed layers: %v", id, allowed),
-			fmt.Sprintf("keep %q confined to allowed layers: %v", id, allowed),
-		))
-	}
+	pos := pkg.Fset.Position(field.Pos())
+	*out = append(*out, r.violation(
+		typeInSignatureID,
+		analysisutil.RelPathFromRoot(ctx.Root(), pos.Filename),
+		pos.Line,
+		fmt.Sprintf("tx type %q must not appear in function signature outside allowed layers: %v", id, allowed),
+		fmt.Sprintf("keep %q confined to allowed layers: %v", id, allowed),
+	))
 }
 
 func (r *Boundary) walkInternalPackages(ctx *core.Context, visit func(*packages.Package, string)) {
-	module := analysisutil.ResolveModuleFromContext(ctx, "")
-	if module == "" {
-		return
-	}
-	internalPrefix := module + "/" + ctx.Arch().Layout.InternalRoot + "/"
-	for _, pkg := range ctx.Pkgs() {
-		if !strings.HasPrefix(pkg.PkgPath, internalPrefix) {
-			continue
-		}
-		if ctx.IsExcluded(analysisutil.ProjectRelativePackagePath(pkg.PkgPath, module)) {
-			continue
-		}
-		layer := packageLayer(ctx.Arch(), pkg.PkgPath, internalPrefix)
-		if layer == "" {
-			continue
-		}
-		visit(pkg, layer)
-	}
+	walkInternalPackages(ctx, visit)
 }
 
 func (r *Boundary) violation(rule, file string, line int, message, fix string) core.Violation {
@@ -217,13 +179,7 @@ func (r *Boundary) violation(rule, file string, line int, message, fix string) c
 // but the supplied core.Architecture configuration prevents it from running.
 // Severity defaults to Warning via the runner's meta.* prefix handling.
 func metaRuleDisabledByConfig(ruleID, reason, fix string) core.Violation {
-	return core.Violation{
-		Rule:              "meta.rule-disabled-by-config",
-		Message:           fmt.Sprintf("%s: %s", ruleID, reason),
-		Fix:               fix,
-		DefaultSeverity:   core.Warning,
-		EffectiveSeverity: core.Warning,
-	}
+	return rulemeta.RuleDisabledByConfig(ruleID, reason, fix)
 }
 
 func packageLayer(arch core.Architecture, pkgPath, internalPrefix string) string {

--- a/rules/tx/calls.go
+++ b/rules/tx/calls.go
@@ -1,0 +1,236 @@
+package tx
+
+import (
+	"fmt"
+	"go/ast"
+	"slices"
+	"strings"
+
+	"github.com/NamhaeSusan/go-arch-guard/core"
+	"github.com/NamhaeSusan/go-arch-guard/core/analysisutil"
+	"golang.org/x/tools/go/packages"
+)
+
+const (
+	forbiddenCallRuleID    = "tx.forbidden-call"
+	mandatoryWrapperRuleID = "tx.mandatory-wrapper"
+)
+
+type ForbiddenCall struct {
+	Symbols       []string
+	AllowedLayers []string
+}
+
+type MandatoryWrapper struct {
+	Symbols       []string
+	AllowedLayers []string
+	ReplaceWith   string
+}
+
+type CallOption func(*callRule)
+
+func WithCallSeverity(s core.Severity) CallOption {
+	return func(r *callRule) {
+		r.severity = s
+	}
+}
+
+type callPolicy struct {
+	symbols       []string
+	allowedLayers []string
+	replaceWith   string
+}
+
+type symbolCall struct {
+	pkg    *packages.Package
+	layer  string
+	relPkg string
+	symbol string
+	call   *ast.CallExpr
+}
+
+type callRule struct {
+	id          string
+	description string
+	policies    []callPolicy
+	severity    core.Severity
+	message     func(symbol, layer string, allowed []string, replacement string) (string, string)
+}
+
+func NewForbiddenCalls(calls []ForbiddenCall, opts ...CallOption) core.Rule {
+	policies := make([]callPolicy, 0, len(calls))
+	for _, call := range calls {
+		policies = append(policies, callPolicy{
+			symbols:       slices.Clone(call.Symbols),
+			allowedLayers: slices.Clone(call.AllowedLayers),
+		})
+	}
+	return newCallRule(forbiddenCallRuleID, "forbid configured calls outside allowed layers", policies, forbiddenCallMessage, opts...)
+}
+
+func NewMandatoryWrapper(wrappers []MandatoryWrapper, opts ...CallOption) core.Rule {
+	policies := make([]callPolicy, 0, len(wrappers))
+	for _, wrapper := range wrappers {
+		policies = append(policies, callPolicy{
+			symbols:       slices.Clone(wrapper.Symbols),
+			allowedLayers: slices.Clone(wrapper.AllowedLayers),
+			replaceWith:   wrapper.ReplaceWith,
+		})
+	}
+	return newCallRule(mandatoryWrapperRuleID, "require configured calls to go through project wrappers", policies, mandatoryWrapperMessage, opts...)
+}
+
+func newCallRule(id, description string, policies []callPolicy, message func(string, string, []string, string) (string, string), opts ...CallOption) *callRule {
+	r := &callRule{
+		id:          id,
+		description: description,
+		policies:    policies,
+		severity:    core.Error,
+		message:     message,
+	}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r
+}
+
+func (r *callRule) Spec() core.RuleSpec {
+	return core.RuleSpec{
+		ID:              r.id,
+		Description:     r.description,
+		DefaultSeverity: r.severity,
+		Violations: []core.ViolationSpec{{
+			ID:              r.id,
+			Description:     r.description,
+			DefaultSeverity: r.severity,
+		}},
+	}
+}
+
+func (r *callRule) Check(ctx *core.Context) []core.Violation {
+	if ctx == nil {
+		return nil
+	}
+	if len(r.policies) == 0 || !hasConfiguredSymbols(r.policies) {
+		return []core.Violation{metaRuleDisabledByConfig(r.id,
+			"no call symbols configured; call enforcement skipped",
+			"configure at least one symbol, or remove this tx call rule from your RuleSet")}
+	}
+
+	module := analysisutil.ResolveModuleFromContext(ctx, "")
+	if module == "" {
+		return nil
+	}
+	var violations []core.Violation
+	checkSymbolCalls(ctx, false, func(hit symbolCall) {
+		for _, policy := range r.policies {
+			if !slices.Contains(policy.symbols, hit.symbol) || isAllowedCallSite(ctx.Arch().Layout.InternalRoot, policy.allowedLayers, hit.layer, hit.relPkg) {
+				continue
+			}
+			pos := hit.pkg.Fset.Position(hit.call.Pos())
+			message, fix := r.message(hit.symbol, hit.layer, policy.allowedLayers, policy.replaceWith)
+			violations = append(violations, core.Violation{
+				File:              analysisutil.RelPathFromRoot(ctx.Root(), pos.Filename),
+				Line:              pos.Line,
+				Rule:              r.id,
+				Message:           message,
+				Fix:               fix,
+				DefaultSeverity:   r.severity,
+				EffectiveSeverity: r.severity,
+			})
+		}
+	})
+	return violations
+}
+
+func hasConfiguredSymbols(policies []callPolicy) bool {
+	for _, policy := range policies {
+		if len(policy.symbols) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func isAllowedCallSite(internalRoot string, allowed []string, layer, relPkg string) bool {
+	if internalRoot == "" {
+		internalRoot = "internal"
+	}
+	relWithoutRoot := strings.TrimPrefix(relPkg, internalRoot+"/")
+	for _, item := range allowed {
+		item = strings.Trim(strings.TrimSpace(item), "/")
+		if item == "" {
+			continue
+		}
+		if item == layer {
+			return true
+		}
+		if strings.Contains(item, "/") &&
+			(relPkg == item || strings.HasPrefix(relPkg, item+"/") ||
+				relWithoutRoot == item || strings.HasPrefix(relWithoutRoot, item+"/")) {
+			return true
+		}
+	}
+	return false
+}
+
+func forbiddenCallMessage(symbol, layer string, allowed []string, _ string) (string, string) {
+	return fmt.Sprintf("call to %q is forbidden in layer %q; allowed layers/packages: %v", symbol, layer, allowed),
+		fmt.Sprintf("move this call into an allowed layer/package: %v", allowed)
+}
+
+func mandatoryWrapperMessage(symbol, layer string, allowed []string, replacement string) (string, string) {
+	if replacement == "" {
+		replacement = "a project wrapper"
+	}
+	return fmt.Sprintf("call to %q in layer %q must go through %s", symbol, layer, replacement),
+		fmt.Sprintf("replace the direct call with %s; direct calls are only allowed in: %v", replacement, allowed)
+}
+
+func walkInternalPackages(ctx *core.Context, visit func(*packages.Package, string)) {
+	walkInternalPackagesByMode(ctx, true, visit)
+}
+
+func walkInternalPackagesByMode(ctx *core.Context, layeredOnly bool, visit func(*packages.Package, string)) {
+	module := analysisutil.ResolveModuleFromContext(ctx, "")
+	if module == "" {
+		return
+	}
+	internalPrefix := module + "/" + ctx.Arch().Layout.InternalRoot + "/"
+	for _, pkg := range ctx.Pkgs() {
+		if !strings.HasPrefix(pkg.PkgPath, internalPrefix) {
+			continue
+		}
+		if ctx.IsExcluded(analysisutil.ProjectRelativePackagePath(pkg.PkgPath, module)) {
+			continue
+		}
+		layer := packageLayer(ctx.Arch(), pkg.PkgPath, internalPrefix)
+		if layer == "" && layeredOnly {
+			continue
+		}
+		visit(pkg, layer)
+	}
+}
+
+func checkSymbolCalls(ctx *core.Context, layeredOnly bool, visit func(symbolCall)) {
+	module := analysisutil.ResolveModuleFromContext(ctx, "")
+	walkInternalPackagesByMode(ctx, layeredOnly, func(pkg *packages.Package, layer string) {
+		if pkg.TypesInfo == nil {
+			return
+		}
+		relPkg := analysisutil.ProjectRelativePackagePath(pkg.PkgPath, module)
+		for _, file := range pkg.Syntax {
+			ast.Inspect(file, func(n ast.Node) bool {
+				call, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				symbol := analysisutil.ResolveCalleeID(pkg.TypesInfo, call)
+				if symbol != "" {
+					visit(symbolCall{pkg: pkg, layer: layer, relPkg: relPkg, symbol: symbol, call: call})
+				}
+				return true
+			})
+		}
+	})
+}

--- a/rules/tx/calls_test.go
+++ b/rules/tx/calls_test.go
@@ -1,0 +1,145 @@
+package tx_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/NamhaeSusan/go-arch-guard/analyzer"
+	"github.com/NamhaeSusan/go-arch-guard/core"
+	"github.com/NamhaeSusan/go-arch-guard/rules/tx"
+)
+
+func TestForbiddenCallsDetectsWrongLayer(t *testing.T) {
+	rule := tx.NewForbiddenCalls([]tx.ForbiddenCall{{
+		Symbols:       []string{"database/sql.(*DB).BeginTx"},
+		AllowedLayers: []string{"app"},
+	}})
+
+	got := rule.Check(txBoundaryContext(t, nil))
+
+	if countRule(got, "tx.forbidden-call") != 1 {
+		t.Fatalf("forbidden call count = %d, want 1: %+v", countRule(got, "tx.forbidden-call"), got)
+	}
+	if got[0].File != "internal/domain/order/core/repo/repository.go" {
+		t.Fatalf("violation file = %q, want repo", got[0].File)
+	}
+}
+
+func TestForbiddenCallsRespectsExcludesAndSeverity(t *testing.T) {
+	rule := tx.NewForbiddenCalls([]tx.ForbiddenCall{{
+		Symbols:       []string{"database/sql.(*DB).BeginTx"},
+		AllowedLayers: []string{"app"},
+	}}, tx.WithCallSeverity(core.Warning))
+
+	ctx := txBoundaryContext(t, []string{"internal/domain/order/core/repo/..."})
+	got := core.Run(ctx, core.NewRuleSet(rule))
+	if len(got) != 0 {
+		t.Fatalf("excluded repo should suppress forbidden calls, got %+v", got)
+	}
+
+	got = core.Run(txBoundaryContext(t, nil), core.NewRuleSet(rule))
+	if len(got) == 0 {
+		t.Fatal("expected severity-covered violation")
+	}
+	if got[0].DefaultSeverity != core.Warning || got[0].EffectiveSeverity != core.Warning {
+		t.Fatalf("severity = %s/%s, want warning/warning", got[0].DefaultSeverity, got[0].EffectiveSeverity)
+	}
+}
+
+func TestMandatoryWrapperDetectsDirectCallAndMentionsReplacement(t *testing.T) {
+	rule := tx.NewMandatoryWrapper([]tx.MandatoryWrapper{{
+		Symbols:       []string{"database/sql.(*DB).BeginTx"},
+		AllowedLayers: []string{"app"},
+		ReplaceWith:   "internal/pkg/tx.BeginTx",
+	}})
+
+	got := rule.Check(txBoundaryContext(t, nil))
+
+	if countRule(got, "tx.mandatory-wrapper") != 1 {
+		t.Fatalf("mandatory wrapper count = %d, want 1: %+v", countRule(got, "tx.mandatory-wrapper"), got)
+	}
+	if !strings.Contains(got[0].Fix, "internal/pkg/tx.BeginTx") {
+		t.Fatalf("fix should mention replacement, got %q", got[0].Fix)
+	}
+}
+
+func TestCallRulesAllowProjectRelativePackagePrefixesUnderInternalRoot(t *testing.T) {
+	rule := tx.NewMandatoryWrapper([]tx.MandatoryWrapper{{
+		Symbols:       []string{"database/sql.(*DB).BeginTx"},
+		AllowedLayers: []string{"pkg/httpclient"},
+		ReplaceWith:   "pkg/httpclient.BeginTx",
+	}})
+
+	got := rule.Check(callRuleSharedContext(t))
+
+	if countRule(got, "tx.mandatory-wrapper") != 1 {
+		t.Fatalf("mandatory wrapper count = %d, want only sibling shared package violation: %+v", countRule(got, "tx.mandatory-wrapper"), got)
+	}
+	if !strings.Contains(got[0].File, "internal/pkg/bad/bad.go") {
+		t.Fatalf("violation file = %q, want sibling shared package", got[0].File)
+	}
+}
+
+func TestCallRulesEmptyConfigEmitsMeta(t *testing.T) {
+	for _, rule := range []core.Rule{
+		tx.NewForbiddenCalls(nil),
+		tx.NewMandatoryWrapper(nil),
+	} {
+		got := rule.Check(txBoundaryContext(t, nil))
+		if len(got) != 1 || got[0].Rule != "meta.rule-disabled-by-config" {
+			t.Fatalf("%s empty config: got %+v", rule.Spec().ID, got)
+		}
+	}
+}
+
+func countRule(violations []core.Violation, rule string) int {
+	var count int
+	for _, v := range violations {
+		if v.Rule == rule {
+			count++
+		}
+	}
+	return count
+}
+
+func callRuleSharedContext(t *testing.T) *core.Context {
+	t.Helper()
+	root := t.TempDir()
+	writeCallRuleFile(t, filepath.Join(root, "go.mod"), "module example.com/callrules\n\ngo 1.25.0\n")
+	source := `package PLACEHOLDER
+
+import (
+	"context"
+	"database/sql"
+)
+
+func Begin(ctx context.Context, db *sql.DB) error {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+`
+	writeCallRuleFile(t, filepath.Join(root, "internal", "pkg", "httpclient", "httpclient.go"), strings.ReplaceAll(source, "PLACEHOLDER", "httpclient"))
+	writeCallRuleFile(t, filepath.Join(root, "internal", "pkg", "bad", "bad.go"), strings.ReplaceAll(source, "PLACEHOLDER", "bad"))
+
+	pkgs, err := analyzer.Load(root, "internal/...")
+	if err != nil {
+		t.Fatal(err)
+	}
+	arch := txBoundaryArch()
+	return core.NewContext(pkgs, "example.com/callrules", root, arch, nil)
+}
+
+func writeCallRuleFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/tui/app.go
+++ b/tui/app.go
@@ -16,7 +16,7 @@ import (
 func Run(pkgs []*packages.Package, module, root string, arch core.Architecture, ruleSet core.RuleSet) error {
 	violations := BuildViolationIndex(pkgs, module, root, arch, ruleSet)
 	importedBy := BuildImportedByMap(pkgs)
-	metrics := BuildMetricsIndex(pkgs, module)
+	metrics := BuildMetricsIndexForRoot(pkgs, module, arch.Layout.InternalRoot)
 	tree := BuildTree(pkgs, module, violations)
 	detail := NewDetailPanel(importedBy, violations, metrics, module)
 

--- a/tui/metrics.go
+++ b/tui/metrics.go
@@ -19,7 +19,17 @@ type MetricsIndex map[string]*PkgMetrics
 
 // BuildMetricsIndex computes coupling metrics for internal packages.
 func BuildMetricsIndex(pkgs []*packages.Package, module string) MetricsIndex {
-	internalPrefix := module + "/internal/"
+	return BuildMetricsIndexForRoot(pkgs, module, "internal")
+}
+
+// BuildMetricsIndexForRoot computes coupling metrics for packages under the
+// configured architecture internal root.
+func BuildMetricsIndexForRoot(pkgs []*packages.Package, module, internalRoot string) MetricsIndex {
+	internalRoot = strings.Trim(strings.TrimSpace(internalRoot), "/")
+	if internalRoot == "" {
+		internalRoot = "internal"
+	}
+	internalPrefix := module + "/" + internalRoot + "/"
 
 	internalPkgs := make(map[string]bool)
 	for _, pkg := range pkgs {

--- a/tui/tree_test.go
+++ b/tui/tree_test.go
@@ -150,3 +150,28 @@ func TestBuildMetricsIndex(t *testing.T) {
 		}
 	}
 }
+
+func TestBuildMetricsIndexForRoot(t *testing.T) {
+	pkgs, err := analyzer.Load("../testdata/custom_root", "packages/...")
+	if err != nil {
+		t.Logf("partial load: %v", err)
+	}
+	if len(pkgs) == 0 {
+		t.Fatal("no packages loaded")
+	}
+
+	module := ""
+	for _, pkg := range pkgs {
+		if pkg.Module != nil {
+			module = pkg.Module.Path
+			break
+		}
+	}
+
+	if metrics := tui.BuildMetricsIndex(pkgs, module); len(metrics) != 0 {
+		t.Fatalf("default metrics must ignore non-internal root, got %d entries", len(metrics))
+	}
+	if metrics := tui.BuildMetricsIndexForRoot(pkgs, module, "packages"); len(metrics) == 0 {
+		t.Fatal("expected metrics for custom internal root packages")
+	}
+}


### PR DESCRIPTION
## Summary
- Fixes #112, #113, #114, #115, #116, #117, #104, and #11.
- Excludes tx.boundary-specific issues #103 and #15 as requested.
- Keeps tx call guards opt-in and preserves recommended preset behavior.

## Changes
- Anchored sublayer matching to configured internal/domain layout and rejected path-substring false matches.
- Made TUI load/metrics respect custom `Layout.InternalRoot`.
- Documented and tested absolute filesystem patterns in `analyzer.Load`.
- Centralized path normalization and meta violation construction helpers.
- Shared AST traversal helpers across rules and migrated remaining local loops.
- Added `LayerModel.LayerLocations` template support for structural layer placement with legacy fallback.
- Added opt-in `tx.NewForbiddenCalls` and `tx.NewMandatoryWrapper` rules on a shared symbol-call engine.

## Review
- Subagent reviewed #112, #113, #114, #115, #116, #117, #104, and #11.
- Follow-up findings were fixed for sublayer layout anchoring, LayerLocations fallback, AST traversal reuse, and tx call package-prefix behavior.

## Verification
- `git diff --check`
- `go test ./...`
- `go vet ./...`

## Not tested
- `go test -race ./...`
