### PR TITLE
Respect custom internal roots in TUI

### DIFF
--- a/cmd/tui/main.go
+++ b/cmd/tui/main.go
@@ -41,6 +41,7 @@ func presetNames() string {
 
 func main() {
 	preset := flag.String("preset", "ddd", "architecture preset: "+presetNames())
+	internalRoot := flag.String("internal-root", "", `package root to analyze, e.g. "internal", "packages", or "src"`)
 	flag.Parse()
 
 	dir := "."
@@ -61,6 +62,7 @@ func main() {
 	}
 
 	arch := entry.arch()
+	applyInternalRoot(&arch, *internalRoot)
 	pkgs, err := analyzer.Load(dir, loadPatterns(arch)...)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "warning: %v\n", err)
@@ -85,6 +87,13 @@ func main() {
 	if err := tui.Run(pkgs, module, absDir, arch, entry.ruleset()); err != nil {
 		fmt.Fprintf(os.Stderr, "tui error: %v\n", err)
 		os.Exit(1)
+	}
+}
+
+func applyInternalRoot(arch *core.Architecture, internalRoot string) {
+	internalRoot = strings.Trim(strings.TrimSpace(internalRoot), "/")
+	if internalRoot != "" {
+		arch.Layout.InternalRoot = internalRoot
 	}
 }
 

--- a/cmd/tui/main.go
+++ b/cmd/tui/main.go
@@ -60,7 +60,8 @@ func main() {
 		os.Exit(1)
 	}
 
-	pkgs, err := analyzer.Load(dir, "internal/...", "cmd/...")
+	arch := entry.arch()
+	pkgs, err := analyzer.Load(dir, loadPatterns(arch)...)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "warning: %v\n", err)
 	}
@@ -81,8 +82,16 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := tui.Run(pkgs, module, absDir, entry.arch(), entry.ruleset()); err != nil {
+	if err := tui.Run(pkgs, module, absDir, arch, entry.ruleset()); err != nil {
 		fmt.Fprintf(os.Stderr, "tui error: %v\n", err)
 		os.Exit(1)
 	}
+}
+
+func loadPatterns(arch core.Architecture) []string {
+	internalRoot := strings.Trim(strings.TrimSpace(arch.Layout.InternalRoot), "/")
+	if internalRoot == "" {
+		internalRoot = "internal"
+	}
+	return []string{internalRoot + "/...", "cmd/..."}
 }

--- a/cmd/tui/main_test.go
+++ b/cmd/tui/main_test.go
@@ -4,11 +4,24 @@ import (
 	"sort"
 	"strings"
 	"testing"
+
+	"github.com/NamhaeSusan/go-arch-guard/core"
 )
 
 func TestPresetNamesAreSorted(t *testing.T) {
 	got := strings.Split(presetNames(), ", ")
 	if !sort.StringsAreSorted(got) {
 		t.Fatalf("presetNames() = %q, want sorted names", presetNames())
+	}
+}
+
+func TestLoadPatternsRespectInternalRoot(t *testing.T) {
+	arch := core.Architecture{}
+	arch.Layout.InternalRoot = "packages"
+
+	got := loadPatterns(arch)
+	want := []string{"packages/...", "cmd/..."}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("loadPatterns() = %#v, want %#v", got, want)
 	}
 }

--- a/cmd/tui/main_test.go
+++ b/cmd/tui/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os/exec"
 	"sort"
 	"strings"
 	"testing"
