### PR TITLE
Add opt-in symbol call guards

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -760,6 +760,28 @@ ruleset := presets.RecommendedDDD().With(tx.New(tx.Config{
 
 발생 가능한 규칙 ID: `tx.start-outside-allowed-layer`, `tx.type-in-signature`.
 
+### `tx.NewForbiddenCalls` / `tx.NewMandatoryWrapper` (옵트인)
+
+프리셋 번들에 포함하지 않고 SDK/client 직접 호출을 거칠게 막고 싶을 때 사용합니다.
+`AllowedLayers`에는 아키텍처 레이어명(`"infra"`, `"app"`) 또는 프로젝트 상대
+패키지 prefix(`"pkg/httpclient"`)를 넣을 수 있습니다.
+
+```go
+ruleset = ruleset.With(
+    tx.NewForbiddenCalls([]tx.ForbiddenCall{{
+        Symbols:       []string{"database/sql.Open"},
+        AllowedLayers: []string{"infra"},
+    }}),
+    tx.NewMandatoryWrapper([]tx.MandatoryWrapper{{
+        Symbols:       []string{"net/http.(*Client).Do"},
+        AllowedLayers: []string{"pkg/httpclient"},
+        ReplaceWith:   "pkg/httpclient.Do",
+    }}),
+)
+```
+
+발생 가능한 규칙 ID: `tx.forbidden-call`, `tx.mandatory-wrapper`.
+
 ## 세터 패턴
 
 ### `types.NewNoSetter`
@@ -860,7 +882,7 @@ go run github.com/NamhaeSusan/go-arch-guard/cmd/tui --preset hexagonal .
 | `structural.WithRepoPortSuffixes(...)` | `structural.NewRepoFileInterface`의 repository-port 인터페이스 이름 suffix 옵션. 기본값은 `Repository`, `Repo`; 빈 suffix는 무시 |
 | `interfaces.NewPattern()` / `NewContainer()` / `NewCrossDomainAnonymous()` / `NewTooManyMethods()` | 인터페이스 규칙 |
 | `interfaces.WithMaxMethods(n)` | `interfaces.NewTooManyMethods`의 인터페이스 메서드 상한 옵션. 옵션 미지정 시 기본 10; n ≤ 0이면 fallback 10. 다른 interfaces.New*() 룰에 넘기면 silently 무시 |
-| `tx.New(tx.Config{...})` | 트랜잭션 경계 검사 (옵트인) |
+| `tx.New(tx.Config{...})` / `tx.NewForbiddenCalls(...)` / `tx.NewMandatoryWrapper(...)` | 트랜잭션 및 symbol-call 검사 (옵트인) |
 | `types.NewNoSetter()` | setter 규칙 (값 타입의 불변성 강제) |
 
 ## 기계 친화적인 JSON 출력

--- a/README.md
+++ b/README.md
@@ -804,6 +804,28 @@ ruleset := presets.RecommendedDDD().With(tx.New(tx.Config{
 
 Emitted rule IDs: `tx.start-outside-allowed-layer`, `tx.type-in-signature`.
 
+### `tx.NewForbiddenCalls` / `tx.NewMandatoryWrapper` (opt-in)
+
+Use these for coarse SDK/client call guards without adding them to preset
+bundles. `AllowedLayers` accepts architecture layer names (`"infra"`, `"app"`)
+and project-relative package prefixes (`"pkg/httpclient"`).
+
+```go
+ruleset = ruleset.With(
+    tx.NewForbiddenCalls([]tx.ForbiddenCall{{
+        Symbols:       []string{"database/sql.Open"},
+        AllowedLayers: []string{"infra"},
+    }}),
+    tx.NewMandatoryWrapper([]tx.MandatoryWrapper{{
+        Symbols:       []string{"net/http.(*Client).Do"},
+        AllowedLayers: []string{"pkg/httpclient"},
+        ReplaceWith:   "pkg/httpclient.Do",
+    }}),
+)
+```
+
+Emitted rule IDs: `tx.forbidden-call`, `tx.mandatory-wrapper`.
+
 ## Setter Pattern
 
 ### `types.NewNoSetter`
@@ -909,7 +931,7 @@ Features: health-status tree coloring, imports/reverse dependencies/coupling met
 | `interfaces.NewPattern()` / `NewContainer()` / `NewCrossDomainAnonymous()` / `NewTooManyMethods()` | interface rules |
 | `testpolicy.NewNoHandMock()` | test policy rules |
 | `interfaces.WithMaxMethods(n)` | option for `interfaces.NewTooManyMethods` setting the per-interface method cap. Default 10 when the option is omitted; n ≤ 0 also falls back to 10. Silently ignored if passed to other interfaces.New*() rules. |
-| `tx.New(tx.Config{...})` | transaction boundary enforcement (opt-in) |
+| `tx.New(tx.Config{...})` / `tx.NewForbiddenCalls(...)` / `tx.NewMandatoryWrapper(...)` | transaction and symbol-call guards (opt-in) |
 | `types.NewNoSetter()` | setter rule (immutability for value types) |
 
 ## Machine-readable JSON Output

--- a/plugins/go-arch-guard/skills/go-arch-guard/SKILL.md
+++ b/plugins/go-arch-guard/skills/go-arch-guard/SKILL.md
@@ -349,6 +349,24 @@ ruleset := presets.RecommendedDDD().With(tx.New(tx.Config{
 
 위반 규칙 ID: `tx.start-outside-allowed-layer`, `tx.type-in-signature`.
 
+SDK/client 직접 호출을 제한하려면 opt-in symbol-call 룰을 추가한다:
+
+```go
+ruleset = ruleset.With(
+    tx.NewForbiddenCalls([]tx.ForbiddenCall{{
+        Symbols:       []string{"database/sql.Open"},
+        AllowedLayers: []string{"infra"},
+    }}),
+    tx.NewMandatoryWrapper([]tx.MandatoryWrapper{{
+        Symbols:       []string{"net/http.(*Client).Do"},
+        AllowedLayers: []string{"pkg/httpclient"},
+        ReplaceWith:   "pkg/httpclient.Do",
+    }}),
+)
+```
+
+위반 규칙 ID: `tx.forbidden-call`, `tx.mandatory-wrapper`.
+
 ## Machine-readable Output
 
 AI 에이전트나 CI 봇이 violation을 후처리해야 하면 JSON 출력을 우선한다.

--- a/presets/presets_test.go
+++ b/presets/presets_test.go
@@ -157,8 +157,10 @@ func TestRecommendedRuleSetsContainCoreRules(t *testing.T) {
 					t.Errorf("unexpected rule %q in Recommended%s", id, tc.name)
 				}
 			}
-			if ids["tx.boundary"] {
-				t.Errorf("tx.boundary must remain opt-in; found in Recommended%s", tc.name)
+			for _, optInID := range []string{"tx.boundary", "tx.forbidden-call", "tx.mandatory-wrapper"} {
+				if ids[optInID] {
+					t.Errorf("%s must remain opt-in; found in Recommended%s", optInID, tc.name)
+				}
 			}
 		})
 	}

--- a/rules/tx/boundary.go
+++ b/rules/tx/boundary.go
@@ -105,30 +105,18 @@ func (r *Boundary) checkStartCalls(ctx *core.Context, allowed []string) []core.V
 	allowedSet := stringSet(allowed)
 
 	var violations []core.Violation
-	r.walkInternalPackages(ctx, func(pkg *packages.Package, layer string) {
-		if allowedSet[layer] || pkg.TypesInfo == nil {
+	checkSymbolCalls(ctx, true, func(hit symbolCall) {
+		if allowedSet[hit.layer] || !wanted[hit.symbol] {
 			return
 		}
-		for _, file := range pkg.Syntax {
-			ast.Inspect(file, func(n ast.Node) bool {
-				call, ok := n.(*ast.CallExpr)
-				if !ok {
-					return true
-				}
-				if !wanted[analysisutil.ResolveCalleeID(pkg.TypesInfo, call)] {
-					return true
-				}
-				pos := pkg.Fset.Position(call.Pos())
-				violations = append(violations, r.violation(
-					startOutsideLayerID,
-					analysisutil.RelPathFromRoot(ctx.Root(), pos.Filename),
-					pos.Line,
-					fmt.Sprintf("transaction must not start in layer %q; allowed layers: %v", layer, allowed),
-					fmt.Sprintf("move the transaction-starting call out of %q into an allowed layer: %v", layer, allowed),
-				))
-				return true
-			})
-		}
+		pos := hit.pkg.Fset.Position(hit.call.Pos())
+		violations = append(violations, r.violation(
+			startOutsideLayerID,
+			analysisutil.RelPathFromRoot(ctx.Root(), pos.Filename),
+			pos.Line,
+			fmt.Sprintf("transaction must not start in layer %q; allowed layers: %v", hit.layer, allowed),
+			fmt.Sprintf("move the transaction-starting call out of %q into an allowed layer: %v", hit.layer, allowed),
+		))
 	})
 	return violations
 }

--- a/rules/tx/calls.go
+++ b/rules/tx/calls.go
@@ -1,0 +1,236 @@
+package tx
+
+import (
+	"fmt"
+	"go/ast"
+	"slices"
+	"strings"
+
+	"github.com/NamhaeSusan/go-arch-guard/core"
+	"github.com/NamhaeSusan/go-arch-guard/core/analysisutil"
+	"golang.org/x/tools/go/packages"
+)
+
+const (
+	forbiddenCallRuleID    = "tx.forbidden-call"
+	mandatoryWrapperRuleID = "tx.mandatory-wrapper"
+)
+
+type ForbiddenCall struct {
+	Symbols       []string
+	AllowedLayers []string
+}
+
+type MandatoryWrapper struct {
+	Symbols       []string
+	AllowedLayers []string
+	ReplaceWith   string
+}
+
+type CallOption func(*callRule)
+
+func WithCallSeverity(s core.Severity) CallOption {
+	return func(r *callRule) {
+		r.severity = s
+	}
+}
+
+type callPolicy struct {
+	symbols       []string
+	allowedLayers []string
+	replaceWith   string
+}
+
+type symbolCall struct {
+	pkg    *packages.Package
+	layer  string
+	relPkg string
+	symbol string
+	call   *ast.CallExpr
+}
+
+type callRule struct {
+	id          string
+	description string
+	policies    []callPolicy
+	severity    core.Severity
+	message     func(symbol, layer string, allowed []string, replacement string) (string, string)
+}
+
+func NewForbiddenCalls(calls []ForbiddenCall, opts ...CallOption) core.Rule {
+	policies := make([]callPolicy, 0, len(calls))
+	for _, call := range calls {
+		policies = append(policies, callPolicy{
+			symbols:       slices.Clone(call.Symbols),
+			allowedLayers: slices.Clone(call.AllowedLayers),
+		})
+	}
+	return newCallRule(forbiddenCallRuleID, "forbid configured calls outside allowed layers", policies, forbiddenCallMessage, opts...)
+}
+
+func NewMandatoryWrapper(wrappers []MandatoryWrapper, opts ...CallOption) core.Rule {
+	policies := make([]callPolicy, 0, len(wrappers))
+	for _, wrapper := range wrappers {
+		policies = append(policies, callPolicy{
+			symbols:       slices.Clone(wrapper.Symbols),
+			allowedLayers: slices.Clone(wrapper.AllowedLayers),
+			replaceWith:   wrapper.ReplaceWith,
+		})
+	}
+	return newCallRule(mandatoryWrapperRuleID, "require configured calls to go through project wrappers", policies, mandatoryWrapperMessage, opts...)
+}
+
+func newCallRule(id, description string, policies []callPolicy, message func(string, string, []string, string) (string, string), opts ...CallOption) *callRule {
+	r := &callRule{
+		id:          id,
+		description: description,
+		policies:    policies,
+		severity:    core.Error,
+		message:     message,
+	}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r
+}
+
+func (r *callRule) Spec() core.RuleSpec {
+	return core.RuleSpec{
+		ID:              r.id,
+		Description:     r.description,
+		DefaultSeverity: r.severity,
+		Violations: []core.ViolationSpec{{
+			ID:              r.id,
+			Description:     r.description,
+			DefaultSeverity: r.severity,
+		}},
+	}
+}
+
+func (r *callRule) Check(ctx *core.Context) []core.Violation {
+	if ctx == nil {
+		return nil
+	}
+	if len(r.policies) == 0 || !hasConfiguredSymbols(r.policies) {
+		return []core.Violation{metaRuleDisabledByConfig(r.id,
+			"no call symbols configured; call enforcement skipped",
+			"configure at least one symbol, or remove this tx call rule from your RuleSet")}
+	}
+
+	module := analysisutil.ResolveModuleFromContext(ctx, "")
+	if module == "" {
+		return nil
+	}
+	var violations []core.Violation
+	checkSymbolCalls(ctx, false, func(hit symbolCall) {
+		for _, policy := range r.policies {
+			if !slices.Contains(policy.symbols, hit.symbol) || isAllowedCallSite(ctx.Arch().Layout.InternalRoot, policy.allowedLayers, hit.layer, hit.relPkg) {
+				continue
+			}
+			pos := hit.pkg.Fset.Position(hit.call.Pos())
+			message, fix := r.message(hit.symbol, hit.layer, policy.allowedLayers, policy.replaceWith)
+			violations = append(violations, core.Violation{
+				File:              analysisutil.RelPathFromRoot(ctx.Root(), pos.Filename),
+				Line:              pos.Line,
+				Rule:              r.id,
+				Message:           message,
+				Fix:               fix,
+				DefaultSeverity:   r.severity,
+				EffectiveSeverity: r.severity,
+			})
+		}
+	})
+	return violations
+}
+
+func hasConfiguredSymbols(policies []callPolicy) bool {
+	for _, policy := range policies {
+		if len(policy.symbols) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func isAllowedCallSite(internalRoot string, allowed []string, layer, relPkg string) bool {
+	if internalRoot == "" {
+		internalRoot = "internal"
+	}
+	relWithoutRoot := strings.TrimPrefix(relPkg, internalRoot+"/")
+	for _, item := range allowed {
+		item = strings.Trim(strings.TrimSpace(item), "/")
+		if item == "" {
+			continue
+		}
+		if item == layer {
+			return true
+		}
+		if strings.Contains(item, "/") &&
+			(relPkg == item || strings.HasPrefix(relPkg, item+"/") ||
+				relWithoutRoot == item || strings.HasPrefix(relWithoutRoot, item+"/")) {
+			return true
+		}
+	}
+	return false
+}
+
+func forbiddenCallMessage(symbol, layer string, allowed []string, _ string) (string, string) {
+	return fmt.Sprintf("call to %q is forbidden in layer %q; allowed layers/packages: %v", symbol, layer, allowed),
+		fmt.Sprintf("move this call into an allowed layer/package: %v", allowed)
+}
+
+func mandatoryWrapperMessage(symbol, layer string, allowed []string, replacement string) (string, string) {
+	if replacement == "" {
+		replacement = "a project wrapper"
+	}
+	return fmt.Sprintf("call to %q in layer %q must go through %s", symbol, layer, replacement),
+		fmt.Sprintf("replace the direct call with %s; direct calls are only allowed in: %v", replacement, allowed)
+}
+
+func walkInternalPackages(ctx *core.Context, visit func(*packages.Package, string)) {
+	walkInternalPackagesByMode(ctx, true, visit)
+}
+
+func walkInternalPackagesByMode(ctx *core.Context, layeredOnly bool, visit func(*packages.Package, string)) {
+	module := analysisutil.ResolveModuleFromContext(ctx, "")
+	if module == "" {
+		return
+	}
+	internalPrefix := module + "/" + ctx.Arch().Layout.InternalRoot + "/"
+	for _, pkg := range ctx.Pkgs() {
+		if !strings.HasPrefix(pkg.PkgPath, internalPrefix) {
+			continue
+		}
+		if ctx.IsExcluded(analysisutil.ProjectRelativePackagePath(pkg.PkgPath, module)) {
+			continue
+		}
+		layer := packageLayer(ctx.Arch(), pkg.PkgPath, internalPrefix)
+		if layer == "" && layeredOnly {
+			continue
+		}
+		visit(pkg, layer)
+	}
+}
+
+func checkSymbolCalls(ctx *core.Context, layeredOnly bool, visit func(symbolCall)) {
+	module := analysisutil.ResolveModuleFromContext(ctx, "")
+	walkInternalPackagesByMode(ctx, layeredOnly, func(pkg *packages.Package, layer string) {
+		if pkg.TypesInfo == nil {
+			return
+		}
+		relPkg := analysisutil.ProjectRelativePackagePath(pkg.PkgPath, module)
+		for _, file := range pkg.Syntax {
+			ast.Inspect(file, func(n ast.Node) bool {
+				call, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				symbol := analysisutil.ResolveCalleeID(pkg.TypesInfo, call)
+				if symbol != "" {
+					visit(symbolCall{pkg: pkg, layer: layer, relPkg: relPkg, symbol: symbol, call: call})
+				}
+				return true
+			})
+		}
+	})
+}

--- a/rules/tx/calls_test.go
+++ b/rules/tx/calls_test.go
@@ -1,0 +1,145 @@
+package tx_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/NamhaeSusan/go-arch-guard/analyzer"
+	"github.com/NamhaeSusan/go-arch-guard/core"
+	"github.com/NamhaeSusan/go-arch-guard/rules/tx"
+)
+
+func TestForbiddenCallsDetectsWrongLayer(t *testing.T) {
+	rule := tx.NewForbiddenCalls([]tx.ForbiddenCall{{
+		Symbols:       []string{"database/sql.(*DB).BeginTx"},
+		AllowedLayers: []string{"app"},
+	}})
+
+	got := rule.Check(txBoundaryContext(t, nil))
+
+	if countRule(got, "tx.forbidden-call") != 1 {
+		t.Fatalf("forbidden call count = %d, want 1: %+v", countRule(got, "tx.forbidden-call"), got)
+	}
+	if got[0].File != "internal/domain/order/core/repo/repository.go" {
+		t.Fatalf("violation file = %q, want repo", got[0].File)
+	}
+}
+
+func TestForbiddenCallsRespectsExcludesAndSeverity(t *testing.T) {
+	rule := tx.NewForbiddenCalls([]tx.ForbiddenCall{{
+		Symbols:       []string{"database/sql.(*DB).BeginTx"},
+		AllowedLayers: []string{"app"},
+	}}, tx.WithCallSeverity(core.Warning))
+
+	ctx := txBoundaryContext(t, []string{"internal/domain/order/core/repo/..."})
+	got := core.Run(ctx, core.NewRuleSet(rule))
+	if len(got) != 0 {
+		t.Fatalf("excluded repo should suppress forbidden calls, got %+v", got)
+	}
+
+	got = core.Run(txBoundaryContext(t, nil), core.NewRuleSet(rule))
+	if len(got) == 0 {
+		t.Fatal("expected severity-covered violation")
+	}
+	if got[0].DefaultSeverity != core.Warning || got[0].EffectiveSeverity != core.Warning {
+		t.Fatalf("severity = %s/%s, want warning/warning", got[0].DefaultSeverity, got[0].EffectiveSeverity)
+	}
+}
+
+func TestMandatoryWrapperDetectsDirectCallAndMentionsReplacement(t *testing.T) {
+	rule := tx.NewMandatoryWrapper([]tx.MandatoryWrapper{{
+		Symbols:       []string{"database/sql.(*DB).BeginTx"},
+		AllowedLayers: []string{"app"},
+		ReplaceWith:   "internal/pkg/tx.BeginTx",
+	}})
+
+	got := rule.Check(txBoundaryContext(t, nil))
+
+	if countRule(got, "tx.mandatory-wrapper") != 1 {
+		t.Fatalf("mandatory wrapper count = %d, want 1: %+v", countRule(got, "tx.mandatory-wrapper"), got)
+	}
+	if !strings.Contains(got[0].Fix, "internal/pkg/tx.BeginTx") {
+		t.Fatalf("fix should mention replacement, got %q", got[0].Fix)
+	}
+}
+
+func TestCallRulesAllowProjectRelativePackagePrefixesUnderInternalRoot(t *testing.T) {
+	rule := tx.NewMandatoryWrapper([]tx.MandatoryWrapper{{
+		Symbols:       []string{"database/sql.(*DB).BeginTx"},
+		AllowedLayers: []string{"pkg/httpclient"},
+		ReplaceWith:   "pkg/httpclient.BeginTx",
+	}})
+
+	got := rule.Check(callRuleSharedContext(t))
+
+	if countRule(got, "tx.mandatory-wrapper") != 1 {
+		t.Fatalf("mandatory wrapper count = %d, want only sibling shared package violation: %+v", countRule(got, "tx.mandatory-wrapper"), got)
+	}
+	if !strings.Contains(got[0].File, "internal/pkg/bad/bad.go") {
+		t.Fatalf("violation file = %q, want sibling shared package", got[0].File)
+	}
+}
+
+func TestCallRulesEmptyConfigEmitsMeta(t *testing.T) {
+	for _, rule := range []core.Rule{
+		tx.NewForbiddenCalls(nil),
+		tx.NewMandatoryWrapper(nil),
+	} {
+		got := rule.Check(txBoundaryContext(t, nil))
+		if len(got) != 1 || got[0].Rule != "meta.rule-disabled-by-config" {
+			t.Fatalf("%s empty config: got %+v", rule.Spec().ID, got)
+		}
+	}
+}
+
+func countRule(violations []core.Violation, rule string) int {
+	var count int
+	for _, v := range violations {
+		if v.Rule == rule {
+			count++
+		}
+	}
+	return count
+}
+
+func callRuleSharedContext(t *testing.T) *core.Context {
+	t.Helper()
+	root := t.TempDir()
+	writeCallRuleFile(t, filepath.Join(root, "go.mod"), "module example.com/callrules\n\ngo 1.25.0\n")
+	source := `package PLACEHOLDER
+
+import (
+	"context"
+	"database/sql"
+)
+
+func Begin(ctx context.Context, db *sql.DB) error {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+`
+	writeCallRuleFile(t, filepath.Join(root, "internal", "pkg", "httpclient", "httpclient.go"), strings.ReplaceAll(source, "PLACEHOLDER", "httpclient"))
+	writeCallRuleFile(t, filepath.Join(root, "internal", "pkg", "bad", "bad.go"), strings.ReplaceAll(source, "PLACEHOLDER", "bad"))
+
+	pkgs, err := analyzer.Load(root, "internal/...")
+	if err != nil {
+		t.Fatal(err)
+	}
+	arch := txBoundaryArch()
+	return core.NewContext(pkgs, "example.com/callrules", root, arch, nil)
+}
+
+func writeCallRuleFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Fixes #11

## Summary
- Add opt-in `tx.NewForbiddenCalls` and `tx.NewMandatoryWrapper` rules.
- Share a symbol-call walker with tx boundary start-call detection.
- Support allowed layer names and project-relative package prefixes such as `pkg/httpclient`.
- Keep all tx call guards out of recommended preset rule sets.

## Verification
- `go test -count=1 ./rules/tx ./presets`
- `git diff --check`
