### PR TITLE
Share AST traversal helpers across rules

### DIFF
--- a/core/analysisutil/ast.go
+++ b/core/analysisutil/ast.go
@@ -28,12 +28,11 @@ type TypeSpecInfo struct {
 	AliasFrom   string // import path of `type X = pkg.Y`; empty if not an alias
 }
 
-// InspectTypeSpecs walks the top-level type decls in file and returns one
-// entry per interface declaration or per type alias whose RHS is
-// `<ident>.<Name>`. Other type decls are skipped. Callers usually want to
-// detect interfaces or detect re-exports of types from other packages.
-func InspectTypeSpecs(file *ast.File, fset *token.FileSet) []TypeSpecInfo {
-	var result []TypeSpecInfo
+// WalkTypeSpecs visits top-level type declarations in source order.
+func WalkTypeSpecs(file *ast.File, fset *token.FileSet, visit func(*ast.TypeSpec, token.Position)) {
+	if file == nil || visit == nil {
+		return
+	}
 	for _, decl := range file.Decls {
 		gd, ok := decl.(*ast.GenDecl)
 		if !ok {
@@ -44,25 +43,53 @@ func InspectTypeSpecs(file *ast.File, fset *token.FileSet) []TypeSpecInfo {
 			if !ok {
 				continue
 			}
-			info := TypeSpecInfo{
-				Name: ts.Name.Name,
-				Line: fset.Position(ts.Name.Pos()).Line,
+			var pos token.Position
+			if fset != nil {
+				pos = fset.Position(ts.Name.Pos())
 			}
-			if _, ok := ts.Type.(*ast.InterfaceType); ok {
-				info.IsInterface = true
-			}
-			if ts.Assign != 0 {
-				if sel, ok := ts.Type.(*ast.SelectorExpr); ok {
-					if ident, ok := sel.X.(*ast.Ident); ok {
-						info.AliasFrom = ResolveIdentImportPath(file, ident.Name)
-					}
-				}
-			}
-			if info.IsInterface || info.AliasFrom != "" {
-				result = append(result, info)
-			}
+			visit(ts, pos)
 		}
 	}
+}
+
+// WalkFuncDecls visits top-level function declarations in source order.
+func WalkFuncDecls(file *ast.File, visit func(*ast.FuncDecl)) {
+	if file == nil || visit == nil {
+		return
+	}
+	for _, decl := range file.Decls {
+		fd, ok := decl.(*ast.FuncDecl)
+		if ok {
+			visit(fd)
+		}
+	}
+}
+
+// InspectTypeSpecs walks the top-level type decls in file and returns one
+// entry per interface declaration or per type alias whose RHS is
+// `<ident>.<Name>`. Other type decls are skipped. Callers usually want to
+// detect interfaces or detect re-exports of types from other packages.
+func InspectTypeSpecs(file *ast.File, fset *token.FileSet) []TypeSpecInfo {
+	var result []TypeSpecInfo
+	WalkTypeSpecs(file, fset, func(ts *ast.TypeSpec, pos token.Position) {
+		info := TypeSpecInfo{
+			Name: ts.Name.Name,
+			Line: pos.Line,
+		}
+		if _, ok := ts.Type.(*ast.InterfaceType); ok {
+			info.IsInterface = true
+		}
+		if ts.Assign != 0 {
+			if sel, ok := ts.Type.(*ast.SelectorExpr); ok {
+				if ident, ok := sel.X.(*ast.Ident); ok {
+					info.AliasFrom = ResolveIdentImportPath(file, ident.Name)
+				}
+			}
+		}
+		if info.IsInterface || info.AliasFrom != "" {
+			result = append(result, info)
+		}
+	})
 	return result
 }
 
@@ -151,14 +178,13 @@ func WalkFuncSignatureTypes(info *types.Info, file *ast.File, visit func(*ast.Fu
 	if info == nil || file == nil || visit == nil {
 		return
 	}
-	for _, decl := range file.Decls {
-		fd, ok := decl.(*ast.FuncDecl)
-		if !ok || fd.Type == nil {
-			continue
+	WalkFuncDecls(file, func(fd *ast.FuncDecl) {
+		if fd.Type == nil {
+			return
 		}
 		walkFieldListTypes(info, fd, fd.Type.Params, visit)
 		walkFieldListTypes(info, fd, fd.Type.Results, visit)
-	}
+	})
 }
 
 func StripWrappers(t types.Type) types.Type {

--- a/core/analysisutil/ast_test.go
+++ b/core/analysisutil/ast_test.go
@@ -6,6 +6,7 @@ import (
 	"go/parser"
 	"go/token"
 	"go/types"
+	"strings"
 	"testing"
 )
 
@@ -135,6 +136,38 @@ func Process(items []Item, err error) (*Item, error) { return nil, nil }
 		if got[i] != want[i] {
 			t.Fatalf("WalkFuncSignatureTypes()[%d] = %q, want %q", i, got[i], want[i])
 		}
+	}
+}
+
+func TestWalkTypeSpecsAndFuncDecls(t *testing.T) {
+	src := `package p
+
+type A struct{}
+type B = A
+func one() {}
+var ignored = 1
+func two() {}
+`
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "sample.go", src, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var types []string
+	WalkTypeSpecs(file, fset, func(ts *ast.TypeSpec, _ token.Position) {
+		types = append(types, ts.Name.Name)
+	})
+	if got, want := strings.Join(types, ","), "A,B"; got != want {
+		t.Fatalf("WalkTypeSpecs() = %q, want %q", got, want)
+	}
+
+	var funcs []string
+	WalkFuncDecls(file, func(fd *ast.FuncDecl) {
+		funcs = append(funcs, fd.Name.Name)
+	})
+	if got, want := strings.Join(funcs, ","), "one,two"; got != want {
+		t.Fatalf("WalkFuncDecls() = %q, want %q", got, want)
 	}
 }
 

--- a/rules/interfaces/container.go
+++ b/rules/interfaces/container.go
@@ -172,21 +172,14 @@ func collectNonTestInterfaces(pkg *packages.Package) map[string]token.Position {
 		if analysisutil.IsTestFile(file, pkg.Fset) {
 			continue
 		}
-		for _, decl := range file.Decls {
-			gd, ok := decl.(*ast.GenDecl)
-			if !ok {
-				continue
+		analysisutil.WalkTypeSpecs(file, pkg.Fset, func(ts *ast.TypeSpec, pos token.Position) {
+			if ts.Assign != 0 {
+				return
 			}
-			for _, spec := range gd.Specs {
-				ts, ok := spec.(*ast.TypeSpec)
-				if !ok || ts.Assign != 0 {
-					continue
-				}
-				if _, ok := ts.Type.(*ast.InterfaceType); ok {
-					result[ts.Name.Name] = pkg.Fset.Position(ts.Name.Pos())
-				}
+			if _, ok := ts.Type.(*ast.InterfaceType); ok {
+				result[ts.Name.Name] = pos
 			}
-		}
+		})
 	}
 	return result
 }

--- a/rules/interfaces/cross_domain.go
+++ b/rules/interfaces/cross_domain.go
@@ -3,6 +3,7 @@ package interfaces
 import (
 	"fmt"
 	"go/ast"
+	"go/token"
 	"sort"
 	"strings"
 
@@ -64,27 +65,19 @@ func (r *CrossDomainAnonymous) checkPackage(pkg *packages.Package, arch core.Arc
 		if analysisutil.IsTestFile(file, pkg.Fset) {
 			continue
 		}
-		for _, decl := range file.Decls {
-			switch d := decl.(type) {
-			case *ast.GenDecl:
-				for _, spec := range d.Specs {
-					ts, ok := spec.(*ast.TypeSpec)
-					if !ok {
-						continue
-					}
-					if _, isIface := ts.Type.(*ast.InterfaceType); isIface {
-						continue
-					}
-					violations = append(violations, r.inspectExpr(ts.Type, file, pkg, currentDomain, arch)...)
-				}
-			case *ast.FuncDecl:
-				if d.Type == nil {
-					continue
-				}
-				violations = append(violations, r.inspectFieldList(d.Type.Params, file, pkg, currentDomain, arch)...)
-				violations = append(violations, r.inspectFieldList(d.Type.Results, file, pkg, currentDomain, arch)...)
+		analysisutil.WalkTypeSpecs(file, pkg.Fset, func(ts *ast.TypeSpec, _ token.Position) {
+			if _, isIface := ts.Type.(*ast.InterfaceType); isIface {
+				return
 			}
-		}
+			violations = append(violations, r.inspectExpr(ts.Type, file, pkg, currentDomain, arch)...)
+		})
+		analysisutil.WalkFuncDecls(file, func(fd *ast.FuncDecl) {
+			if fd.Type == nil {
+				return
+			}
+			violations = append(violations, r.inspectFieldList(fd.Type.Params, file, pkg, currentDomain, arch)...)
+			violations = append(violations, r.inspectFieldList(fd.Type.Results, file, pkg, currentDomain, arch)...)
+		})
 	}
 	return violations
 }

--- a/rules/interfaces/pattern.go
+++ b/rules/interfaces/pattern.go
@@ -3,6 +3,7 @@ package interfaces
 import (
 	"fmt"
 	"go/ast"
+	"go/token"
 	"go/types"
 	"sort"
 	"strings"
@@ -196,19 +197,11 @@ func collectExportedStructs(pkg *packages.Package) map[string]bool {
 func collectExportedTypeSpecs(pkg *packages.Package) []*ast.TypeSpec {
 	var result []*ast.TypeSpec
 	for _, file := range pkg.Syntax {
-		for _, decl := range file.Decls {
-			gd, ok := decl.(*ast.GenDecl)
-			if !ok {
-				continue
-			}
-			for _, spec := range gd.Specs {
-				ts, ok := spec.(*ast.TypeSpec)
-				if !ok || !ts.Name.IsExported() {
-					continue
-				}
+		analysisutil.WalkTypeSpecs(file, nil, func(ts *ast.TypeSpec, _ token.Position) {
+			if ts.Name.IsExported() {
 				result = append(result, ts)
 			}
-		}
+		})
 	}
 	return result
 }
@@ -228,10 +221,9 @@ func lookupInterface(scope *types.Scope, name string) *types.Interface {
 func (r *Pattern) checkConstructorName(pkg *packages.Package) []core.Violation {
 	var violations []core.Violation
 	for _, file := range pkg.Syntax {
-		for _, decl := range file.Decls {
-			fd, ok := decl.(*ast.FuncDecl)
-			if !ok || fd.Recv != nil || !fd.Name.IsExported() {
-				continue
+		analysisutil.WalkFuncDecls(file, func(fd *ast.FuncDecl) {
+			if fd.Recv != nil || !fd.Name.IsExported() {
+				return
 			}
 			name := fd.Name.Name
 			if strings.HasPrefix(name, "New") && name != "New" {
@@ -239,7 +231,7 @@ func (r *Pattern) checkConstructorName(pkg *packages.Package) []core.Violation {
 					fmt.Sprintf("constructor %q must be named \"New\"; NewXxx variants are not allowed", name),
 					"rename to \"New\""))
 			}
-		}
+		})
 	}
 	return violations
 }
@@ -247,18 +239,17 @@ func (r *Pattern) checkConstructorName(pkg *packages.Package) []core.Violation {
 func (r *Pattern) checkConstructorReturnsInterface(pkg *packages.Package, ifaces map[string]*ast.InterfaceType) []core.Violation {
 	var violations []core.Violation
 	for _, file := range pkg.Syntax {
-		for _, decl := range file.Decls {
-			fd, ok := decl.(*ast.FuncDecl)
-			if !ok || fd.Recv != nil || fd.Name.Name != "New" {
-				continue
+		analysisutil.WalkFuncDecls(file, func(fd *ast.FuncDecl) {
+			if fd.Recv != nil || fd.Name.Name != "New" {
+				return
 			}
 			if fd.Type.Results == nil || len(fd.Type.Results.List) == 0 {
-				continue
+				return
 			}
 
 			firstRet := fd.Type.Results.List[0].Type
 			if ident, ok := firstRet.(*ast.Ident); ok && ifaces[ident.Name] != nil {
-				continue
+				return
 			}
 
 			fix := "return an interface type"
@@ -270,7 +261,7 @@ func (r *Pattern) checkConstructorReturnsInterface(pkg *packages.Package, ifaces
 			violations = append(violations, r.violation(pkg, 0, "interfaces.constructor-returns-interface",
 				fmt.Sprintf("New() returns %s, should return an interface", formatTypeExpr(firstRet)),
 				fix))
-		}
+		})
 	}
 	return violations
 }

--- a/rules/naming/impl_suffix.go
+++ b/rules/naming/impl_suffix.go
@@ -2,6 +2,7 @@ package naming
 
 import (
 	"go/ast"
+	"go/token"
 	"strings"
 
 	"github.com/NamhaeSusan/go-arch-guard/core"
@@ -33,28 +34,20 @@ func (r *ImplSuffix) Check(ctx *core.Context) []core.Violation {
 			if ctx.IsExcluded(filePath) {
 				continue
 			}
-			for _, decl := range file.Decls {
-				gd, ok := decl.(*ast.GenDecl)
-				if !ok {
-					continue
+			analysisutil.WalkTypeSpecs(file, pkg.Fset, func(ts *ast.TypeSpec, pos token.Position) {
+				if !ts.Name.IsExported() || !strings.HasSuffix(ts.Name.Name, "Impl") {
+					return
 				}
-				for _, spec := range gd.Specs {
-					ts, ok := spec.(*ast.TypeSpec)
-					if !ok || !ts.Name.IsExported() || !strings.HasSuffix(ts.Name.Name, "Impl") {
-						continue
-					}
-					pos := pkg.Fset.Position(ts.Name.Pos())
-					violations = append(violations, core.Violation{
-						File:              analysisutil.RelativePathForPackage(pkg, pos.Filename),
-						Line:              pos.Line,
-						Rule:              "naming.no-impl-suffix",
-						Message:           `type "` + ts.Name.Name + `" uses banned suffix "Impl"`,
-						Fix:               "rename without Impl suffix",
-						DefaultSeverity:   r.severity,
-						EffectiveSeverity: r.severity,
-					})
-				}
-			}
+				violations = append(violations, core.Violation{
+					File:              analysisutil.RelativePathForPackage(pkg, pos.Filename),
+					Line:              pos.Line,
+					Rule:              "naming.no-impl-suffix",
+					Message:           `type "` + ts.Name.Name + `" uses banned suffix "Impl"`,
+					Fix:               "rename without Impl suffix",
+					DefaultSeverity:   r.severity,
+					EffectiveSeverity: r.severity,
+				})
+			})
 		}
 	}
 	return violations

--- a/rules/naming/no_stutter.go
+++ b/rules/naming/no_stutter.go
@@ -2,6 +2,7 @@ package naming
 
 import (
 	"go/ast"
+	"go/token"
 	"strings"
 	"unicode"
 
@@ -36,30 +37,22 @@ func (r *NoStutter) Check(ctx *core.Context) []core.Violation {
 			if ctx.IsExcluded(filePath) {
 				continue
 			}
-			for _, decl := range file.Decls {
-				gd, ok := decl.(*ast.GenDecl)
-				if !ok {
-					continue
+			analysisutil.WalkTypeSpecs(file, pkg.Fset, func(ts *ast.TypeSpec, pos token.Position) {
+				if !ts.Name.IsExported() {
+					return
 				}
-				for _, spec := range gd.Specs {
-					ts, ok := spec.(*ast.TypeSpec)
-					if !ok || !ts.Name.IsExported() {
-						continue
-					}
-					name := ts.Name.Name
-					if !stutters(pkgName, name) {
-						continue
-					}
-					suggested := string([]rune(name)[pkgNameLen:])
-					pos := pkg.Fset.Position(ts.Name.Pos())
-					violations = append(violations, r.violation(
-						analysisutil.RelativePathForPackage(pkg, pos.Filename),
-						pos.Line,
-						`type "`+name+`" stutters with package "`+pkgName+`"`,
-						`rename to "`+suggested+`"`,
-					))
+				name := ts.Name.Name
+				if !stutters(pkgName, name) {
+					return
 				}
-			}
+				suggested := string([]rune(name)[pkgNameLen:])
+				violations = append(violations, r.violation(
+					analysisutil.RelativePathForPackage(pkg, pos.Filename),
+					pos.Line,
+					`type "`+name+`" stutters with package "`+pkgName+`"`,
+					`rename to "`+suggested+`"`,
+				))
+			})
 		}
 	}
 	return violations

--- a/rules/naming/type_pattern.go
+++ b/rules/naming/type_pattern.go
@@ -3,6 +3,7 @@ package naming
 import (
 	"fmt"
 	"go/ast"
+	"go/token"
 	"path/filepath"
 	"strings"
 
@@ -120,37 +121,27 @@ func (r *TypePattern) checkPackage(ctx *core.Context, pkg *packages.Package, pat
 }
 
 func hasTypePatternExportedType(file *ast.File, name string) bool {
-	for _, decl := range file.Decls {
-		gd, ok := decl.(*ast.GenDecl)
-		if !ok {
-			continue
+	found := false
+	analysisutil.WalkTypeSpecs(file, nil, func(ts *ast.TypeSpec, _ token.Position) {
+		if ts.Name.Name == name && ts.Name.IsExported() {
+			found = true
 		}
-		for _, spec := range gd.Specs {
-			ts, ok := spec.(*ast.TypeSpec)
-			if !ok {
-				continue
-			}
-			if ts.Name.Name == name && ts.Name.IsExported() {
-				return true
-			}
-		}
-	}
-	return false
+	})
+	return found
 }
 
 func collectTypePatternMethods(pkg *packages.Package) map[string]bool {
 	result := make(map[string]bool)
 	for _, file := range pkg.Syntax {
-		for _, decl := range file.Decls {
-			fd, ok := decl.(*ast.FuncDecl)
-			if !ok || fd.Recv == nil || len(fd.Recv.List) == 0 {
-				continue
+		analysisutil.WalkFuncDecls(file, func(fd *ast.FuncDecl) {
+			if fd.Recv == nil || len(fd.Recv.List) == 0 {
+				return
 			}
 			typeName := analysisutil.ReceiverTypeName(fd.Recv.List[0].Type)
 			if typeName != "" {
 				result[typeName+"."+fd.Name.Name] = true
 			}
-		}
+		})
 	}
 	return result
 }

--- a/rules/structural/repo_file_interface.go
+++ b/rules/structural/repo_file_interface.go
@@ -2,6 +2,7 @@ package structural
 
 import (
 	"go/ast"
+	"go/token"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -171,21 +172,11 @@ func (r *RepoFileInterface) violation(file string, line int, rule, message, fix 
 
 func collectInterfacesFromFile(file *ast.File) map[string]*ast.InterfaceType {
 	result := make(map[string]*ast.InterfaceType)
-	for _, decl := range file.Decls {
-		gd, ok := decl.(*ast.GenDecl)
-		if !ok {
-			continue
+	analysisutil.WalkTypeSpecs(file, nil, func(ts *ast.TypeSpec, _ token.Position) {
+		if iface, ok := ts.Type.(*ast.InterfaceType); ok {
+			result[ts.Name.Name] = iface
 		}
-		for _, spec := range gd.Specs {
-			ts, ok := spec.(*ast.TypeSpec)
-			if !ok {
-				continue
-			}
-			if iface, ok := ts.Type.(*ast.InterfaceType); ok {
-				result[ts.Name.Name] = iface
-			}
-		}
-	}
+	})
 	return result
 }
 

--- a/rules/testpolicy/no_hand_mock.go
+++ b/rules/testpolicy/no_hand_mock.go
@@ -67,15 +67,14 @@ func (r *NoHandMock) checkFile(path, relPath string) []core.Violation {
 	}
 	var violations []core.Violation
 	base := filepath.Base(path)
-	for _, decl := range file.Decls {
-		fd, ok := decl.(*ast.FuncDecl)
-		if !ok || fd.Recv == nil || len(fd.Recv.List) == 0 {
-			continue
+	analysisutil.WalkFuncDecls(file, func(fd *ast.FuncDecl) {
+		if fd.Recv == nil || len(fd.Recv.List) == 0 {
+			return
 		}
 		recvName := analysisutil.ReceiverTypeName(fd.Recv.List[0].Type)
 		line, ok := structs[recvName]
 		if !ok {
-			continue
+			return
 		}
 		violations = append(violations, core.Violation{
 			File:              relPath,
@@ -87,31 +86,21 @@ func (r *NoHandMock) checkFile(path, relPath string) []core.Violation {
 			EffectiveSeverity: r.severity,
 		})
 		delete(structs, recvName)
-	}
+	})
 	return violations
 }
 
 func collectMockStructs(fset *token.FileSet, file *ast.File) map[string]int {
 	result := make(map[string]int)
-	for _, decl := range file.Decls {
-		gd, ok := decl.(*ast.GenDecl)
-		if !ok {
-			continue
+	analysisutil.WalkTypeSpecs(file, fset, func(ts *ast.TypeSpec, pos token.Position) {
+		if _, ok := ts.Type.(*ast.StructType); !ok {
+			return
 		}
-		for _, spec := range gd.Specs {
-			ts, ok := spec.(*ast.TypeSpec)
-			if !ok {
-				continue
-			}
-			if _, ok := ts.Type.(*ast.StructType); !ok {
-				continue
-			}
-			lower := strings.ToLower(ts.Name.Name)
-			if strings.HasPrefix(lower, "mock") || strings.HasPrefix(lower, "fake") || strings.HasPrefix(lower, "stub") {
-				result[ts.Name.Name] = fset.Position(ts.Name.Pos()).Line
-			}
+		lower := strings.ToLower(ts.Name.Name)
+		if strings.HasPrefix(lower, "mock") || strings.HasPrefix(lower, "fake") || strings.HasPrefix(lower, "stub") {
+			result[ts.Name.Name] = pos.Line
 		}
-	}
+	})
 	return result
 }
 

--- a/rules/tx/boundary.go
+++ b/rules/tx/boundary.go
@@ -3,6 +3,7 @@ package tx
 import (
 	"fmt"
 	"go/ast"
+	"go/types"
 	"slices"
 	"strings"
 
@@ -146,38 +147,27 @@ func (r *Boundary) checkSignatureTypes(ctx *core.Context, allowed []string) []co
 			return
 		}
 		for _, file := range pkg.Syntax {
-			for _, decl := range file.Decls {
-				fd, ok := decl.(*ast.FuncDecl)
-				if !ok || fd.Type == nil {
-					continue
-				}
-				r.checkFields(ctx, pkg, fd.Type.Params, wanted, allowed, &violations)
-				r.checkFields(ctx, pkg, fd.Type.Results, wanted, allowed, &violations)
-			}
+			analysisutil.WalkFuncSignatureTypes(pkg.TypesInfo, file, func(_ *ast.FuncDecl, field *ast.Field, typ types.Type) {
+				r.checkSignatureField(ctx, pkg, field, typ, wanted, allowed, &violations)
+			})
 		}
 	})
 	return violations
 }
 
-func (r *Boundary) checkFields(ctx *core.Context, pkg *packages.Package, fields *ast.FieldList, wanted map[string]bool, allowed []string, out *[]core.Violation) {
-	if fields == nil {
+func (r *Boundary) checkSignatureField(ctx *core.Context, pkg *packages.Package, field *ast.Field, typ types.Type, wanted map[string]bool, allowed []string, out *[]core.Violation) {
+	id := analysisutil.NamedQualifiedName(analysisutil.StripWrappers(typ))
+	if id == "" || !wanted[id] {
 		return
 	}
-	for _, field := range fields.List {
-		typ := pkg.TypesInfo.TypeOf(field.Type)
-		id := analysisutil.NamedQualifiedName(analysisutil.StripWrappers(typ))
-		if id == "" || !wanted[id] {
-			continue
-		}
-		pos := pkg.Fset.Position(field.Pos())
-		*out = append(*out, r.violation(
-			typeInSignatureID,
-			analysisutil.RelPathFromRoot(ctx.Root(), pos.Filename),
-			pos.Line,
-			fmt.Sprintf("tx type %q must not appear in function signature outside allowed layers: %v", id, allowed),
-			fmt.Sprintf("keep %q confined to allowed layers: %v", id, allowed),
-		))
-	}
+	pos := pkg.Fset.Position(field.Pos())
+	*out = append(*out, r.violation(
+		typeInSignatureID,
+		analysisutil.RelPathFromRoot(ctx.Root(), pos.Filename),
+		pos.Line,
+		fmt.Sprintf("tx type %q must not appear in function signature outside allowed layers: %v", id, allowed),
+		fmt.Sprintf("keep %q confined to allowed layers: %v", id, allowed),
+	))
 }
 
 func (r *Boundary) walkInternalPackages(ctx *core.Context, visit func(*packages.Package, string)) {

--- a/rules/types/no_setter.go
+++ b/rules/types/no_setter.go
@@ -78,13 +78,9 @@ func (r *NoSetter) Check(ctx *core.Context) []core.Violation {
 
 func (r *NoSetter) checkFile(pkg *packages.Package, file *ast.File, relPath string) []core.Violation {
 	var violations []core.Violation
-	for _, decl := range file.Decls {
-		fd, ok := decl.(*ast.FuncDecl)
-		if !ok {
-			continue
-		}
+	analysisutil.WalkFuncDecls(file, func(fd *ast.FuncDecl) {
 		if !isExportedSetter(fd.Name.Name) || !hasPointerReceiver(fd) || !hasParams(fd) || isFluentBuilder(fd) {
-			continue
+			return
 		}
 		recvType := receiverTypeString(fd)
 		pos := pkg.Fset.Position(fd.Pos())
@@ -98,7 +94,7 @@ func (r *NoSetter) checkFile(pkg *packages.Package, file *ast.File, relPath stri
 			DefaultSeverity:   r.severity,
 			EffectiveSeverity: r.severity,
 		})
-	}
+	})
 	return violations
 }
 


### PR DESCRIPTION
Fixes #117

## Summary
- Add shared `analysisutil.WalkTypeSpecs` and `WalkFuncDecls` helpers.
- Reuse traversal helpers in interfaces, naming, and tx rules.
- Keep rule-specific predicates and reporting local.

## Verification
- `go test -count=1 ./core/analysisutil ./rules/interfaces ./rules/naming ./rules/tx`
- `git diff --check`