@@ -23,5 +24,33 @@ func TestLoadPatternsRespectInternalRoot(t *testing.T) {
 	want := []string{"packages/...", "cmd/..."}
 	if strings.Join(got, ",") != strings.Join(want, ",") {
 		t.Fatalf("loadPatterns() = %#v, want %#v", got, want)
+	}
+}
+
+func TestApplyInternalRoot(t *testing.T) {
+	arch := core.Architecture{}
+	applyInternalRoot(&arch, "/packages/")
+	if got := arch.Layout.InternalRoot; got != "packages" {
+		t.Fatalf("InternalRoot = %q, want packages", got)
+	}
+
+	applyInternalRoot(&arch, " ")
+	if got := arch.Layout.InternalRoot; got != "packages" {
+		t.Fatalf("blank override changed InternalRoot to %q", got)
+	}
+}
+
+func TestTUICommandLoadsCustomInternalRoot(t *testing.T) {
+	cmd := exec.Command("go", "run", ".", "--internal-root", "packages", "../../testdata/custom_root")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatal("expected command to fail after loading because no interactive terminal is available")
+	}
+	text := string(out)
+	if strings.Contains(text, "no packages found") || strings.Contains(text, "pattern ./internal/...") {
+		t.Fatalf("custom internal root was not used; output:\n%s", text)
+	}
+	if !strings.Contains(text, "tui error:") {
+		t.Fatalf("expected command to reach TUI startup, got:\n%s", text)
 	}
 }

--- a/tui/app.go
+++ b/tui/app.go
@@ -16,7 +16,7 @@ import (
 func Run(pkgs []*packages.Package, module, root string, arch core.Architecture, ruleSet core.RuleSet) error {
 	violations := BuildViolationIndex(pkgs, module, root, arch, ruleSet)
 	importedBy := BuildImportedByMap(pkgs)
-	metrics := BuildMetricsIndex(pkgs, module)
+	metrics := BuildMetricsIndexForRoot(pkgs, module, arch.Layout.InternalRoot)
 	tree := BuildTree(pkgs, module, violations)
 	detail := NewDetailPanel(importedBy, violations, metrics, module)
 

--- a/tui/metrics.go
+++ b/tui/metrics.go
@@ -19,7 +19,17 @@ type MetricsIndex map[string]*PkgMetrics
 
 // BuildMetricsIndex computes coupling metrics for internal packages.
 func BuildMetricsIndex(pkgs []*packages.Package, module string) MetricsIndex {
-	internalPrefix := module + "/internal/"
+	return BuildMetricsIndexForRoot(pkgs, module, "internal")
+}
+
+// BuildMetricsIndexForRoot computes coupling metrics for packages under the
+// configured architecture internal root.
+func BuildMetricsIndexForRoot(pkgs []*packages.Package, module, internalRoot string) MetricsIndex {
+	internalRoot = strings.Trim(strings.TrimSpace(internalRoot), "/")
+	if internalRoot == "" {
+		internalRoot = "internal"
+	}
+	internalPrefix := module + "/" + internalRoot + "/"
 
 	internalPkgs := make(map[string]bool)
 	for _, pkg := range pkgs {

--- a/tui/tree_test.go
+++ b/tui/tree_test.go
@@ -150,3 +150,28 @@ func TestBuildMetricsIndex(t *testing.T) {
 		}
 	}
 }
+
+func TestBuildMetricsIndexForRoot(t *testing.T) {
+	pkgs, err := analyzer.Load("../testdata/custom_root", "packages/...")
+	if err != nil {
+		t.Logf("partial load: %v", err)
+	}
+	if len(pkgs) == 0 {
+		t.Fatal("no packages loaded")
+	}
+
+	module := ""
+	for _, pkg := range pkgs {
+		if pkg.Module != nil {
+			module = pkg.Module.Path
+			break
+		}
+	}
+
+	if metrics := tui.BuildMetricsIndex(pkgs, module); len(metrics) != 0 {
+		t.Fatalf("default metrics must ignore non-internal root, got %d entries", len(metrics))
+	}
+	if metrics := tui.BuildMetricsIndexForRoot(pkgs, module, "packages"); len(metrics) == 0 {
+		t.Fatal("expected metrics for custom internal root packages")
+	}
+}


### PR DESCRIPTION
Fixes #113

## Summary
- Load `<InternalRoot>/...` instead of hardcoded `internal/...` in the TUI command.
- Compute TUI metrics for the configured internal root while preserving the default wrapper.
- Add tests for load patterns and custom-root metrics.

## Verification
- `go test -count=1 ./cmd/tui ./tui`
- `git diff --check`
