### PR TITLE
Generalize structural layer placement

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -195,6 +195,7 @@ arch := core.Architecture{
 | `LayerModel.PkgRestricted` | 공유 패키지 import 금지 서브레이어 |
 | `LayerModel.InternalTopLevel` | 패키지 루트 아래 허용 최상위 디렉토리 |
 | `LayerModel.LayerDirNames` | 파일/디렉토리 배치 룰이 인식하는 레이어 **basename** (`"repo"`); 의도적으로 `Sublayers`에 있을 필요 없음 |
+| `LayerModel.LayerLocations` | `structural.layer-placement`용 basename → 허용 경로 템플릿; `{InternalRoot}`, `{DomainDir}`, `{AppDir}`, `{ServerDir}`, `*`, `**` 지원 |
 | `LayoutModel.InternalRoot` | 프로젝트 상대 패키지 루트 디렉토리; 빈 값은 `"internal"`로 정규화됨 (`"packages"`, `"src"` 등 비표준 레이아웃 지원) |
 | `LayoutModel.DomainDir` | 도메인 최상위 디렉토리명. 플랫 레이아웃은 빈 값 |
 | `LayoutModel.OrchestrationDir` | 오케스트레이션 최상위 디렉토리명 |

--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ Architecture fields:
 | `LayerModel.PkgRestricted` | sublayers that must not import shared packages |
 | `LayerModel.InternalTopLevel` | allowed top-level directories under the package root |
 | `LayerModel.LayerDirNames` | layer **basenames** (`"repo"`) recognized by file/directory placement rules; intentionally NOT required to appear in `Sublayers` |
+| `LayerModel.LayerLocations` | optional basename → allowed path templates for `structural.layer-placement`; supports `{InternalRoot}`, `{DomainDir}`, `{AppDir}`, `{ServerDir}`, `*`, and `**` |
 | `LayoutModel.InternalRoot` | project-relative package-root directory; defaults to `"internal"` when empty (set to `"packages"`, `"src"`, etc. for non-default layouts) |
 | `LayoutModel.DomainDir` | top-level directory name for domains; empty for flat layouts |
 | `LayoutModel.OrchestrationDir` | top-level directory name for orchestration |

--- a/core/architecture.go
+++ b/core/architecture.go
@@ -54,6 +54,11 @@ type LayerModel struct {
 	// directory placement rules. Keys are basenames, NOT full Sublayer
 	// paths.
 	LayerDirNames map[string]bool
+	// LayerLocations maps a layer basename to allowed project-relative path
+	// templates for structural placement checks. Templates may use layout
+	// placeholders such as {InternalRoot}, {DomainDir}, {AppDir},
+	// {ServerDir}, and glob segments "*" or "**".
+	LayerLocations map[string][]string
 }
 
 // LayoutModel describes the package-root directory topology. Empty fields
@@ -115,6 +120,7 @@ func cloneArchitecture(a Architecture) Architecture {
 			PkgRestricted:    cloneBoolMap(a.Layers.PkgRestricted),
 			InternalTopLevel: cloneBoolMap(a.Layers.InternalTopLevel),
 			LayerDirNames:    cloneBoolMap(a.Layers.LayerDirNames),
+			LayerLocations:   cloneStringSliceMap(a.Layers.LayerLocations),
 		},
 		Layout: a.Layout, // value type with only string fields
 		Naming: NamingPolicy{

--- a/core/architecture_validate.go
+++ b/core/architecture_validate.go
@@ -103,6 +103,19 @@ func (a Architecture) Validate() error {
 			errs = append(errs, "LayerDirNames contains empty-string key")
 		}
 	}
+	for k, locations := range a.Layers.LayerLocations {
+		if k == "" {
+			errs = append(errs, "LayerLocations contains empty-string key")
+		}
+		if len(locations) == 0 {
+			errs = append(errs, fmt.Sprintf("LayerLocations[%q] has no locations", k))
+		}
+		for _, location := range locations {
+			if strings.TrimSpace(location) == "" {
+				errs = append(errs, fmt.Sprintf("LayerLocations[%q] contains empty location", k))
+			}
+		}
+	}
 	// InternalTopLevel keys are top-level dir names; they don't have to map
 	// to Sublayers either, but empty keys are always a typo.
 	for k := range a.Layers.InternalTopLevel {

--- a/core/architecture_validate_test.go
+++ b/core/architecture_validate_test.go
@@ -54,6 +54,25 @@ func TestValidateRejectsEmptyLayerDirNamesKey(t *testing.T) {
 	}
 }
 
+func TestValidateRejectsMalformedLayerLocations(t *testing.T) {
+	a := validArchitecture()
+	a.Layers.LayerLocations = map[string][]string{
+		"":           {"{InternalRoot}/{DomainDir}/*/adapter"},
+		"controller": {""},
+		"adapter":    nil,
+	}
+	err := a.Validate()
+	if err == nil {
+		t.Fatal("expected malformed LayerLocations to be rejected")
+	}
+	msg := err.Error()
+	for _, want := range []string{"LayerLocations contains empty-string key", "LayerLocations[\"controller\"] contains empty location", "LayerLocations[\"adapter\"] has no locations"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("expected %q in %q", want, msg)
+		}
+	}
+}
+
 func TestValidateRejectsEmptyInternalTopLevelKey(t *testing.T) {
 	a := validArchitecture()
 	a.Layers.InternalTopLevel = map[string]bool{"": true}

--- a/core/context_test.go
+++ b/core/context_test.go
@@ -167,11 +167,14 @@ func TestContextPkgsHeaderCopyDoesNotAffectOthers(t *testing.T) {
 func TestNewContextIsolatesCallerArchitectureMutation(t *testing.T) {
 	arch := validArchitecture()
 	arch.Layers.LayerDirNames = map[string]bool{"handler": true, "app": true}
+	arch.Layers.LayerLocations = map[string][]string{"app": {"{InternalRoot}/{AppDir}"}}
 	c := NewContext(nil, "m", "/r", arch, nil)
 
 	// Mutate the original arch maps and slices after NewContext.
 	arch.Layers.Sublayers = append(arch.Layers.Sublayers, "rogue")
 	arch.Layers.LayerDirNames["rogue"] = true
+	arch.Layers.LayerLocations["app"][0] = "mutated"
+	arch.Layers.LayerLocations["rogue"] = []string{"rogue"}
 	arch.Layers.Direction["rogue"] = []string{"handler"}
 
 	got := c.Arch()
@@ -182,6 +185,9 @@ func TestNewContextIsolatesCallerArchitectureMutation(t *testing.T) {
 	}
 	if got.Layers.LayerDirNames["rogue"] {
 		t.Fatalf("caller mutation leaked into Context: LayerDirNames contains rogue")
+	}
+	if got.Layers.LayerLocations["app"][0] == "mutated" || got.Layers.LayerLocations["rogue"] != nil {
+		t.Fatalf("caller mutation leaked into Context: LayerLocations = %#v", got.Layers.LayerLocations)
 	}
 	if _, ok := got.Layers.Direction["rogue"]; ok {
 		t.Fatalf("caller mutation leaked into Context: Direction contains rogue")

--- a/docs/model-concepts.md
+++ b/docs/model-concepts.md
@@ -45,6 +45,7 @@ truth: every field that names a layer must refer to a value in `Sublayers`.
 | `PkgRestricted` | Layers that must not import the shared package tree. |
 | `InternalTopLevel` | Top-level directories allowed under `internal/`. Structure rules use this to catch accidental directories. |
 | `LayerDirNames` | Basename hints used by placement rules to identify layer-like directories. |
+| `LayerLocations` | Optional basename → allowed path templates for layer placement. Templates support layout placeholders such as `{InternalRoot}` and glob segments `*` / `**`. |
 
 Example:
 
@@ -65,6 +66,11 @@ layers := core.LayerModel{
     },
     LayerDirNames: map[string]bool{
         "api": true, "logic": true, "data": true,
+    },
+    LayerLocations: map[string][]string{
+        "api":   {"{InternalRoot}/{DomainDir}/*/api"},
+        "logic": {"{InternalRoot}/{DomainDir}/*/logic"},
+        "data":  {"{InternalRoot}/{DomainDir}/*/data"},
     },
 }
 ```

--- a/docs/presets.md
+++ b/docs/presets.md
@@ -8,6 +8,10 @@ For custom architectures, see [Architecture Concepts](model-concepts.md).
 > Projects that keep packages under a different directory (`packages/`, `src/`, etc.)
 > should set `arch.Layout.InternalRoot` accordingly — the same layout structure applies,
 > just under a different root.
+>
+> Custom layer vocabularies can also set `arch.Layers.LayerLocations` so
+> `structural.layer-placement` checks names beyond the built-in
+> `app`/`infra`/`handler` fallback vocabulary.
 
 ## DDD Layout
 

--- a/plugins/go-arch-guard/skills/go-arch-guard/SKILL.md
+++ b/plugins/go-arch-guard/skills/go-arch-guard/SKILL.md
@@ -286,8 +286,8 @@ arch := core.Architecture{
 ```
 
 전체 필드: `LayerModel.Sublayers`, `LayerModel.Direction`, `LayerModel.PkgRestricted`,
-`LayerModel.InternalTopLevel`, `LayerModel.LayerDirNames`, `LayerModel.PortLayers`,
-`LayerModel.ContractLayers`, `LayoutModel.InternalRoot` (default `"internal"`,
+`LayerModel.InternalTopLevel`, `LayerModel.LayerDirNames`, `LayerModel.LayerLocations`,
+`LayerModel.PortLayers`, `LayerModel.ContractLayers`, `LayoutModel.InternalRoot` (default `"internal"`,
 `"packages"`/`"src"` 등 비표준 패키지 루트 지원), `LayoutModel.DomainDir`,
 `LayoutModel.OrchestrationDir`, `LayoutModel.SharedDir`, `LayoutModel.AppDir`,
 `LayoutModel.ServerDir`, `NamingPolicy.BannedPkgNames`, `NamingPolicy.LegacyPkgNames`,

--- a/rules/structural/layer_placement.go
+++ b/rules/structural/layer_placement.go
@@ -91,10 +91,11 @@ func (r *LayerPlacement) Check(ctx *core.Context) []core.Violation {
 }
 
 func isMisplacedLayerDir(arch core.Architecture, rel, name string) bool {
-	if len(arch.Layers.LayerDirNames) > 0 && !arch.Layers.LayerDirNames[name] {
+	locations, hasLocations := arch.Layers.LayerLocations[name]
+	if len(arch.Layers.LayerDirNames) > 0 && !arch.Layers.LayerDirNames[name] && !hasLocations {
 		return false
 	}
-	if locations, ok := arch.Layers.LayerLocations[name]; ok {
+	if hasLocations {
 		return !matchesAnyLayerLocation(arch, rel, locations)
 	}
 	switch name {

--- a/rules/structural/layer_placement.go
+++ b/rules/structural/layer_placement.go
@@ -14,8 +14,9 @@ const (
 )
 
 // LayerPlacement flags layer-named directories that appear outside their
-// allowed slice. It enforces a fixed vocabulary of three layer names —
-// "app", "infra", "handler" — each with its own ad-hoc placement logic:
+// allowed slice. LayerModel.LayerLocations can define custom placement
+// templates for any layer basename. When no explicit template exists for a
+// name, the rule keeps its legacy fallback vocabulary:
 //
 //   - "app": allowed at internal/<Layout.AppDir> or per-domain
 //     internal/<DomainDir>/<X>/app/
@@ -27,12 +28,8 @@ const (
 //     internal/<DomainDir>/<X>/handler/.
 //
 // LayerDirNames can narrow the active set (only names present in the map
-// are checked) but cannot add new names — directory names other than the
-// three above silently pass. Teams using a different vocabulary
-// (e.g. "controller", "usecase", "port") get no protection from this rule.
-//
-// Generalizing to fully data-driven placement (LayerLocations on
-// LayerModel) is tracked in issue #104.
+// are checked). LayerLocations adds protection for additional names such as
+// "controller", "usecase", or "port" without changing the legacy fallback.
 type LayerPlacement struct {
 	severity core.Severity
 }
@@ -97,6 +94,9 @@ func isMisplacedLayerDir(arch core.Architecture, rel, name string) bool {
 	if len(arch.Layers.LayerDirNames) > 0 && !arch.Layers.LayerDirNames[name] {
 		return false
 	}
+	if locations, ok := arch.Layers.LayerLocations[name]; ok {
+		return !matchesAnyLayerLocation(arch, rel, locations)
+	}
 	switch name {
 	case "app", "infra":
 		if name == "app" && arch.Layout.AppDir != "" && rel == filepath.ToSlash(filepath.Join(arch.Layout.InternalRoot, arch.Layout.AppDir)) {
@@ -115,6 +115,47 @@ func isMisplacedLayerDir(arch core.Architecture, rel, name string) bool {
 	default:
 		return false
 	}
+}
+
+func matchesAnyLayerLocation(arch core.Architecture, rel string, locations []string) bool {
+	for _, location := range locations {
+		if matchLayerLocation(arch, rel, location) {
+			return true
+		}
+	}
+	return false
+}
+
+func matchLayerLocation(arch core.Architecture, rel, location string) bool {
+	location = strings.Trim(strings.TrimSpace(location), "/")
+	location = strings.NewReplacer(
+		"{InternalRoot}", arch.Layout.InternalRoot,
+		"{DomainDir}", arch.Layout.DomainDir,
+		"{OrchestrationDir}", arch.Layout.OrchestrationDir,
+		"{SharedDir}", arch.Layout.SharedDir,
+		"{AppDir}", arch.Layout.AppDir,
+		"{ServerDir}", arch.Layout.ServerDir,
+	).Replace(location)
+	patternParts := strings.Split(filepath.ToSlash(location), "/")
+	relParts := strings.Split(strings.Trim(filepath.ToSlash(rel), "/"), "/")
+	return matchLayerLocationParts(patternParts, relParts)
+}
+
+func matchLayerLocationParts(pattern, rel []string) bool {
+	if len(pattern) == 0 {
+		return len(rel) == 0
+	}
+	if pattern[0] == "**" {
+		return len(pattern) == 1 || matchLayerLocationParts(pattern[1:], rel) ||
+			(len(rel) > 0 && matchLayerLocationParts(pattern, rel[1:]))
+	}
+	if len(rel) == 0 {
+		return false
+	}
+	if pattern[0] == "*" {
+		return rel[0] != "" && matchLayerLocationParts(pattern[1:], rel[1:])
+	}
+	return pattern[0] == rel[0] && matchLayerLocationParts(pattern[1:], rel[1:])
 }
 
 func matchesDomainLayer(arch core.Architecture, rel, name string) bool {

--- a/rules/structural/layer_placement_test.go
+++ b/rules/structural/layer_placement_test.go
@@ -1,8 +1,10 @@
 package structural_test
 
 import (
+	"path/filepath"
 	"testing"
 
+	"github.com/NamhaeSusan/go-arch-guard/core"
 	"github.com/NamhaeSusan/go-arch-guard/rules/structural"
 )
 
@@ -16,4 +18,46 @@ func TestLayerPlacement(t *testing.T) {
 		violations := runRule(t, "../../testdata/invalid", structural.NewLayerPlacement())
 		assertViolation(t, violations, "structural.misplaced-layer", "internal/platform/handler/")
 	})
+
+	t.Run("detects custom layer names using configured locations", func(t *testing.T) {
+		root := t.TempDir()
+		writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "controller", "controller.go"), "package controller\n")
+		writeTestFile(t, filepath.Join(root, "internal", "platform", "controller", "controller.go"), "package controller\n")
+
+		arch := dddArch()
+		arch.Layers.LayerDirNames["controller"] = true
+		arch.Layers.LayerLocations = map[string][]string{
+			"controller": {"{InternalRoot}/{DomainDir}/*/controller"},
+		}
+		ctx := core.NewContext(nil, "github.com/example/app", root, arch, nil)
+
+		violations := core.Run(ctx, core.NewRuleSet(structural.NewLayerPlacement()))
+		assertViolation(t, violations, "structural.misplaced-layer", "internal/platform/controller/")
+		assertNoViolationAt(t, violations, "structural.misplaced-layer", "internal/domain/order/controller/")
+	})
+
+	t.Run("keeps built-in fallback checks when custom locations are configured", func(t *testing.T) {
+		root := t.TempDir()
+		writeTestFile(t, filepath.Join(root, "internal", "platform", "handler", "handler.go"), "package handler\n")
+		writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "controller", "controller.go"), "package controller\n")
+
+		arch := dddArch()
+		arch.Layers.LayerDirNames["controller"] = true
+		arch.Layers.LayerLocations = map[string][]string{
+			"controller": {"{InternalRoot}/{DomainDir}/*/controller"},
+		}
+		ctx := core.NewContext(nil, "github.com/example/app", root, arch, nil)
+
+		violations := core.Run(ctx, core.NewRuleSet(structural.NewLayerPlacement()))
+		assertViolation(t, violations, "structural.misplaced-layer", "internal/platform/handler/")
+	})
+}
+
+func assertNoViolationAt(t *testing.T, violations []core.Violation, rule, file string) {
+	t.Helper()
+	for _, v := range violations {
+		if v.Rule == rule && v.File == file {
+			t.Fatalf("unexpected %s at %s in %#v", rule, file, violations)
+		}
+	}
 }

--- a/rules/structural/layer_placement_test.go
+++ b/rules/structural/layer_placement_test.go
@@ -51,6 +51,21 @@ func TestLayerPlacement(t *testing.T) {
 		violations := core.Run(ctx, core.NewRuleSet(structural.NewLayerPlacement()))
 		assertViolation(t, violations, "structural.misplaced-layer", "internal/platform/handler/")
 	})
+
+	t.Run("treats LayerLocations keys as recognized layer names", func(t *testing.T) {
+		root := t.TempDir()
+		writeTestFile(t, filepath.Join(root, "internal", "platform", "usecase", "usecase.go"), "package usecase\n")
+
+		arch := dddArch()
+		delete(arch.Layers.LayerDirNames, "usecase")
+		arch.Layers.LayerLocations = map[string][]string{
+			"usecase": {"{InternalRoot}/{DomainDir}/*/usecase"},
+		}
+		ctx := core.NewContext(nil, "github.com/example/app", root, arch, nil)
+
+		violations := core.Run(ctx, core.NewRuleSet(structural.NewLayerPlacement()))
+		assertViolation(t, violations, "structural.misplaced-layer", "internal/platform/usecase/")
+	})
 }
 
 func assertNoViolationAt(t *testing.T, violations []core.Violation, rule, file string) {


### PR DESCRIPTION
Fixes #104

## Summary
- Add `LayerModel.LayerLocations` for template-driven layer placement checks.
- Support layout placeholders and `*`/`**` path matching.
- Preserve built-in `app`/`infra`/`handler` fallback behavior when custom locations are partial or absent.
- Update model/docs/plugin guidance.

## Verification
- `go test -count=1 ./core ./rules/structural ./presets`
- `git diff --check`
