### PR TITLE
Centralize meta violation helpers

### DIFF
--- a/rules/dependency/isolation.go
+++ b/rules/dependency/isolation.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/NamhaeSusan/go-arch-guard/core"
 	"github.com/NamhaeSusan/go-arch-guard/core/analysisutil"
+	"github.com/NamhaeSusan/go-arch-guard/rules/internal/rulemeta"
 	"golang.org/x/tools/go/packages"
 )
 
@@ -407,13 +408,7 @@ func validateModule(pkgs []*packages.Package, projectModule string) []core.Viola
 }
 
 func metaNoMatchingPackages(message string) core.Violation {
-	return core.Violation{
-		Rule:              "meta.no-matching-packages",
-		Message:           message,
-		Fix:               "verify the module argument matches go.mod",
-		DefaultSeverity:   core.Warning,
-		EffectiveSeverity: core.Warning,
-	}
+	return rulemeta.NoMatchingPackages(message)
 }
 
 // metaRuleDisabledByConfig signals that a rule is registered in the RuleSet
@@ -421,13 +416,7 @@ func metaNoMatchingPackages(message string) core.Violation {
 // (whole rule) or makes a sub-check inert (partial). Severity defaults to
 // Warning via the runner's meta.* prefix handling.
 func metaRuleDisabledByConfig(ruleID, reason, fix string) core.Violation {
-	return core.Violation{
-		Rule:              "meta.rule-disabled-by-config",
-		Message:           fmt.Sprintf("%s: %s", ruleID, reason),
-		Fix:               fix,
-		DefaultSeverity:   core.Warning,
-		EffectiveSeverity: core.Warning,
-	}
+	return rulemeta.RuleDisabledByConfig(ruleID, reason, fix)
 }
 
 // hasInternalPackages reports whether any loaded package lives under
@@ -445,13 +434,9 @@ func hasInternalPackages(pkgs []*packages.Package, projectModule, internalRoot s
 }
 
 func metaLayoutNotSupported(ruleID, projectModule string) core.Violation {
-	return core.Violation{
-		Rule:              "meta.layout-not-supported",
-		Message:           fmt.Sprintf("%s requires an internal/-based layout; no internal/ packages found in module %q", ruleID, projectModule),
-		Fix:               "use this rule with internal/-based presets (DDD, CleanArch, Hexagonal, ModularMonolith), or remove it from your ruleset for flat layouts",
-		DefaultSeverity:   core.Warning,
-		EffectiveSeverity: core.Warning,
-	}
+	return rulemeta.LayoutNotSupported(
+		fmt.Sprintf("%s requires an internal/-based layout; no internal/ packages found in module %q", ruleID, projectModule),
+		"use this rule with internal/-based presets (DDD, CleanArch, Hexagonal, ModularMonolith), or remove it from your ruleset for flat layouts")
 }
 
 func violationSpecs(severity core.Severity, ids ...string) []core.ViolationSpec {

--- a/rules/interfaces/layout_meta.go
+++ b/rules/interfaces/layout_meta.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/NamhaeSusan/go-arch-guard/core"
+	"github.com/NamhaeSusan/go-arch-guard/rules/internal/rulemeta"
 	"golang.org/x/tools/go/packages"
 )
 
@@ -27,13 +28,9 @@ func hasInternalPackages(pkgs []*packages.Package, projectModule, internalRoot s
 }
 
 func metaLayoutNotSupported(ruleID, projectModule string) core.Violation {
-	return core.Violation{
-		Rule:              "meta.layout-not-supported",
-		Message:           fmt.Sprintf("%s requires an internal/-based layout; no internal/ packages found in module %q", ruleID, projectModule),
-		Fix:               "use this rule with internal/-based presets (DDD, CleanArch, Hexagonal, ModularMonolith), or remove it from your ruleset for flat layouts",
-		DefaultSeverity:   core.Warning,
-		EffectiveSeverity: core.Warning,
-	}
+	return rulemeta.LayoutNotSupported(
+		fmt.Sprintf("%s requires an internal/-based layout; no internal/ packages found in module %q", ruleID, projectModule),
+		"use this rule with internal/-based presets (DDD, CleanArch, Hexagonal, ModularMonolith), or remove it from your ruleset for flat layouts")
 }
 
 // metaRuleDisabledByConfig signals that a rule is registered in the RuleSet
@@ -41,11 +38,5 @@ func metaLayoutNotSupported(ruleID, projectModule string) core.Violation {
 // (whole rule) or makes a sub-check inert (partial). Severity defaults to
 // Warning via the runner's meta.* prefix handling.
 func metaRuleDisabledByConfig(ruleID, reason, fix string) core.Violation {
-	return core.Violation{
-		Rule:              "meta.rule-disabled-by-config",
-		Message:           fmt.Sprintf("%s: %s", ruleID, reason),
-		Fix:               fix,
-		DefaultSeverity:   core.Warning,
-		EffectiveSeverity: core.Warning,
-	}
+	return rulemeta.RuleDisabledByConfig(ruleID, reason, fix)
 }

--- a/rules/internal/rulemeta/meta.go
+++ b/rules/internal/rulemeta/meta.go
@@ -1,0 +1,29 @@
+package rulemeta
+
+import (
+	"fmt"
+
+	"github.com/NamhaeSusan/go-arch-guard/core"
+)
+
+func Warning(rule, message, fix string) core.Violation {
+	return core.Violation{
+		Rule:              rule,
+		Message:           message,
+		Fix:               fix,
+		DefaultSeverity:   core.Warning,
+		EffectiveSeverity: core.Warning,
+	}
+}
+
+func RuleDisabledByConfig(ruleID, reason, fix string) core.Violation {
+	return Warning("meta.rule-disabled-by-config", fmt.Sprintf("%s: %s", ruleID, reason), fix)
+}
+
+func LayoutNotSupported(message, fix string) core.Violation {
+	return Warning("meta.layout-not-supported", message, fix)
+}
+
+func NoMatchingPackages(message string) core.Violation {
+	return Warning("meta.no-matching-packages", message, "verify the module argument matches go.mod")
+}

--- a/rules/internal/rulemeta/meta_test.go
+++ b/rules/internal/rulemeta/meta_test.go
@@ -1,0 +1,24 @@
+package rulemeta_test
+
+import (
+	"testing"
+
+	"github.com/NamhaeSusan/go-arch-guard/core"
+	"github.com/NamhaeSusan/go-arch-guard/rules/internal/rulemeta"
+)
+
+func TestRuleDisabledByConfig(t *testing.T) {
+	got := rulemeta.RuleDisabledByConfig("rules.example", "missing config", "set config")
+	if got.Rule != "meta.rule-disabled-by-config" {
+		t.Fatalf("Rule = %q", got.Rule)
+	}
+	if got.Message != "rules.example: missing config" {
+		t.Fatalf("Message = %q", got.Message)
+	}
+	if got.Fix != "set config" {
+		t.Fatalf("Fix = %q", got.Fix)
+	}
+	if got.DefaultSeverity != core.Warning || got.EffectiveSeverity != core.Warning {
+		t.Fatalf("severity = %s/%s, want warning/warning", got.DefaultSeverity, got.EffectiveSeverity)
+	}
+}

--- a/rules/structural/layout_meta.go
+++ b/rules/structural/layout_meta.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/NamhaeSusan/go-arch-guard/core"
+	"github.com/NamhaeSusan/go-arch-guard/rules/internal/rulemeta"
 )
 
 // hasInternalDir reports whether <root>/<internalRoot> exists as a
@@ -21,13 +22,9 @@ func hasInternalDir(root, internalRoot string) bool {
 }
 
 func metaLayoutNotSupported(ruleID string) core.Violation {
-	return core.Violation{
-		Rule:              "meta.layout-not-supported",
-		Message:           fmt.Sprintf("%s requires an internal/-based layout; internal/ directory not found", ruleID),
-		Fix:               "use this rule with internal/-based presets (DDD, CleanArch, Hexagonal, ModularMonolith), or remove it from your ruleset for flat layouts",
-		DefaultSeverity:   core.Warning,
-		EffectiveSeverity: core.Warning,
-	}
+	return rulemeta.LayoutNotSupported(
+		fmt.Sprintf("%s requires an internal/-based layout; internal/ directory not found", ruleID),
+		"use this rule with internal/-based presets (DDD, CleanArch, Hexagonal, ModularMonolith), or remove it from your ruleset for flat layouts")
 }
 
 // metaRuleDisabledByConfig signals that a rule is registered in the RuleSet
@@ -35,11 +32,5 @@ func metaLayoutNotSupported(ruleID string) core.Violation {
 // (whole rule) or makes a sub-check inert (partial). Severity defaults to
 // Warning via the runner's meta.* prefix handling.
 func metaRuleDisabledByConfig(ruleID, reason, fix string) core.Violation {
-	return core.Violation{
-		Rule:              "meta.rule-disabled-by-config",
-		Message:           fmt.Sprintf("%s: %s", ruleID, reason),
-		Fix:               fix,
-		DefaultSeverity:   core.Warning,
-		EffectiveSeverity: core.Warning,
-	}
+	return rulemeta.RuleDisabledByConfig(ruleID, reason, fix)
 }

--- a/rules/tx/boundary.go
+++ b/rules/tx/boundary.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/NamhaeSusan/go-arch-guard/core"
 	"github.com/NamhaeSusan/go-arch-guard/core/analysisutil"
+	"github.com/NamhaeSusan/go-arch-guard/rules/internal/rulemeta"
 	"golang.org/x/tools/go/packages"
 )
 
@@ -217,13 +218,7 @@ func (r *Boundary) violation(rule, file string, line int, message, fix string) c
 // but the supplied core.Architecture configuration prevents it from running.
 // Severity defaults to Warning via the runner's meta.* prefix handling.
 func metaRuleDisabledByConfig(ruleID, reason, fix string) core.Violation {
-	return core.Violation{
-		Rule:              "meta.rule-disabled-by-config",
-		Message:           fmt.Sprintf("%s: %s", ruleID, reason),
-		Fix:               fix,
-		DefaultSeverity:   core.Warning,
-		EffectiveSeverity: core.Warning,
-	}
+	return rulemeta.RuleDisabledByConfig(ruleID, reason, fix)
 }
 
 func packageLayer(arch core.Architecture, pkgPath, internalPrefix string) string {


### PR DESCRIPTION
Fixes #116

## Summary
- Add `rules/internal/rulemeta` for shared `meta.*` violation construction.
- Route dependency, interfaces, structural, and tx meta helper callsites through it.
- Preserve existing IDs/messages/fixes/severity behavior and add helper-level regression coverage.

## Verification
- `go test -count=1 ./rules/internal/rulemeta ./rules/dependency ./rules/interfaces ./rules/structural ./rules/tx`
- `git diff --check`
