### PR TITLE
Define analyzer absolute load patterns

### DIFF
--- a/analyzer/loader.go
+++ b/analyzer/loader.go
@@ -9,7 +9,11 @@ import (
 	"golang.org/x/tools/go/packages"
 )
 
-// Load parses Go packages matching the given patterns under dir.
+// Load parses Go packages matching the given patterns under dir. Relative
+// directory patterns such as "internal/..." are resolved under dir, patterns
+// beginning with "./" are passed through, module-path patterns such as
+// "github.com/acme/project/..." are passed through, and absolute filesystem
+// patterns are passed through unchanged.
 // When some packages contain errors (e.g. type-check failures), they are
 // skipped and the successfully loaded packages are returned alongside a
 // non-nil error describing what was skipped. Callers that want partial
@@ -38,6 +42,8 @@ func Load(dir string, patterns ...string) ([]*packages.Package, error) {
 	for i, p := range patterns {
 		switch {
 		case strings.HasPrefix(p, "./"):
+			prefixed[i] = p
+		case filepath.IsAbs(p):
 			prefixed[i] = p
 		case looksLikeModulePath(p):
 			prefixed[i] = p

--- a/analyzer/loader_test.go
+++ b/analyzer/loader_test.go
@@ -1,6 +1,7 @@
 package analyzer_test
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -133,6 +134,26 @@ func TestLoad(t *testing.T) {
 			// be from pattern handling, not classification
 			if strings.Contains(err.Error(), "./github.com/") {
 				t.Fatalf("loader double-prefixed an absolute module pattern: %v", err)
+			}
+		}
+	})
+
+	t.Run("absolute filesystem patterns are passed through unchanged", func(t *testing.T) {
+		root, err := filepath.Abs("../testdata/load_type_error")
+		if err != nil {
+			t.Fatal(err)
+		}
+		pattern := filepath.Join(root, "internal", "...")
+		pkgs, err := analyzer.Load(root, pattern)
+		if err != nil {
+			t.Fatalf("expected absolute filesystem pattern to load, got %v", err)
+		}
+		if len(pkgs) == 0 {
+			t.Fatal("expected packages to be loaded from absolute filesystem pattern")
+		}
+		for _, pkg := range pkgs {
+			if !strings.HasPrefix(pkg.PkgPath, "github.com/kimtaeyun/testproject-load-type-error/internal/") {
+				t.Fatalf("loaded unexpected package %q from absolute filesystem pattern", pkg.PkgPath)
 			}
 		}
 	})


### PR DESCRIPTION
Fixes #114

## Summary
- Pass absolute filesystem patterns through unchanged in `analyzer.Load`.
- Add regression coverage for absolute pattern loading.
- Update loader godoc with supported pattern shapes.

## Verification
- `go test -count=1 ./analyzer`
- `git diff --check`
