### PR TITLE
Anchor sublayer matching to layout roots

### DIFF
--- a/core/analysisutil/sublayer.go
+++ b/core/analysisutil/sublayer.go
@@ -44,11 +44,15 @@ func HasPortSublayer(layers core.LayerModel) bool {
 }
 
 func MatchPortSublayer(layers core.LayerModel, pkgPath string) string {
+	return MatchPortSublayerInLayout(layers, core.LayoutModel{InternalRoot: "internal", DomainDir: "domain"}, pkgPath)
+}
+
+func MatchPortSublayerInLayout(layers core.LayerModel, layout core.LayoutModel, pkgPath string) string {
 	for _, sl := range layers.Sublayers {
 		if !IsPortSublayer(layers, sl) {
 			continue
 		}
-		if strings.HasSuffix(pkgPath, "/"+sl) || strings.Contains(pkgPath, "/"+sl+"/") {
+		if matchesSublayerBoundary(layout, pkgPath, sl) {
 			return sl
 		}
 	}
@@ -56,15 +60,52 @@ func MatchPortSublayer(layers core.LayerModel, pkgPath string) string {
 }
 
 func MatchContractSublayer(layers core.LayerModel, pkgPath string) string {
+	return MatchContractSublayerInLayout(layers, core.LayoutModel{InternalRoot: "internal", DomainDir: "domain"}, pkgPath)
+}
+
+func MatchContractSublayerInLayout(layers core.LayerModel, layout core.LayoutModel, pkgPath string) string {
 	for _, sl := range layers.Sublayers {
 		if !IsContractSublayer(layers, sl) {
 			continue
 		}
-		if strings.HasSuffix(pkgPath, "/"+sl) || strings.Contains(pkgPath, "/"+sl+"/") {
+		if matchesSublayerBoundary(layout, pkgPath, sl) {
 			return sl
 		}
 	}
 	return ""
+}
+
+func matchesSublayerBoundary(layout core.LayoutModel, pkgPath, sublayer string) bool {
+	internalRoot := layout.InternalRoot
+	if internalRoot == "" {
+		internalRoot = "internal"
+	}
+	domainDir := layout.DomainDir
+	if domainDir == "" {
+		domainDir = "domain"
+	}
+	parts := strings.Split(pkgPath, "/")
+	for i := 0; i+2 < len(parts); i++ {
+		if parts[i] == internalRoot && parts[i+1] == domainDir {
+			if matchesSublayerParts(parts[i+2:], sublayer) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func matchesSublayerParts(relParts []string, sublayer string) bool {
+	slParts := strings.Split(sublayer, "/")
+	if len(relParts) < 1+len(slParts) {
+		return false
+	}
+	for i, want := range slParts {
+		if relParts[1+i] != want {
+			return false
+		}
+	}
+	return true
 }
 
 func PortSublayerName(layers core.LayerModel) string {

--- a/core/analysisutil/sublayer_test.go
+++ b/core/analysisutil/sublayer_test.go
@@ -52,6 +52,50 @@ func TestFallbackSublayerMatching(t *testing.T) {
 	}
 }
 
+func TestSublayerMatchingRejectsPathSubstringsOutsideDomainLayer(t *testing.T) {
+	layers := core.LayerModel{
+		Sublayers: []string{"core/repo", "core/svc", "core/model"},
+	}
+
+	if got := MatchPortSublayer(layers, "example.com/app/internal/pkg/core/repo/cache"); got != "" {
+		t.Fatalf("MatchPortSublayer() = %q, want no match outside domain layer", got)
+	}
+	if got := MatchPortSublayer(layers, "example.com/app/internal/pkg/core/repo"); got != "" {
+		t.Fatalf("MatchPortSublayer() = %q, want no exact suffix match outside domain layer", got)
+	}
+	if got := MatchPortSublayer(layers, "example.com/app/internal/pkg/domain/order/core/repo"); got != "" {
+		t.Fatalf("MatchPortSublayer() = %q, want no internal/pkg/domain false match", got)
+	}
+	if got := MatchPortSublayer(layers, "example.com/domain/app/internal/domain/order/core/repo"); got != "core/repo" {
+		t.Fatalf("MatchPortSublayer() = %q, want core/repo with module prefix containing domain", got)
+	}
+	if got := MatchPortSublayer(layers, "example.com/app/internal/domain/order/core/repo/internal/domain/cache"); got != "core/repo" {
+		t.Fatalf("MatchPortSublayer() = %q, want core/repo with nested internal/domain below layer", got)
+	}
+	if got := MatchContractSublayer(layers, "example.com/app/internal/pkg/core/svc/cache"); got != "" {
+		t.Fatalf("MatchContractSublayer() = %q, want no match outside domain layer", got)
+	}
+}
+
+func TestSublayerMatchingUsesConfiguredLayout(t *testing.T) {
+	layers := core.LayerModel{
+		Sublayers: []string{"core/repo", "core/svc", "core/model"},
+	}
+
+	layout := core.LayoutModel{InternalRoot: "packages", DomainDir: "domain"}
+	if got := MatchPortSublayerInLayout(layers, layout, "example.com/app/packages/domain/order/core/repo"); got != "core/repo" {
+		t.Fatalf("MatchPortSublayerInLayout() = %q, want core/repo for custom InternalRoot", got)
+	}
+	if got := MatchPortSublayerInLayout(layers, layout, "example.com/app/internal/domain/order/core/repo"); got != "" {
+		t.Fatalf("MatchPortSublayerInLayout() = %q, want no match for wrong InternalRoot", got)
+	}
+
+	layout = core.LayoutModel{InternalRoot: "internal", DomainDir: "module"}
+	if got := MatchContractSublayerInLayout(layers, layout, "example.com/app/internal/module/order/core/svc"); got != "core/svc" {
+		t.Fatalf("MatchContractSublayerInLayout() = %q, want core/svc for custom DomainDir", got)
+	}
+}
+
 func TestExplicitPortSublayerMatching(t *testing.T) {
 	layers := core.LayerModel{
 		Sublayers:      []string{"handler", "usecase", "port", "domain", "adapter"},

--- a/rules/structural/alias.go
+++ b/rules/structural/alias.go
@@ -93,7 +93,7 @@ func (r *Alias) Check(ctx *core.Context) []core.Violation {
 
 		violations = append(violations, r.checkAliasPackage(aliasPath, aliasRel, aliasName, domainName)...)
 		violations = append(violations, r.checkAliasOnly(ctx, rootDir, relPath, aliasName, domainName)...)
-		violations = append(violations, r.checkAliasTypes(aliasPath, aliasRel, aliasName, arch)...)
+		violations = append(violations, r.checkAliasTypes(ctx, aliasPath, aliasRel, aliasName, arch)...)
 	}
 	return violations
 }
@@ -130,7 +130,7 @@ func (r *Alias) checkAliasOnly(ctx *core.Context, rootDir, relPath, aliasName, d
 	return violations
 }
 
-func (r *Alias) checkAliasTypes(aliasPath, aliasRel, aliasName string, arch core.Architecture) []core.Violation {
+func (r *Alias) checkAliasTypes(ctx *core.Context, aliasPath, aliasRel, aliasName string, arch core.Architecture) []core.Violation {
 	fset := token.NewFileSet()
 	file, err := parser.ParseFile(fset, aliasPath, nil, 0)
 	if err != nil {
@@ -145,7 +145,7 @@ func (r *Alias) checkAliasTypes(aliasPath, aliasRel, aliasName string, arch core
 			v.Line = info.Line
 			violations = append(violations, v)
 		}
-		if src := analysisutil.MatchContractSublayerInLayout(arch.Layers, arch.Layout, info.AliasFrom); src != "" {
+		if src := projectContractSublayer(ctx.Module(), arch, info.AliasFrom); src != "" {
 			v := violation(r.severity, aliasContractExport, aliasRel,
 				aliasName+` re-exports "`+info.Name+`" from `+src+` - suspected cross-domain dependency; use `+arch.Layout.OrchestrationDir+`/ instead`,
 				"move cross-domain coordination to "+arch.Layout.OrchestrationDir+"/handler/ or "+arch.Layout.OrchestrationDir+"/")
@@ -154,6 +154,17 @@ func (r *Alias) checkAliasTypes(aliasPath, aliasRel, aliasName string, arch core
 		}
 	}
 	return violations
+}
+
+func projectContractSublayer(module string, arch core.Architecture, importPath string) string {
+	if module == "" || importPath == "" {
+		return ""
+	}
+	prefix := strings.TrimSuffix(module, "/") + "/" + arch.Layout.InternalRoot + "/"
+	if !strings.HasPrefix(importPath, prefix) {
+		return ""
+	}
+	return analysisutil.MatchContractSublayerInLayout(arch.Layers, arch.Layout, importPath)
 }
 
 func withSeverity(spec core.RuleSpec, severity core.Severity) core.RuleSpec {

--- a/rules/structural/alias.go
+++ b/rules/structural/alias.go
@@ -145,7 +145,7 @@ func (r *Alias) checkAliasTypes(aliasPath, aliasRel, aliasName string, arch core
 			v.Line = info.Line
 			violations = append(violations, v)
 		}
-		if src := analysisutil.MatchContractSublayer(arch.Layers, info.AliasFrom); src != "" {
+		if src := analysisutil.MatchContractSublayerInLayout(arch.Layers, arch.Layout, info.AliasFrom); src != "" {
 			v := violation(r.severity, aliasContractExport, aliasRel,
 				aliasName+` re-exports "`+info.Name+`" from `+src+` - suspected cross-domain dependency; use `+arch.Layout.OrchestrationDir+`/ instead`,
 				"move cross-domain coordination to "+arch.Layout.OrchestrationDir+"/handler/ or "+arch.Layout.OrchestrationDir+"/")

--- a/rules/structural/alias_test.go
+++ b/rules/structural/alias_test.go
@@ -37,7 +37,7 @@ func TestAlias(t *testing.T) {
 		root := t.TempDir()
 		writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "alias.go"), `package order
 
-import "example.com/app/internal/domain/order/core/svc"
+import "github.com/example/app/internal/domain/order/core/svc"
 
 type AdminOps = svc.AdminOps
 `)
@@ -46,6 +46,40 @@ type AdminOps = svc.AdminOps
 
 		violations := runRule(t, root, structural.NewAlias())
 		assertMessageContains(t, violations, "structural.domain-alias-contract-reexport", "AdminOps")
+	})
+
+	t.Run("ignores external imports with matching layout-shaped path", func(t *testing.T) {
+		root := t.TempDir()
+		writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "alias.go"), `package order
+
+import external "github.com/acme/lib/internal/domain/order/core/svc"
+
+type ExternalOps = external.ExternalOps
+`)
+		writeTestFile(t, filepath.Join(root, "internal", "domain", "order", "core", "model", "order.go"), "package model\n")
+
+		violations := runRule(t, root, structural.NewAlias())
+		assertNoRulePrefix(t, violations, "structural.domain-alias-contract-reexport")
+	})
+
+	t.Run("detects project contract re-export with custom layout", func(t *testing.T) {
+		root := t.TempDir()
+		writeTestFile(t, filepath.Join(root, "packages", "module", "order", "alias.go"), `package order
+
+import "github.com/example/app/packages/module/order/core/svc"
+
+type AdminOps = svc.AdminOps
+`)
+		writeTestFile(t, filepath.Join(root, "packages", "module", "order", "core", "model", "order.go"), "package model\n")
+		writeTestFile(t, filepath.Join(root, "packages", "module", "order", "core", "svc", "admin.go"), "package svc\n\ntype AdminOps interface{ Do() }\n")
+
+		arch := dddArch()
+		arch.Layout.InternalRoot = "packages"
+		arch.Layout.DomainDir = "module"
+		ctx := core.NewContext(nil, "github.com/example/app", root, arch, nil)
+
+		got := structural.NewAlias().Check(ctx)
+		assertMessageContains(t, got, "structural.domain-alias-contract-reexport", "AdminOps")
 	})
 
 	t.Run("emits meta.rule-disabled-by-config when DomainDir is empty (flat layout)", func(t *testing.T) {

--- a/rules/structural/repo_file_interface.go
+++ b/rules/structural/repo_file_interface.go
@@ -56,15 +56,17 @@ func (r *RepoFileInterface) Spec() core.RuleSpec {
 }
 
 func (r *RepoFileInterface) Check(ctx *core.Context) []core.Violation {
-	layers := ctx.Arch().Layers
+	arch := ctx.Arch()
+	layers := arch.Layers
 	if !analysisutil.HasPortSublayer(layers) {
 		return []core.Violation{metaRuleDisabledByConfig("structural.repo-file-interface",
 			"LayerModel.PortLayers is empty; repo-file interface enforcement requires at least one port sublayer",
 			"declare PortLayers in your LayerModel (e.g. []string{\"core/repo\"}), or remove structural.NewRepoFileInterface() from your RuleSet")}
 	}
+	module := analysisutil.ResolveModuleFromContext(ctx, "")
 	var violations []core.Violation
 	for _, pkg := range ctx.Pkgs() {
-		if portLayer := analysisutil.MatchPortSublayer(layers, pkg.PkgPath); portLayer != "" {
+		if portLayer, ok := domainSublayerForPackage(module, arch, pkg.PkgPath); ok && analysisutil.IsPortSublayer(layers, portLayer) {
 			violations = append(violations, r.checkPortPackage(ctx, pkg, portLayer)...)
 			continue
 		}


### PR DESCRIPTION
Fixes #112

## Summary
- Reject sibling/path-substring false matches in port/contract sublayer matching.
- Add layout-aware matching for custom `InternalRoot` and `DomainDir`.
- Update structural callsites that need architecture-aware package matching.

## Verification
- `go test -count=1 ./core/analysisutil ./rules/structural`
- `git diff --check`
